### PR TITLE
Created no.js

### DIFF
--- a/source/js/language/locale/no.js
+++ b/source/js/language/locale/no.js
@@ -1,0 +1,14 @@
+VCO.Language = {
+    name: "Norsk",
+    lang: "no",
+    messages: {
+        loading: "Laster inn",
+        wikipedia: "fra Wikipedia, den frie encyklopedi",
+    },
+    buttons: {
+        map_overview:      "Se oversiktskart",
+        backtostart:       "Til begynnelsen",
+        collapse_toggle:   "Skjul kartet",
+        uncollapse_toggle: "Vis kartet"
+    }
+};


### PR DESCRIPTION
Norwegian (Norsk) translation - could be supplemented or replaced with nb and nn for the two dialects/versions
