### PR TITLE
fix for #178 <650px width layout problem

### DIFF
--- a/source/less/map/leaflet/VCO.Leaflet.MiniMap.less
+++ b/source/less/map/leaflet/VCO.Leaflet.MiniMap.less
@@ -9,7 +9,7 @@
 		.leaflet-top {
 			.leaflet-control-minimap {
 				margin-left:10px;
-				margin-top:10px;
+				margin-top:33px;
 			}
 		}
 		.leaflet-control-minimap {


### PR DESCRIPTION
lowered minimap by 23px, no longer covers buttons.

33px seems to be the number where the gap between the buttons and minimap mirrors the 10px offset from the left edge