### PR TITLE
Remove morpheous/vcoanimate module definition

### DIFF
--- a/source/js/animation/VCO.Animate.js
+++ b/source/js/animation/VCO.Animate.js
@@ -8,7 +8,7 @@ VCO.Animate = function(el, options) {
 		/*
 		// POSSIBLE ISSUE WITH WEBKIT FUTURE BUILDS
 	var onWebKitTimeout = function() {
-		
+
 		animation.stop(true);
 	}
 	if (VCO.Browser.webkit) {
@@ -23,15 +23,7 @@ VCO.Animate = function(el, options) {
 	https://github.com/ded/morpheus - (c) Dustin Diaz 2011
 	License MIT
 ================================================== */
-!function (name, definition) {
-  if (typeof define == 'function') {
-	  define(definition)
-  } else if (typeof module != 'undefined') {
-	  module.exports = definition()
-  } else {
-	  this[name] = definition()
-  }
-}('vcoanimate', function () {
+window.vcoanimate = (function() {
 
 	var doc = document,
 		win = window,
@@ -56,7 +48,7 @@ VCO.Animate = function(el, options) {
 		var styles = doc.createElement('a').style,
 			props = ['webkitTransform', 'MozTransform', 'OTransform', 'msTransform', 'Transform'],
 			i;
-			
+
 		for (i = 0; i < props.length; i++) {
 			if (props[i] in styles) return props[i]
 		};
@@ -74,7 +66,7 @@ VCO.Animate = function(el, options) {
 		property = camelize(property)
 		var value = null,
 			computed = doc.defaultView.getComputedStyle(el, '');
-		
+
 		computed && (value = computed[property]);
 		return el.style[property] || value;
 	} : html.currentStyle ?
@@ -90,7 +82,7 @@ VCO.Animate = function(el, options) {
 				try {
 					val = el.filters('alpha').opacity
 				} catch (e2) {
-					
+
 				}
 			}
 			return val / 100
@@ -98,7 +90,7 @@ VCO.Animate = function(el, options) {
 		var value = el.currentStyle ? el.currentStyle[property] : null
 		return el.style[property] || value
 	} :
-	
+
     function (el, property) {
 		return el.style[camelize(property)]
     }
@@ -120,13 +112,13 @@ VCO.Animate = function(el, options) {
   }()
 
   var children = []
-  
+
 	frame(function(timestamp) {
 	  	// feature-detect if rAF and now() are of the same scale (epoch or high-res),
 		// if not, we have to do a timestamp fix on each frame
 		fixTs = timestamp > 1e12 != now() > 1e12
 	})
-	
+
   function has(array, elem, i) {
     if (Array.prototype.indexOf) return array.indexOf(elem)
     for (i = 0; i < array.length; ++i) {
@@ -435,8 +427,4 @@ VCO.Animate = function(el, options) {
   morpheus.easings = {}
 
   return morpheus
-
-});
-
-
-
+})();


### PR DESCRIPTION
This removes the blanket copy of morpheus which defines a specific module which screws up use of module loader like RequireJS.

I had a tough time figuring how to get this project "installed" and since I don't have CodeKit, I don't think I could build it.  Any help in figuring out how to test this would be great.
