### PR TITLE
Removed protocol from openstreetmap and stamen tile references

### DIFF
--- a/build/js/storymap.js
+++ b/build/js/storymap.js
@@ -1,5 +1,5 @@
 /* storymapjs - v2015-02-20-20-56-06 - 2015-02-20
- * Copyright (c) 2015 Northwestern University Knight Lab 
+ * Copyright (c) 2015 Northwestern University Knight Lab
  */
 
 /* **********************************************
@@ -7,29 +7,29 @@
 ********************************************** */
 
 /*!
-	VCO
+  VCO
 */
 
 (function (root) {
-	root.VCO = {
-		VERSION: '0.1',
-		_originalL: root.VCO
-	};
+  root.VCO = {
+    VERSION: '0.1',
+    _originalL: root.VCO
+  };
 }(this));
 
-/*	VCO.Debug
-	Debug mode
+/*  VCO.Debug
+  Debug mode
 ================================================== */
 VCO.debug = true;
 
 
 
-/*	VCO.Bind
+/*  VCO.Bind
 ================================================== */
 VCO.Bind = function (/*Function*/ fn, /*Object*/ obj) /*-> Object*/ {
-	return function () {
-		return fn.apply(obj, arguments);
-	};
+  return function () {
+    return fn.apply(obj, arguments);
+  };
 };
 
 
@@ -37,353 +37,353 @@ VCO.Bind = function (/*Function*/ fn, /*Object*/ obj) /*-> Object*/ {
 /* Trace (console.log)
 ================================================== */
 trace = function( msg ) {
-	if (VCO.debug) {
-		if (window.console) {
-			console.log(msg);
-		} else if ( typeof( jsTrace ) != 'undefined' ) {
-			jsTrace.send( msg );
-		} else {
-			//alert(msg);
-		}
-	}
+  if (VCO.debug) {
+    if (window.console) {
+      console.log(msg);
+    } else if ( typeof( jsTrace ) != 'undefined' ) {
+      jsTrace.send( msg );
+    } else {
+      //alert(msg);
+    }
+  }
 }
 
 /* **********************************************
      Begin VCO.Util.js
 ********************************************** */
 
-/*	VCO.Util
-	Class of utilities
+/*  VCO.Util
+  Class of utilities
 ================================================== */
 
 VCO.Util = {
-	
-	extend: function (/*Object*/ dest) /*-> Object*/ {	// merge src properties into dest
-		var sources = Array.prototype.slice.call(arguments, 1);
-		for (var j = 0, len = sources.length, src; j < len; j++) {
-			src = sources[j] || {};
-			for (var i in src) {
-				if (src.hasOwnProperty(i)) {
-					dest[i] = src[i];
-				}
-			}
-		}
-		return dest;
-	},
-	
-	setOptions: function (obj, options) {
-		obj.options = VCO.Util.extend({}, obj.options, options);
-		if (obj.options.uniqueid === "") {
-			obj.options.uniqueid = VCO.Util.unique_ID(6);
-		}
-	},
-	
-	findArrayNumberByUniqueID: function(id, array, prop) {
-		var _n = 0;
-		
-		for (var i = 0; i < array.length; i++) {
-			if (array[i].data[prop] == id) {
-				trace(array[i].data[prop]);
-				_n = i;
-			}
-		};
-		
-		return _n;
-	},
-	
-	convertUnixTime: function(str) { // created for Instagram. It's ISO8601-ish
-		// 2013-12-09 01:56:28
-		var pattern = /^(\d{4})-(\d{2})-(\d{2})[T\s](\d{2}):(\d{2}):(\d{2})/;
-		if (str.match(pattern)) {
-			var date_parts = str.match(pattern).slice(1);
-		}
-			
-		var date_array = [];
 
-		for(var i = 0; i < date_parts.length; i++) {
-			var val = parseInt(date_parts[i]);
-			if (i == 1) { val = val - 1 } // stupid javascript months
-		 	date_array.push( val )
-		}
+  extend: function (/*Object*/ dest) /*-> Object*/ {  // merge src properties into dest
+    var sources = Array.prototype.slice.call(arguments, 1);
+    for (var j = 0, len = sources.length, src; j < len; j++) {
+      src = sources[j] || {};
+      for (var i in src) {
+        if (src.hasOwnProperty(i)) {
+          dest[i] = src[i];
+        }
+      }
+    }
+    return dest;
+  },
 
-	 	date = new Date(date_array[0], date_array[1], date_array[2], date_array[3], date_array[4], date_array[5]);
-	 	months = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
-	 	year = date.getFullYear();
-	 	month = months[date.getMonth()];
-	 	day = date.getDate();
-	 	time = month + ', ' + day + ' ' + year;
-		
-		return time;
-	},
-	
-	setData: function (obj, data) {
-		obj.data = VCO.Util.extend({}, obj.data, data);
-		if (obj.data.uniqueid === "") {
-			obj.data.uniqueid = VCO.Util.unique_ID(6);
-		}
-	},
-	
-	mergeData: function(data_main, data_to_merge) {
-		var x;
-		for (x in data_to_merge) {
-			if (Object.prototype.hasOwnProperty.call(data_to_merge, x)) {
-				data_main[x] = data_to_merge[x];
-			}
-		}
-		return data_main;
-	},
-	
-	/*  Like mergeData, except will only try to copy data that already exists
-	    in data_main
-	*/
-	updateData: function(data_main, data_to_merge) {
-	    var x;
-	    for (x in data_main) {
-			if (Object.prototype.hasOwnProperty.call(data_to_merge, x)) {
-				data_main[x] = data_to_merge[x];
-			}
-		}
-		return data_main;
+  setOptions: function (obj, options) {
+    obj.options = VCO.Util.extend({}, obj.options, options);
+    if (obj.options.uniqueid === "") {
+      obj.options.uniqueid = VCO.Util.unique_ID(6);
+    }
+  },
+
+  findArrayNumberByUniqueID: function(id, array, prop) {
+    var _n = 0;
+
+    for (var i = 0; i < array.length; i++) {
+      if (array[i].data[prop] == id) {
+        trace(array[i].data[prop]);
+        _n = i;
+      }
+    };
+
+    return _n;
+  },
+
+  convertUnixTime: function(str) { // created for Instagram. It's ISO8601-ish
+    // 2013-12-09 01:56:28
+    var pattern = /^(\d{4})-(\d{2})-(\d{2})[T\s](\d{2}):(\d{2}):(\d{2})/;
+    if (str.match(pattern)) {
+      var date_parts = str.match(pattern).slice(1);
+    }
+
+    var date_array = [];
+
+    for(var i = 0; i < date_parts.length; i++) {
+      var val = parseInt(date_parts[i]);
+      if (i == 1) { val = val - 1 } // stupid javascript months
+      date_array.push( val )
+    }
+
+    date = new Date(date_array[0], date_array[1], date_array[2], date_array[3], date_array[4], date_array[5]);
+    months = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+    year = date.getFullYear();
+    month = months[date.getMonth()];
+    day = date.getDate();
+    time = month + ', ' + day + ' ' + year;
+
+    return time;
+  },
+
+  setData: function (obj, data) {
+    obj.data = VCO.Util.extend({}, obj.data, data);
+    if (obj.data.uniqueid === "") {
+      obj.data.uniqueid = VCO.Util.unique_ID(6);
+    }
+  },
+
+  mergeData: function(data_main, data_to_merge) {
+    var x;
+    for (x in data_to_merge) {
+      if (Object.prototype.hasOwnProperty.call(data_to_merge, x)) {
+        data_main[x] = data_to_merge[x];
+      }
+    }
+    return data_main;
+  },
+
+  /*  Like mergeData, except will only try to copy data that already exists
+      in data_main
+  */
+  updateData: function(data_main, data_to_merge) {
+      var x;
+      for (x in data_main) {
+      if (Object.prototype.hasOwnProperty.call(data_to_merge, x)) {
+        data_main[x] = data_to_merge[x];
+      }
+    }
+    return data_main;
     },
-    	
-	stamp: (function () {
-		var lastId = 0, key = '_vco_id';
-		
 
-		return function (/*Object*/ obj) {
-			obj[key] = obj[key] || ++lastId;
-			return obj[key];
-		};
-	}()),
-	
-	isArray: (function () {
-	    // Use compiler's own isArray when available
-	    if (Array.isArray) {
-	        return Array.isArray;
-	    }
- 
-	    // Retain references to variables for performance
-	    // optimization
-	    var objectToStringFn = Object.prototype.toString,
-	        arrayToStringResult = objectToStringFn.call([]);
- 
-	    return function (subject) {
-	        return objectToStringFn.call(subject) === arrayToStringResult;
-	    };
-	}()),
-	
-	unique_ID: function(size, prefix) {
-		
-		var getRandomNumber = function(range) {
-			return Math.floor(Math.random() * range);
-		};
+  stamp: (function () {
+    var lastId = 0, key = '_vco_id';
 
-		var getRandomChar = function() {
-			var chars = "abcdefghijklmnopqurstuvwxyz";
-			return chars.substr( getRandomNumber(32), 1 );
-		};
 
-		var randomID = function(size) {
-			var str = "";
-			for(var i = 0; i < size; i++) {
-				str += getRandomChar();
-			}
-			return str;
-		};
-		
-		if (prefix) {
-			return prefix + "-" + randomID(size);
-		} else {
-			return "vco-" + randomID(size);
-		}
-	},
-	
-	htmlify: function(str) {
-		//if (str.match(/<\s*p[^>]*>([^<]*)<\s*\/\s*p\s*>/)) {
-		if (VCO.Browser.chrome) {
-			str = VCO.Emoji(str);
-		}
-		if (str.match(/<p>[\s\S]*?<\/p>/)) {
-			
-			return str;
-		} else {
-			return "<p>" + str + "</p>";
-		}
-	},
-	
-	getParamString: function (obj) {
-		var params = [];
-		for (var i in obj) {
-			if (obj.hasOwnProperty(i)) {
-				params.push(i + '=' + obj[i]);
-			}
-		}
-		return '?' + params.join('&');
-	},
-	
-	formatNum: function (num, digits) {
-		var pow = Math.pow(10, digits || 5);
-		return Math.round(num * pow) / pow;
-	},
-	
-	falseFn: function () {
-		return false;
-	},
-	
-	requestAnimFrame: (function () {
-		function timeoutDefer(callback) {
-			window.setTimeout(callback, 1000 / 60);
-		}
+    return function (/*Object*/ obj) {
+      obj[key] = obj[key] || ++lastId;
+      return obj[key];
+    };
+  }()),
 
-		var requestFn = window.requestAnimationFrame ||
-			window.webkitRequestAnimationFrame ||
-			window.mozRequestAnimationFrame ||
-			window.oRequestAnimationFrame ||
-			window.msRequestAnimationFrame ||
-			timeoutDefer;
+  isArray: (function () {
+      // Use compiler's own isArray when available
+      if (Array.isArray) {
+          return Array.isArray;
+      }
 
-		return function (callback, context, immediate, contextEl) {
-			callback = context ? VCO.Util.bind(callback, context) : callback;
-			if (immediate && requestFn === timeoutDefer) {
-				callback();
-			} else {
-				requestFn(callback, contextEl);
-			}
-		};
-	}()),
-	
-	bind: function (/*Function*/ fn, /*Object*/ obj) /*-> Object*/ {
-		return function () {
-			return fn.apply(obj, arguments);
-		};
-	},
-	
-	template: function (str, data) {
-		return str.replace(/\{ *([\w_]+) *\}/g, function (str, key) {
-			var value = data[key];
-			if (!data.hasOwnProperty(key)) {
-				throw new Error('No value provided for variable ' + str);
-			}
-			return value;
-		});
-	},
-	
-	hexToRgb: function(hex) {
-	    // Expand shorthand form (e.g. "03F") to full form (e.g. "0033FF")
-	    var shorthandRegex = /^#?([a-f\d])([a-f\d])([a-f\d])$/i;
-	    hex = hex.replace(shorthandRegex, function(m, r, g, b) {
-	        return r + r + g + g + b + b;
-	    });
+      // Retain references to variables for performance
+      // optimization
+      var objectToStringFn = Object.prototype.toString,
+          arrayToStringResult = objectToStringFn.call([]);
 
-	    var result = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(hex);
-	    return result ? {
-	        r: parseInt(result[1], 16),
-	        g: parseInt(result[2], 16),
-	        b: parseInt(result[3], 16)
-	    } : null;
-	},
-	
-	ratio: {
-		square: function(size) {
-			var s = {
-				w: 0,
-				h: 0
-			}
-			if (size.w > size.h && size.h > 0) {
-				s.h = size.h;
-				s.w = size.h;
-			} else {
-				s.w = size.w;
-				s.h = size.w;
-			}
-			return s;
-		},
-		
-		r16_9: function(size) {
-			if (size.w !== null && size.w !== "") {
-				return Math.round((size.w / 16) * 9);
-			} else if (size.h !== null && size.h !== "") {
-				return Math.round((size.h / 9) * 16);
-			} else {
-				return 0;
-			}
-		},
-		r4_3: function(size) {
-			if (size.w !== null && size.w !== "") {
-				return Math.round((size.w / 4) * 3);
-			} else if (size.h !== null && size.h !== "") {
-				return Math.round((size.h / 3) * 4);
-			}
-		}
-	},
-	getObjectAttributeByIndex: function(obj, index) {
-		if(typeof obj != 'undefined') {
-			var i = 0;
-			for (var attr in obj){
-				if (index === i){
-					return obj[attr];
-				}
-				i++;
-			}
-			return "";
-		} else {
-			return "";
-		}
-		
-	},
-	urljoin: function(base_url,path) {
+      return function (subject) {
+          return objectToStringFn.call(subject) === arrayToStringResult;
+      };
+  }()),
 
-		var url1 = base_url.split('/');
-		var url2 = path.split('/');
-		var url3 = [ ];
-		for (var i = 0, l = url1.length; i < l; i ++) {
-		if (url1[i] == '..') {
-		  url3.pop();
-		} else if (url1[i] == '.') {
-		  continue;
-		} else {
-		  url3.push(url1[i]);
-		}
-		}
-		for (var i = 0, l = url2.length; i < l; i ++) {
-		if (url2[i] == '..') {
-		  url3.pop();
-		} else if (url2[i] == '.') {
-		  continue;
-		} else {
-		  url3.push(url2[i]);
-		}
-		}
-		return url3.join('/');
+  unique_ID: function(size, prefix) {
 
-	},
-	getUrlVars: function(string) {
-		var str,
-			vars = [],
-			hash,
-			hashes;
-		
-		str = string.toString();
-		
-		if (str.match('&#038;')) { 
-			str = str.replace("&#038;", "&");
-		} else if (str.match('&#38;')) {
-			str = str.replace("&#38;", "&");
-		} else if (str.match('&amp;')) {
-			str = str.replace("&amp;", "&");
-		}
-		
-		hashes = str.slice(str.indexOf('?') + 1).split('&');
-		
-		for(var i = 0; i < hashes.length; i++) {
-			hash = hashes[i].split('=');
-			vars.push(hash[0]);
-			vars[hash[0]] = hash[1];
-		}
-		
-		
-		return vars;
-	}
+    var getRandomNumber = function(range) {
+      return Math.floor(Math.random() * range);
+    };
+
+    var getRandomChar = function() {
+      var chars = "abcdefghijklmnopqurstuvwxyz";
+      return chars.substr( getRandomNumber(32), 1 );
+    };
+
+    var randomID = function(size) {
+      var str = "";
+      for(var i = 0; i < size; i++) {
+        str += getRandomChar();
+      }
+      return str;
+    };
+
+    if (prefix) {
+      return prefix + "-" + randomID(size);
+    } else {
+      return "vco-" + randomID(size);
+    }
+  },
+
+  htmlify: function(str) {
+    //if (str.match(/<\s*p[^>]*>([^<]*)<\s*\/\s*p\s*>/)) {
+    if (VCO.Browser.chrome) {
+      str = VCO.Emoji(str);
+    }
+    if (str.match(/<p>[\s\S]*?<\/p>/)) {
+
+      return str;
+    } else {
+      return "<p>" + str + "</p>";
+    }
+  },
+
+  getParamString: function (obj) {
+    var params = [];
+    for (var i in obj) {
+      if (obj.hasOwnProperty(i)) {
+        params.push(i + '=' + obj[i]);
+      }
+    }
+    return '?' + params.join('&');
+  },
+
+  formatNum: function (num, digits) {
+    var pow = Math.pow(10, digits || 5);
+    return Math.round(num * pow) / pow;
+  },
+
+  falseFn: function () {
+    return false;
+  },
+
+  requestAnimFrame: (function () {
+    function timeoutDefer(callback) {
+      window.setTimeout(callback, 1000 / 60);
+    }
+
+    var requestFn = window.requestAnimationFrame ||
+      window.webkitRequestAnimationFrame ||
+      window.mozRequestAnimationFrame ||
+      window.oRequestAnimationFrame ||
+      window.msRequestAnimationFrame ||
+      timeoutDefer;
+
+    return function (callback, context, immediate, contextEl) {
+      callback = context ? VCO.Util.bind(callback, context) : callback;
+      if (immediate && requestFn === timeoutDefer) {
+        callback();
+      } else {
+        requestFn(callback, contextEl);
+      }
+    };
+  }()),
+
+  bind: function (/*Function*/ fn, /*Object*/ obj) /*-> Object*/ {
+    return function () {
+      return fn.apply(obj, arguments);
+    };
+  },
+
+  template: function (str, data) {
+    return str.replace(/\{ *([\w_]+) *\}/g, function (str, key) {
+      var value = data[key];
+      if (!data.hasOwnProperty(key)) {
+        throw new Error('No value provided for variable ' + str);
+      }
+      return value;
+    });
+  },
+
+  hexToRgb: function(hex) {
+      // Expand shorthand form (e.g. "03F") to full form (e.g. "0033FF")
+      var shorthandRegex = /^#?([a-f\d])([a-f\d])([a-f\d])$/i;
+      hex = hex.replace(shorthandRegex, function(m, r, g, b) {
+          return r + r + g + g + b + b;
+      });
+
+      var result = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(hex);
+      return result ? {
+          r: parseInt(result[1], 16),
+          g: parseInt(result[2], 16),
+          b: parseInt(result[3], 16)
+      } : null;
+  },
+
+  ratio: {
+    square: function(size) {
+      var s = {
+        w: 0,
+        h: 0
+      }
+      if (size.w > size.h && size.h > 0) {
+        s.h = size.h;
+        s.w = size.h;
+      } else {
+        s.w = size.w;
+        s.h = size.w;
+      }
+      return s;
+    },
+
+    r16_9: function(size) {
+      if (size.w !== null && size.w !== "") {
+        return Math.round((size.w / 16) * 9);
+      } else if (size.h !== null && size.h !== "") {
+        return Math.round((size.h / 9) * 16);
+      } else {
+        return 0;
+      }
+    },
+    r4_3: function(size) {
+      if (size.w !== null && size.w !== "") {
+        return Math.round((size.w / 4) * 3);
+      } else if (size.h !== null && size.h !== "") {
+        return Math.round((size.h / 3) * 4);
+      }
+    }
+  },
+  getObjectAttributeByIndex: function(obj, index) {
+    if(typeof obj != 'undefined') {
+      var i = 0;
+      for (var attr in obj){
+        if (index === i){
+          return obj[attr];
+        }
+        i++;
+      }
+      return "";
+    } else {
+      return "";
+    }
+
+  },
+  urljoin: function(base_url,path) {
+
+    var url1 = base_url.split('/');
+    var url2 = path.split('/');
+    var url3 = [ ];
+    for (var i = 0, l = url1.length; i < l; i ++) {
+    if (url1[i] == '..') {
+      url3.pop();
+    } else if (url1[i] == '.') {
+      continue;
+    } else {
+      url3.push(url1[i]);
+    }
+    }
+    for (var i = 0, l = url2.length; i < l; i ++) {
+    if (url2[i] == '..') {
+      url3.pop();
+    } else if (url2[i] == '.') {
+      continue;
+    } else {
+      url3.push(url2[i]);
+    }
+    }
+    return url3.join('/');
+
+  },
+  getUrlVars: function(string) {
+    var str,
+      vars = [],
+      hash,
+      hashes;
+
+    str = string.toString();
+
+    if (str.match('&#038;')) {
+      str = str.replace("&#038;", "&");
+    } else if (str.match('&#38;')) {
+      str = str.replace("&#38;", "&");
+    } else if (str.match('&amp;')) {
+      str = str.replace("&amp;", "&");
+    }
+
+    hashes = str.slice(str.indexOf('?') + 1).split('&');
+
+    for(var i = 0; i < hashes.length; i++) {
+      hash = hashes[i].split('=');
+      vars.push(hash[0]);
+      vars[hash[0]] = hash[1];
+    }
+
+
+    return vars;
+  }
 };
 
 /* **********************************************
@@ -1946,7 +1946,7 @@ VCO.Util = {
 
 
     VCO.getJSON = Zepto.getJSON;
-	VCO.ajax = Zepto.ajax;
+  VCO.ajax = Zepto.ajax;
 })(VCO)
 
 //     Based on https://github.com/madrobby/zepto/blob/5585fe00f1828711c04208372265a5d71e3238d1/src/ajax.js
@@ -1957,22 +1957,22 @@ VCO.Util = {
 Copyright (c) 2010-2012 Thomas Fuchs
 http://zeptojs.com
 
-Permission is hereby granted, free of charge, to any person obtaining a copy 
-of this software and associated documentation files (the "Software"), to deal 
-in the Software without restriction, including without limitation the rights 
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell 
-copies of the Software, and to permit persons to whom the Software is 
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
 furnished to do so, subject to the following conditions:
 
-The above copyright notice and this permission notice shall be included in all 
+The above copyright notice and this permission notice shall be included in all
 copies or substantial portions of the Software.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE 
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, 
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE 
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 */
 
@@ -1981,70 +1981,70 @@ SOFTWARE.
      Begin VCO.Class.js
 ********************************************** */
 
-/*	VCO.Class
-	Class powers the OOP facilities of the library.
+/*  VCO.Class
+  Class powers the OOP facilities of the library.
 ================================================== */
 VCO.Class = function () {};
 
 VCO.Class.extend = function (/*Object*/ props) /*-> Class*/ {
 
-	// extended class with the new prototype
-	var NewClass = function () {
-		if (this.initialize) {
-			this.initialize.apply(this, arguments);
-		}
-	};
+  // extended class with the new prototype
+  var NewClass = function () {
+    if (this.initialize) {
+      this.initialize.apply(this, arguments);
+    }
+  };
 
-	// instantiate class without calling constructor
-	var F = function () {};
-	F.prototype = this.prototype;
-	var proto = new F();
+  // instantiate class without calling constructor
+  var F = function () {};
+  F.prototype = this.prototype;
+  var proto = new F();
 
-	proto.constructor = NewClass;
-	NewClass.prototype = proto;
+  proto.constructor = NewClass;
+  NewClass.prototype = proto;
 
-	// add superclass access
-	NewClass.superclass = this.prototype;
+  // add superclass access
+  NewClass.superclass = this.prototype;
 
-	// add class name
-	//proto.className = props;
+  // add class name
+  //proto.className = props;
 
-	//inherit parent's statics
-	for (var i in this) {
-		if (this.hasOwnProperty(i) && i !== 'prototype' && i !== 'superclass') {
-			NewClass[i] = this[i];
-		}
-	}
+  //inherit parent's statics
+  for (var i in this) {
+    if (this.hasOwnProperty(i) && i !== 'prototype' && i !== 'superclass') {
+      NewClass[i] = this[i];
+    }
+  }
 
-	// mix static properties into the class
-	if (props.statics) {
-		VCO.Util.extend(NewClass, props.statics);
-		delete props.statics;
-	}
+  // mix static properties into the class
+  if (props.statics) {
+    VCO.Util.extend(NewClass, props.statics);
+    delete props.statics;
+  }
 
-	// mix includes into the prototype
-	if (props.includes) {
-		VCO.Util.extend.apply(null, [proto].concat(props.includes));
-		delete props.includes;
-	}
+  // mix includes into the prototype
+  if (props.includes) {
+    VCO.Util.extend.apply(null, [proto].concat(props.includes));
+    delete props.includes;
+  }
 
-	// merge options
-	if (props.options && proto.options) {
-		props.options = VCO.Util.extend({}, proto.options, props.options);
-	}
+  // merge options
+  if (props.options && proto.options) {
+    props.options = VCO.Util.extend({}, proto.options, props.options);
+  }
 
-	// mix given properties into the prototype
-	VCO.Util.extend(proto, props);
+  // mix given properties into the prototype
+  VCO.Util.extend(proto, props);
 
-	// allow inheriting further
-	NewClass.extend = VCO.Class.extend;
+  // allow inheriting further
+  NewClass.extend = VCO.Class.extend;
 
-	// method for adding properties to prototype
-	NewClass.include = function (props) {
-		VCO.Util.extend(this.prototype, props);
-	};
+  // method for adding properties to prototype
+  NewClass.include = function (props) {
+    VCO.Util.extend(this.prototype, props);
+  };
 
-	return NewClass;
+  return NewClass;
 };
 
 
@@ -2052,64 +2052,64 @@ VCO.Class.extend = function (/*Object*/ props) /*-> Class*/ {
      Begin VCO.Events.js
 ********************************************** */
 
-/*	VCO.Events
-	adds custom events functionality to VCO classes
+/*  VCO.Events
+  adds custom events functionality to VCO classes
 ================================================== */
 VCO.Events = {
-	addEventListener: function (/*String*/ type, /*Function*/ fn, /*(optional) Object*/ context) {
-		var events = this._vco_events = this._vco_events || {};
-		events[type] = events[type] || [];
-		events[type].push({
-			action: fn,
-			context: context || this
-		});
-		return this;
-	},
+  addEventListener: function (/*String*/ type, /*Function*/ fn, /*(optional) Object*/ context) {
+    var events = this._vco_events = this._vco_events || {};
+    events[type] = events[type] || [];
+    events[type].push({
+      action: fn,
+      context: context || this
+    });
+    return this;
+  },
 
-	hasEventListeners: function (/*String*/ type) /*-> Boolean*/ {
-		var k = '_vco_events';
-		return (k in this) && (type in this[k]) && (this[k][type].length > 0);
-	},
+  hasEventListeners: function (/*String*/ type) /*-> Boolean*/ {
+    var k = '_vco_events';
+    return (k in this) && (type in this[k]) && (this[k][type].length > 0);
+  },
 
-	removeEventListener: function (/*String*/ type, /*Function*/ fn, /*(optional) Object*/ context) {
-		if (!this.hasEventListeners(type)) {
-			return this;
-		}
+  removeEventListener: function (/*String*/ type, /*Function*/ fn, /*(optional) Object*/ context) {
+    if (!this.hasEventListeners(type)) {
+      return this;
+    }
 
-		for (var i = 0, events = this._vco_events, len = events[type].length; i < len; i++) {
-			if (
-				(events[type][i].action === fn) &&
-				(!context || (events[type][i].context === context))
-			) {
-				events[type].splice(i, 1);
-				return this;
-			}
-		}
-		return this;
-	},
+    for (var i = 0, events = this._vco_events, len = events[type].length; i < len; i++) {
+      if (
+        (events[type][i].action === fn) &&
+        (!context || (events[type][i].context === context))
+      ) {
+        events[type].splice(i, 1);
+        return this;
+      }
+    }
+    return this;
+  },
 
-	fireEvent: function (/*String*/ type, /*(optional) Object*/ data) {
-		if (!this.hasEventListeners(type)) {
-			return this;
-		}
+  fireEvent: function (/*String*/ type, /*(optional) Object*/ data) {
+    if (!this.hasEventListeners(type)) {
+      return this;
+    }
 
-		var event = VCO.Util.extend({
-			type: type,
-			target: this
-		}, data);
+    var event = VCO.Util.extend({
+      type: type,
+      target: this
+    }, data);
 
-		var listeners = this._vco_events[type].slice();
+    var listeners = this._vco_events[type].slice();
 
-		for (var i = 0, len = listeners.length; i < len; i++) {
-			listeners[i].action.call(listeners[i].context || this, event);
-		}
+    for (var i = 0, len = listeners.length; i < len; i++) {
+      listeners[i].action.call(listeners[i].context || this, event);
+    }
 
-		return this;
-	}
+    return this;
+  }
 };
 
-VCO.Events.on	= VCO.Events.addEventListener;
-VCO.Events.off	= VCO.Events.removeEventListener;
+VCO.Events.on = VCO.Events.addEventListener;
+VCO.Events.off  = VCO.Events.removeEventListener;
 VCO.Events.fire = VCO.Events.fireEvent;
 
 /* **********************************************
@@ -2117,136 +2117,136 @@ VCO.Events.fire = VCO.Events.fireEvent;
 ********************************************** */
 
 /*
-	Based on Leaflet Browser
-	VCO.Browser handles different browser and feature detections for internal  use.
+  Based on Leaflet Browser
+  VCO.Browser handles different browser and feature detections for internal  use.
 */
 
 
 (function() {
 
-	var ua = navigator.userAgent.toLowerCase(),
-		doc = document.documentElement,
+  var ua = navigator.userAgent.toLowerCase(),
+    doc = document.documentElement,
 
-		ie = 'ActiveXObject' in window,
+    ie = 'ActiveXObject' in window,
 
-		webkit = ua.indexOf('webkit') !== -1,
-		phantomjs = ua.indexOf('phantom') !== -1,
-		android23 = ua.search('android [23]') !== -1,
+    webkit = ua.indexOf('webkit') !== -1,
+    phantomjs = ua.indexOf('phantom') !== -1,
+    android23 = ua.search('android [23]') !== -1,
 
-		mobile = typeof orientation !== 'undefined',
-		msPointer = navigator.msPointerEnabled && navigator.msMaxTouchPoints && !window.PointerEvent,
-		pointer = (window.PointerEvent && navigator.pointerEnabled && navigator.maxTouchPoints) || msPointer,
+    mobile = typeof orientation !== 'undefined',
+    msPointer = navigator.msPointerEnabled && navigator.msMaxTouchPoints && !window.PointerEvent,
+    pointer = (window.PointerEvent && navigator.pointerEnabled && navigator.maxTouchPoints) || msPointer,
 
-		ie3d = ie && ('transition' in doc.style),
-		webkit3d = ('WebKitCSSMatrix' in window) && ('m11' in new window.WebKitCSSMatrix()) && !android23,
-		gecko3d = 'MozPerspective' in doc.style,
-		opera3d = 'OTransition' in doc.style,
-		opera = window.opera;
+    ie3d = ie && ('transition' in doc.style),
+    webkit3d = ('WebKitCSSMatrix' in window) && ('m11' in new window.WebKitCSSMatrix()) && !android23,
+    gecko3d = 'MozPerspective' in doc.style,
+    opera3d = 'OTransition' in doc.style,
+    opera = window.opera;
 
 
-	var retina = 'devicePixelRatio' in window && window.devicePixelRatio > 1;
+  var retina = 'devicePixelRatio' in window && window.devicePixelRatio > 1;
 
-	if (!retina && 'matchMedia' in window) {
-		var matches = window.matchMedia('(min-resolution:144dpi)');
-		retina = matches && matches.matches;
-	}
+  if (!retina && 'matchMedia' in window) {
+    var matches = window.matchMedia('(min-resolution:144dpi)');
+    retina = matches && matches.matches;
+  }
 
-	var touch = !window.L_NO_TOUCH && !phantomjs && (pointer || 'ontouchstart' in window || (window.DocumentTouch && document instanceof window.DocumentTouch));
+  var touch = !window.L_NO_TOUCH && !phantomjs && (pointer || 'ontouchstart' in window || (window.DocumentTouch && document instanceof window.DocumentTouch));
 
-	VCO.Browser = {
-		ie: ie,
-		ielt9: ie && !document.addEventListener,
-		webkit: webkit,
-		//gecko: (ua.indexOf('gecko') !== -1) && !webkit && !window.opera && !ie,
-		firefox: (ua.indexOf('gecko') !== -1) && !webkit && !window.opera && !ie,
-		android: ua.indexOf('android') !== -1,
-		android23: android23,
-		chrome: ua.indexOf('chrome') !== -1,
+  VCO.Browser = {
+    ie: ie,
+    ielt9: ie && !document.addEventListener,
+    webkit: webkit,
+    //gecko: (ua.indexOf('gecko') !== -1) && !webkit && !window.opera && !ie,
+    firefox: (ua.indexOf('gecko') !== -1) && !webkit && !window.opera && !ie,
+    android: ua.indexOf('android') !== -1,
+    android23: android23,
+    chrome: ua.indexOf('chrome') !== -1,
 
-		ie3d: ie3d,
-		webkit3d: webkit3d,
-		gecko3d: gecko3d,
-		opera3d: opera3d,
-		any3d: !window.L_DISABLE_3D && (ie3d || webkit3d || gecko3d || opera3d) && !phantomjs,
+    ie3d: ie3d,
+    webkit3d: webkit3d,
+    gecko3d: gecko3d,
+    opera3d: opera3d,
+    any3d: !window.L_DISABLE_3D && (ie3d || webkit3d || gecko3d || opera3d) && !phantomjs,
 
-		mobile: mobile,
-		mobileWebkit: mobile && webkit,
-		mobileWebkit3d: mobile && webkit3d,
-		mobileOpera: mobile && window.opera,
+    mobile: mobile,
+    mobileWebkit: mobile && webkit,
+    mobileWebkit3d: mobile && webkit3d,
+    mobileOpera: mobile && window.opera,
 
-		touch: !! touch,
-		msPointer: !! msPointer,
-		pointer: !! pointer,
+    touch: !! touch,
+    msPointer: !! msPointer,
+    pointer: !! pointer,
 
-		retina: !! retina,
-		orientation: function() {
-			var w = window.innerWidth,
-				h = window.innerHeight,
-				_orientation = "portrait";
-			
-			if (w > h) {
-				_orientation = "landscape";
-			}
-			if (Math.abs(window.orientation) == 90) {
-				//_orientation = "landscape";
-			}
-			trace(_orientation);
-			return _orientation;
-		}
-	};
+    retina: !! retina,
+    orientation: function() {
+      var w = window.innerWidth,
+        h = window.innerHeight,
+        _orientation = "portrait";
 
-}()); 
+      if (w > h) {
+        _orientation = "landscape";
+      }
+      if (Math.abs(window.orientation) == 90) {
+        //_orientation = "landscape";
+      }
+      trace(_orientation);
+      return _orientation;
+    }
+  };
+
+}());
 
 /* **********************************************
      Begin VCO.Load.js
 ********************************************** */
 
-/*	VCO.Load
-	Loads External Javascript and CSS
+/*  VCO.Load
+  Loads External Javascript and CSS
 ================================================== */
 
 VCO.Load = (function (doc) {
-	var loaded	= [];
-	
-	function isLoaded(url) {
-		
-		var i			= 0,
-			has_loaded	= false;
-		
-		for (i = 0; i < loaded.length; i++) {
-			if (loaded[i] == url) {
-				has_loaded = true;
-			}
-		}
-		
-		if (has_loaded) {
-			return true;
-		} else {
-			loaded.push(url);
-			return false;
-		}
-		
-	}
-	
-	return {
-		
-		css: function (urls, callback, obj, context) {
-			if (!isLoaded(urls)) {
-				VCO.LoadIt.css(urls, callback, obj, context);
-			} else {
-				callback();
-			}
-		},
+  var loaded  = [];
 
-		js: function (urls, callback, obj, context) {
-			if (!isLoaded(urls)) {
-				VCO.LoadIt.js(urls, callback, obj, context);
-			} else {
-				callback();
-			}
-		}
+  function isLoaded(url) {
+
+    var i     = 0,
+      has_loaded  = false;
+
+    for (i = 0; i < loaded.length; i++) {
+      if (loaded[i] == url) {
+        has_loaded = true;
+      }
+    }
+
+    if (has_loaded) {
+      return true;
+    } else {
+      loaded.push(url);
+      return false;
+    }
+
+  }
+
+  return {
+
+    css: function (urls, callback, obj, context) {
+      if (!isLoaded(urls)) {
+        VCO.LoadIt.css(urls, callback, obj, context);
+      } else {
+        callback();
+      }
+    },
+
+    js: function (urls, callback, obj, context) {
+      if (!isLoaded(urls)) {
+        VCO.LoadIt.js(urls, callback, obj, context);
+      } else {
+        callback();
+      }
+    }
     };
-	
+
 })(this.document);
 
 
@@ -2648,20 +2648,20 @@ VCO.LoadIt = (function (doc) {
 ********************************************** */
 
 VCO.Language = {
-	name: 					"English",
-	lang: 					"en",
-	messages: {
-		loading: 			"Loading",
-		wikipedia: 			"From Wikipedia, the free encyclopedia",
-		start: 				"Start Exploring"
-	},
-	buttons: {
-	    map_overview: 		"Map Overview",
-		overview: 			"Overview",
-	    backtostart: 		"Back To Beginning",
-	    collapse_toggle: 	"Hide Map",
-	    uncollapse_toggle: 	"Show Map"
-	}
+  name:           "English",
+  lang:           "en",
+  messages: {
+    loading:      "Loading",
+    wikipedia:      "From Wikipedia, the free encyclopedia",
+    start:        "Start Exploring"
+  },
+  buttons: {
+      map_overview:     "Map Overview",
+    overview:       "Overview",
+      backtostart:    "Back To Beginning",
+      collapse_toggle:  "Hide Map",
+      uncollapse_toggle:  "Show Map"
+  }
 }
 
 /* **********************************************
@@ -2696,19 +2696,19 @@ THE SOFTWARE
 */
 
 VCO.Emoji = function(str) {
-	var emoji = {
-		"\ud83d\ude04":0,"\ud83d\ude03":1,"\ud83d\ude00":2,"\ud83d\ude0a":3,"\u263a\ufe0f":4,"\ud83d\ude09":5,"\ud83d\ude0d":6,"\ud83d\ude18":7,"\ud83d\ude1a":8,"\ud83d\ude17":9,"\ud83d\ude19":10,"\ud83d\ude1c":11,"\ud83d\ude1d":12,"\ud83d\ude1b":13,"\ud83d\ude33":14,"\ud83d\ude01":15,"\ud83d\ude14":16,"\ud83d\ude0c":17,"\ud83d\ude12":18,"\ud83d\ude1e":19,"\ud83d\ude23":20,"\ud83d\ude22":21,"\ud83d\ude02":22,"\ud83d\ude2d":23,"\ud83d\ude2a":24,"\ud83d\ude25":25,"\ud83d\ude30":26,"\ud83d\ude05":27,"\ud83d\ude13":28,"\ud83d\ude29":29,"\ud83d\ude2b":30,"\ud83d\ude28":31,"\ud83d\ude31":32,"\ud83d\ude20":33,"\ud83d\ude21":34,"\ud83d\ude24":35,"\ud83d\ude16":36,"\ud83d\ude06":37,"\ud83d\ude0b":38,"\ud83d\ude37":39,"\ud83d\ude0e":40,"\ud83d\ude34":41,"\ud83d\ude35":42,"\ud83d\ude32":43,"\ud83d\ude1f":44,"\ud83d\ude26":45,"\ud83d\ude27":46,"\ud83d\ude08":47,"\ud83d\udc7f":48,"\ud83d\ude2e":49,"\ud83d\ude2c":50,"\ud83d\ude10":51,"\ud83d\ude15":52,"\ud83d\ude2f":53,"\ud83d\ude36":54,"\ud83d\ude07":55,"\ud83d\ude0f":56,"\ud83d\ude11":57,"\ud83d\udc72":58,"\ud83d\udc73":59,"\ud83d\udc6e":60,"\ud83d\udc77":61,"\ud83d\udc82":62,"\ud83d\udc76":63,"\ud83d\udc66":64,"\ud83d\udc67":65,"\ud83d\udc68":66,"\ud83d\udc69":67,"\ud83d\udc74":68,"\ud83d\udc75":69,"\ud83d\udc71":70,"\ud83d\udc7c":71,"\ud83d\udc78":72,"\ud83d\ude3a":73,"\ud83d\ude38":74,"\ud83d\ude3b":75,"\ud83d\ude3d":76,"\ud83d\ude3c":77,"\ud83d\ude40":78,"\ud83d\ude3f":79,"\ud83d\ude39":80,"\ud83d\ude3e":81,"\ud83d\udc79":82,"\ud83d\udc7a":83,"\ud83d\ude48":84,"\ud83d\ude49":85,"\ud83d\ude4a":86,"\ud83d\udc80":87,"\ud83d\udc7d":88,"\ud83d\udca9":89,"\ud83d\udd25":90,"\u2728":91,"\ud83c\udf1f":92,"\ud83d\udcab":93,"\ud83d\udca5":94,"\ud83d\udca2":95,"\ud83d\udca6":96,"\ud83d\udca7":97,"\ud83d\udca4":98,"\ud83d\udca8":99,		"\ud83d\udc42":100,"\ud83d\udc40":101,"\ud83d\udc43":102,"\ud83d\udc45":103,"\ud83d\udc44":104,"\ud83d\udc4d":105,"\ud83d\udc4e":106,"\ud83d\udc4c":107,"\ud83d\udc4a":108,"\u270a":109,"\u270c\ufe0f":110,"\ud83d\udc4b":111,"\u270b":112,"\ud83d\udc50":113,"\ud83d\udc46":114,"\ud83d\udc47":115,"\ud83d\udc49":116,"\ud83d\udc48":117,"\ud83d\ude4c":118,"\ud83d\ude4f":119,"\u261d\ufe0f":120,"\ud83d\udc4f":121,"\ud83d\udcaa":122,"\ud83d\udeb6":123,"\ud83c\udfc3":124,"\ud83d\udc83":125,"\ud83d\udc6b":126,"\ud83d\udc6a":127,"\ud83d\udc6c":128,"\ud83d\udc6d":129,"\ud83d\udc8f":130,"\ud83d\udc91":131,"\ud83d\udc6f":132,"\ud83d\ude46":133,"\ud83d\ude45":134,"\ud83d\udc81":135,"\ud83d\ude4b":136,"\ud83d\udc86":137,"\ud83d\udc87":138,"\ud83d\udc85":139,"\ud83d\udc70":140,"\ud83d\ude4e":141,"\ud83d\ude4d":142,"\ud83d\ude47":143,"\ud83c\udfa9":144,"\ud83d\udc51":145,"\ud83d\udc52":146,"\ud83d\udc5f":147,"\ud83d\udc5e":148,"\ud83d\udc61":149,"\ud83d\udc60":150,"\ud83d\udc62":151,"\ud83d\udc55":152,"\ud83d\udc54":153,"\ud83d\udc5a":154,"\ud83d\udc57":155,"\ud83c\udfbd":156,"\ud83d\udc56":157,"\ud83d\udc58":158,"\ud83d\udc59":159,"\ud83d\udcbc":160,"\ud83d\udc5c":161,"\ud83d\udc5d":162,"\ud83d\udc5b":163,"\ud83d\udc53":164,"\ud83c\udf80":165,"\ud83c\udf02":166,"\ud83d\udc84":167,"\ud83d\udc9b":168,"\ud83d\udc99":169,"\ud83d\udc9c":170,"\ud83d\udc9a":171,"\u2764\ufe0f":172,"\ud83d\udc94":173,"\ud83d\udc97":174,"\ud83d\udc93":175,"\ud83d\udc95":176,"\ud83d\udc96":177,"\ud83d\udc9e":178,"\ud83d\udc98":179,"\ud83d\udc8c":180,"\ud83d\udc8b":181,"\ud83d\udc8d":182,"\ud83d\udc8e":183,"\ud83d\udc64":184,"\ud83d\udc65":185,"\ud83d\udcac":186,"\ud83d\udc63":187,"\ud83d\udcad":188,"\ud83d\udc36":189,"\ud83d\udc3a":190,"\ud83d\udc31":191,"\ud83d\udc2d":192,"\ud83d\udc39":193,"\ud83d\udc30":194,"\ud83d\udc38":195,"\ud83d\udc2f":196,"\ud83d\udc28":197,"\ud83d\udc3b":198,"\ud83d\udc37":199,		"\ud83d\udc3d":200,"\ud83d\udc2e":201,"\ud83d\udc17":202,"\ud83d\udc35":203,"\ud83d\udc12":204,"\ud83d\udc34":205,"\ud83d\udc11":206,"\ud83d\udc18":207,"\ud83d\udc3c":208,"\ud83d\udc27":209,"\ud83d\udc26":210,"\ud83d\udc24":211,"\ud83d\udc25":212,"\ud83d\udc23":213,"\ud83d\udc14":214,"\ud83d\udc0d":215,"\ud83d\udc22":216,"\ud83d\udc1b":217,"\ud83d\udc1d":218,"\ud83d\udc1c":219,"\ud83d\udc1e":220,"\ud83d\udc0c":221,"\ud83d\udc19":222,"\ud83d\udc1a":223,"\ud83d\udc20":224,"\ud83d\udc1f":225,"\ud83d\udc2c":226,"\ud83d\udc33":227,"\ud83d\udc0b":228,"\ud83d\udc04":229,"\ud83d\udc0f":230,"\ud83d\udc00":231,"\ud83d\udc03":232,"\ud83d\udc05":233,"\ud83d\udc07":234,"\ud83d\udc09":235,"\ud83d\udc0e":236,"\ud83d\udc10":237,"\ud83d\udc13":238,"\ud83d\udc15":239,"\ud83d\udc16":240,"\ud83d\udc01":241,"\ud83d\udc02":242,"\ud83d\udc32":243,"\ud83d\udc21":244,"\ud83d\udc0a":245,"\ud83d\udc2b":246,"\ud83d\udc2a":247,"\ud83d\udc06":248,"\ud83d\udc08":249,"\ud83d\udc29":250,"\ud83d\udc3e":251,"\ud83d\udc90":252,"\ud83c\udf38":253,"\ud83c\udf37":254,"\ud83c\udf40":255,"\ud83c\udf39":256,"\ud83c\udf3b":257,"\ud83c\udf3a":258,"\ud83c\udf41":259,"\ud83c\udf43":260,"\ud83c\udf42":261,"\ud83c\udf3f":262,"\ud83c\udf3e":263,"\ud83c\udf44":264,"\ud83c\udf35":265,"\ud83c\udf34":266,"\ud83c\udf32":267,"\ud83c\udf33":268,"\ud83c\udf30":269,"\ud83c\udf31":270,"\ud83c\udf3c":271,"\ud83c\udf10":272,"\ud83c\udf1e":273,"\ud83c\udf1d":274,"\ud83c\udf1a":275,"\ud83c\udf11":276,"\ud83c\udf12":277,"\ud83c\udf13":278,"\ud83c\udf14":279,"\ud83c\udf15":280,"\ud83c\udf16":281,"\ud83c\udf17":282,"\ud83c\udf18":283,"\ud83c\udf1c":284,"\ud83c\udf1b":285,"\ud83c\udf19":286,"\ud83c\udf0d":287,"\ud83c\udf0e":288,"\ud83c\udf0f":289,"\ud83c\udf0b":290,"\ud83c\udf0c":291,"\ud83c\udf20":292,"\u2b50\ufe0f":293,"\u2600\ufe0f":294,"\u26c5\ufe0f":295,"\u2601\ufe0f":296,"\u26a1\ufe0f":297,"\u2614\ufe0f":298,"\u2744\ufe0f":299,		"\u26c4\ufe0f":300,"\ud83c\udf00":301,"\ud83c\udf01":302,"\ud83c\udf08":303,"\ud83c\udf0a":304,"\ud83c\udf8d":305,"\ud83d\udc9d":306,"\ud83c\udf8e":307,"\ud83c\udf92":308,"\ud83c\udf93":309,"\ud83c\udf8f":310,"\ud83c\udf86":311,"\ud83c\udf87":312,"\ud83c\udf90":313,"\ud83c\udf91":314,"\ud83c\udf83":315,"\ud83d\udc7b":316,"\ud83c\udf85":317,"\ud83c\udf84":318,"\ud83c\udf81":319,"\ud83c\udf8b":320,"\ud83c\udf89":321,"\ud83c\udf8a":322,"\ud83c\udf88":323,"\ud83c\udf8c":324,"\ud83d\udd2e":325,"\ud83c\udfa5":326,"\ud83d\udcf7":327,"\ud83d\udcf9":328,"\ud83d\udcfc":329,"\ud83d\udcbf":330,"\ud83d\udcc0":331,"\ud83d\udcbd":332,"\ud83d\udcbe":333,"\ud83d\udcbb":334,"\ud83d\udcf1":335,"\u260e\ufe0f":336,"\ud83d\udcde":337,"\ud83d\udcdf":338,"\ud83d\udce0":339,"\ud83d\udce1":340,"\ud83d\udcfa":341,"\ud83d\udcfb":342,"\ud83d\udd0a":343,"\ud83d\udd09":344,"\ud83d\udd08":345,"\ud83d\udd07":346,"\ud83d\udd14":347,"\ud83d\udd15":348,"\ud83d\udce2":349,"\ud83d\udce3":350,"\u23f3":351,"\u231b\ufe0f":352,"\u23f0":353,"\u231a\ufe0f":354,"\ud83d\udd13":355,"\ud83d\udd12":356,"\ud83d\udd0f":357,"\ud83d\udd10":358,"\ud83d\udd11":359,"\ud83d\udd0e":360,"\ud83d\udca1":361,"\ud83d\udd26":362,"\ud83d\udd06":363,"\ud83d\udd05":364,"\ud83d\udd0c":365,"\ud83d\udd0b":366,"\ud83d\udd0d":367,"\ud83d\udec1":368,"\ud83d\udec0":369,"\ud83d\udebf":370,"\ud83d\udebd":371,"\ud83d\udd27":372,"\ud83d\udd29":373,"\ud83d\udd28":374,"\ud83d\udeaa":375,"\ud83d\udeac":376,"\ud83d\udca3":377,"\ud83d\udd2b":378,"\ud83d\udd2a":379,"\ud83d\udc8a":380,"\ud83d\udc89":381,"\ud83d\udcb0":382,"\ud83d\udcb4":383,"\ud83d\udcb5":384,"\ud83d\udcb7":385,"\ud83d\udcb6":386,"\ud83d\udcb3":387,"\ud83d\udcb8":388,"\ud83d\udcf2":389,"\ud83d\udce7":390,"\ud83d\udce5":391,"\ud83d\udce4":392,"\u2709\ufe0f":393,"\ud83d\udce9":394,"\ud83d\udce8":395,"\ud83d\udcef":396,"\ud83d\udceb":397,"\ud83d\udcea":398,"\ud83d\udcec":399,		"\ud83d\udced":400,"\ud83d\udcee":401,"\ud83d\udce6":402,"\ud83d\udcdd":403,"\ud83d\udcc4":404,"\ud83d\udcc3":405,"\ud83d\udcd1":406,"\ud83d\udcca":407,"\ud83d\udcc8":408,"\ud83d\udcc9":409,"\ud83d\udcdc":410,"\ud83d\udccb":411,"\ud83d\udcc5":412,"\ud83d\udcc6":413,"\ud83d\udcc7":414,"\ud83d\udcc1":415,"\ud83d\udcc2":416,"\u2702\ufe0f":417,"\ud83d\udccc":418,"\ud83d\udcce":419,"\u2712\ufe0f":420,"\u270f\ufe0f":421,"\ud83d\udccf":422,"\ud83d\udcd0":423,"\ud83d\udcd5":424,"\ud83d\udcd7":425,"\ud83d\udcd8":426,"\ud83d\udcd9":427,"\ud83d\udcd3":428,"\ud83d\udcd4":429,"\ud83d\udcd2":430,"\ud83d\udcda":431,"\ud83d\udcd6":432,"\ud83d\udd16":433,"\ud83d\udcdb":434,"\ud83d\udd2c":435,"\ud83d\udd2d":436,"\ud83d\udcf0":437,"\ud83c\udfa8":438,"\ud83c\udfac":439,"\ud83c\udfa4":440,"\ud83c\udfa7":441,"\ud83c\udfbc":442,"\ud83c\udfb5":443,"\ud83c\udfb6":444,"\ud83c\udfb9":445,"\ud83c\udfbb":446,"\ud83c\udfba":447,"\ud83c\udfb7":448,"\ud83c\udfb8":449,"\ud83d\udc7e":450,"\ud83c\udfae":451,"\ud83c\udccf":452,"\ud83c\udfb4":453,"\ud83c\udc04\ufe0f":454,"\ud83c\udfb2":455,"\ud83c\udfaf":456,"\ud83c\udfc8":457,"\ud83c\udfc0":458,"\u26bd\ufe0f":459,"\u26be\ufe0f":460,"\ud83c\udfbe":461,"\ud83c\udfb1":462,"\ud83c\udfc9":463,"\ud83c\udfb3":464,"\u26f3\ufe0f":465,"\ud83d\udeb5":466,"\ud83d\udeb4":467,"\ud83c\udfc1":468,"\ud83c\udfc7":469,"\ud83c\udfc6":470,"\ud83c\udfbf":471,"\ud83c\udfc2":472,"\ud83c\udfca":473,"\ud83c\udfc4":474,"\ud83c\udfa3":475,"\u2615\ufe0f":476,"\ud83c\udf75":477,"\ud83c\udf76":478,"\ud83c\udf7c":479,"\ud83c\udf7a":480,"\ud83c\udf7b":481,"\ud83c\udf78":482,"\ud83c\udf79":483,"\ud83c\udf77":484,"\ud83c\udf74":485,"\ud83c\udf55":486,"\ud83c\udf54":487,"\ud83c\udf5f":488,"\ud83c\udf57":489,"\ud83c\udf56":490,"\ud83c\udf5d":491,"\ud83c\udf5b":492,"\ud83c\udf64":493,"\ud83c\udf71":494,"\ud83c\udf63":495,"\ud83c\udf65":496,"\ud83c\udf59":497,"\ud83c\udf58":498,"\ud83c\udf5a":499,		"\ud83c\udf5c":500,"\ud83c\udf72":501,"\ud83c\udf62":502,"\ud83c\udf61":503,"\ud83c\udf73":504,"\ud83c\udf5e":505,"\ud83c\udf69":506,"\ud83c\udf6e":507,"\ud83c\udf66":508,"\ud83c\udf68":509,"\ud83c\udf67":510,"\ud83c\udf82":511,"\ud83c\udf70":512,"\ud83c\udf6a":513,"\ud83c\udf6b":514,"\ud83c\udf6c":515,"\ud83c\udf6d":516,"\ud83c\udf6f":517,"\ud83c\udf4e":518,"\ud83c\udf4f":519,"\ud83c\udf4a":520,"\ud83c\udf4b":521,"\ud83c\udf52":522,"\ud83c\udf47":523,"\ud83c\udf49":524,"\ud83c\udf53":525,"\ud83c\udf51":526,"\ud83c\udf48":527,"\ud83c\udf4c":528,"\ud83c\udf50":529,"\ud83c\udf4d":530,"\ud83c\udf60":531,"\ud83c\udf46":532,"\ud83c\udf45":533,"\ud83c\udf3d":534,"\ud83c\udfe0":535,"\ud83c\udfe1":536,"\ud83c\udfeb":537,"\ud83c\udfe2":538,"\ud83c\udfe3":539,"\ud83c\udfe5":540,"\ud83c\udfe6":541,"\ud83c\udfea":542,"\ud83c\udfe9":543,"\ud83c\udfe8":544,"\ud83d\udc92":545,"\u26ea\ufe0f":546,"\ud83c\udfec":547,"\ud83c\udfe4":548,"\ud83c\udf07":549,"\ud83c\udf06":550,"\ud83c\udfef":551,"\ud83c\udff0":552,"\u26fa\ufe0f":553,"\ud83c\udfed":554,"\ud83d\uddfc":555,"\ud83d\uddfe":556,"\ud83d\uddfb":557,"\ud83c\udf04":558,"\ud83c\udf05":559,"\ud83c\udf03":560,"\ud83d\uddfd":561,"\ud83c\udf09":562,"\ud83c\udfa0":563,"\ud83c\udfa1":564,"\u26f2\ufe0f":565,"\ud83c\udfa2":566,"\ud83d\udea2":567,"\u26f5\ufe0f":568,"\ud83d\udea4":569,"\ud83d\udea3":570,"\u2693\ufe0f":571,"\ud83d\ude80":572,"\u2708\ufe0f":573,"\ud83d\udcba":574,"\ud83d\ude81":575,"\ud83d\ude82":576,"\ud83d\ude8a":577,"\ud83d\ude89":578,"\ud83d\ude9e":579,"\ud83d\ude86":580,"\ud83d\ude84":581,"\ud83d\ude85":582,"\ud83d\ude88":583,"\ud83d\ude87":584,"\ud83d\ude9d":585,"\ud83d\ude8b":586,"\ud83d\ude83":587,"\ud83d\ude8e":588,"\ud83d\ude8c":589,"\ud83d\ude8d":590,"\ud83d\ude99":591,"\ud83d\ude98":592,"\ud83d\ude97":593,"\ud83d\ude95":594,"\ud83d\ude96":595,"\ud83d\ude9b":596,"\ud83d\ude9a":597,"\ud83d\udea8":598,"\ud83d\ude93":599,		"\ud83d\ude94":600,"\ud83d\ude92":601,"\ud83d\ude91":602,"\ud83d\ude90":603,"\ud83d\udeb2":604,"\ud83d\udea1":605,"\ud83d\ude9f":606,"\ud83d\udea0":607,"\ud83d\ude9c":608,"\ud83d\udc88":609,"\ud83d\ude8f":610,"\ud83c\udfab":611,"\ud83d\udea6":612,"\ud83d\udea5":613,"\u26a0\ufe0f":614,"\ud83d\udea7":615,"\ud83d\udd30":616,"\u26fd\ufe0f":617,"\ud83c\udfee":618,"\ud83c\udfb0":619,"\u2668\ufe0f":620,"\ud83d\uddff":621,"\ud83c\udfaa":622,"\ud83c\udfad":623,"\ud83d\udccd":624,"\ud83d\udea9":625,"\ud83c\uddef\ud83c\uddf5":626,"\ud83c\uddf0\ud83c\uddf7":627,"\ud83c\udde9\ud83c\uddea":628,"\ud83c\udde8\ud83c\uddf3":629,"\ud83c\uddfa\ud83c\uddf8":630,"\ud83c\uddeb\ud83c\uddf7":631,"\ud83c\uddea\ud83c\uddf8":632,"\ud83c\uddee\ud83c\uddf9":633,"\ud83c\uddf7\ud83c\uddfa":634,"\ud83c\uddec\ud83c\udde7":635,"1\u20e3":636,"2\u20e3":637,"3\u20e3":638,"4\u20e3":639,"5\u20e3":640,"6\u20e3":641,"7\u20e3":642,"8\u20e3":643,"9\u20e3":644,"0\u20e3":645,"\ud83d\udd1f":646,"\ud83d\udd22":647,"\u0023\u20e3":648,"\ud83d\udd23":649,"\u2b06\ufe0f":650,"\u2b07\ufe0f":651,"\u2b05\ufe0f":652,"\u27a1\ufe0f":653,"\ud83d\udd20":654,"\ud83d\udd21":655,"\ud83d\udd24":656,"\u2197\ufe0f":657,"\u2196\ufe0f":658,"\u2198\ufe0f":659,"\u2199\ufe0f":660,"\u2194\ufe0f":661,"\u2195\ufe0f":662,"\ud83d\udd04":663,"\u25c0\ufe0f":664,"\u25b6\ufe0f":665,"\ud83d\udd3c":666,"\ud83d\udd3d":667,"\u21a9\ufe0f":668,"\u21aa\ufe0f":669,"\u2139\ufe0f":670,"\u23ea":671,"\u23e9":672,"\u23eb":673,"\u23ec":674,"\u2935\ufe0f":675,"\u2934\ufe0f":676,"\ud83c\udd97":677,"\ud83d\udd00":678,"\ud83d\udd01":679,"\ud83d\udd02":680,"\ud83c\udd95":681,"\ud83c\udd99":682,"\ud83c\udd92":683,"\ud83c\udd93":684,"\ud83c\udd96":685,"\ud83d\udcf6":686,"\ud83c\udfa6":687,"\ud83c\ude01":688,"\ud83c\ude2f\ufe0f":689,"\ud83c\ude33":690,"\ud83c\ude35":691,"\ud83c\ude34":692,"\ud83c\ude32":693,"\ud83c\ude50":694,"\ud83c\ude39":695,"\ud83c\ude3a":696,"\ud83c\ude36":697,"\ud83c\ude1a\ufe0f":698,"\ud83d\udebb":699,		"\ud83d\udeb9":700,"\ud83d\udeba":701,"\ud83d\udebc":702,"\ud83d\udebe":703,"\ud83d\udeb0":704,"\ud83d\udeae":705,"\ud83c\udd7f\ufe0f":706,"\u267f\ufe0f":707,"\ud83d\udead":708,"\ud83c\ude37":709,"\ud83c\ude38":710,"\ud83c\ude02":711,"\u24c2\ufe0f":712,"\ud83d\udec2":713,"\ud83d\udec4":714,"\ud83d\udec5":715,"\ud83d\udec3":716,"\ud83c\ude51":717,"\u3299\ufe0f":718,"\u3297\ufe0f":719,"\ud83c\udd91":720,"\ud83c\udd98":721,"\ud83c\udd94":722,"\ud83d\udeab":723,"\ud83d\udd1e":724,"\ud83d\udcf5":725,"\ud83d\udeaf":726,"\ud83d\udeb1":727,"\ud83d\udeb3":728,"\ud83d\udeb7":729,"\ud83d\udeb8":730,"\u26d4\ufe0f":731,"\u2733\ufe0f":732,"\u2747\ufe0f":733,"\u274e":734,"\u2705":735,"\u2734\ufe0f":736,"\ud83d\udc9f":737,"\ud83c\udd9a":738,"\ud83d\udcf3":739,"\ud83d\udcf4":740,"\ud83c\udd70":741,"\ud83c\udd71":742,"\ud83c\udd8e":743,"\ud83c\udd7e":744,"\ud83d\udca0":745,"\u27bf":746,"\u267b\ufe0f":747,"\u2648\ufe0f":748,"\u2649\ufe0f":749,"\u264a\ufe0f":750,"\u264b\ufe0f":751,"\u264c\ufe0f":752,"\u264d\ufe0f":753,"\u264e\ufe0f":754,"\u264f\ufe0f":755,"\u2650\ufe0f":756,"\u2651\ufe0f":757,"\u2652\ufe0f":758,"\u2653\ufe0f":759,"\u26ce":760,"\ud83d\udd2f":761,"\ud83c\udfe7":762,"\ud83d\udcb9":763,"\ud83d\udcb2":764,"\ud83d\udcb1":765,"\u00a9":766,"\u00ae":767,"\u2122":768,"\u274c":769,"\u203c\ufe0f":770,"\u2049\ufe0f":771,"\u2757\ufe0f":772,"\u2753":773,"\u2755":774,"\u2754":775,"\u2b55\ufe0f":776,"\ud83d\udd1d":777,"\ud83d\udd1a":778,"\ud83d\udd19":779,"\ud83d\udd1b":780,"\ud83d\udd1c":781,"\ud83d\udd03":782,"\ud83d\udd5b":783,"\ud83d\udd67":784,"\ud83d\udd50":785,"\ud83d\udd5c":786,"\ud83d\udd51":787,"\ud83d\udd5d":788,"\ud83d\udd52":789,"\ud83d\udd5e":790,"\ud83d\udd53":791,"\ud83d\udd5f":792,"\ud83d\udd54":793,"\ud83d\udd60":794,"\ud83d\udd55":795,"\ud83d\udd56":796,"\ud83d\udd57":797,"\ud83d\udd58":798,"\ud83d\udd59":799,		"\ud83d\udd5a":800,"\ud83d\udd61":801,"\ud83d\udd62":802,"\ud83d\udd63":803,"\ud83d\udd64":804,"\ud83d\udd65":805,"\ud83d\udd66":806,"\u2716\ufe0f":807,"\u2795":808,"\u2796":809,"\u2797":810,"\u2660\ufe0f":811,"\u2665\ufe0f":812,"\u2663\ufe0f":813,"\u2666\ufe0f":814,"\ud83d\udcae":815,"\ud83d\udcaf":816,"\u2714\ufe0f":817,"\u2611\ufe0f":818,"\ud83d\udd18":819,"\ud83d\udd17":820,"\u27b0":821,"\u3030":822,"\u303d\ufe0f":823,"\ud83d\udd31":824,"\u25fc\ufe0f":825,"\u25fb\ufe0f":826,"\u25fe\ufe0f":827,"\u25fd\ufe0f":828,"\u25aa\ufe0f":829,"\u25ab\ufe0f":830,"\ud83d\udd3a":831,"\ud83d\udd32":832,"\ud83d\udd33":833,"\u26ab\ufe0f":834,"\u26aa\ufe0f":835,"\ud83d\udd34":836,"\ud83d\udd35":837,"\ud83d\udd3b":838,"\u2b1c\ufe0f":839,"\u2b1b\ufe0f":840,"\ud83d\udd36":841,"\ud83d\udd37":842,"\ud83d\udd38":843,"\ud83d\udd39":844
-		,"\u263a":4,"\u270c":110,"\u261d":120,"\u2764":172,"\u2b50":293,"\u2600":294,"\u26c5":295,"\u2601":296,"\u26a1":297,"\u2614":298,"\u2744":299,"\u26c4":300,"\u260e":336,"\u231b":352,"\u231a":354,"\u2709":393,"\u2702":417,"\u2712":420,"\u270f":421,"\ud83c\udc04":454,"\u26bd":459,"\u26be":460,"\u26f3":465,"\u2615":476,"\u26ea":546,"\u26fa":553,"\u26f2":565,"\u26f5":568,"\u2693":571,"\u2708":573,"\u26a0":614,"\u26fd":617,"\u2668":620,"\u2b06":650,"\u2b07":651,"\u2b05":652,"\u27a1":653,"\u2197":657,"\u2196":658,"\u2198":659,"\u2199":660,"\u2194":661,"\u2195":662,"\u25c0":664,"\u25b6":665,"\u21a9":668,"\u21aa":669,"\u2139":670,"\u2935":675,"\u2934":676,"\ud83c\ude2f":689,"\ud83c\ude1a":698,"\ud83c\udd7f":706,"\u267f":707,"\u24c2":712,"\u3299":718,"\u3297":719,"\u26d4":731,"\u2733":732,"\u2747":733,"\u2734":736,"\u267b":747,"\u2648":748,"\u2649":749,"\u264a":750,"\u264b":751,"\u264c":752,"\u264d":753,"\u264e":754,"\u264f":755,"\u2650":756,"\u2651":757,"\u2652":758,"\u2653":759,"\u203c":770,"\u2049":771,"\u2757":772,"\u2b55":776,"\u2716":807,"\u2660":811,"\u2665":812,"\u2663":813,"\u2666":814,"\u2714":817,"\u2611":818,"\u303d":823,"\u25fc":825,"\u25fb":826,"\u25fe":827,"\u25fd":828,"\u25aa":829,"\u25ab":830,"\u26ab":834,"\u26aa":835,"\u2b1c":839,"\u2b1b":840
-	};
-	var regx_arr=[];
-	for(var k in emoji){
-		regx_arr.push(k);
-	}
-	var regx = new RegExp('(' + regx_arr.join('|') + ')', 'g');
-	regx_arr = null;
-	return str.replace(regx, function (a, b) {
-		return '<span class="vco-emoji emj'+emoji[b]+'"></span>';
-	});
+  var emoji = {
+    "\ud83d\ude04":0,"\ud83d\ude03":1,"\ud83d\ude00":2,"\ud83d\ude0a":3,"\u263a\ufe0f":4,"\ud83d\ude09":5,"\ud83d\ude0d":6,"\ud83d\ude18":7,"\ud83d\ude1a":8,"\ud83d\ude17":9,"\ud83d\ude19":10,"\ud83d\ude1c":11,"\ud83d\ude1d":12,"\ud83d\ude1b":13,"\ud83d\ude33":14,"\ud83d\ude01":15,"\ud83d\ude14":16,"\ud83d\ude0c":17,"\ud83d\ude12":18,"\ud83d\ude1e":19,"\ud83d\ude23":20,"\ud83d\ude22":21,"\ud83d\ude02":22,"\ud83d\ude2d":23,"\ud83d\ude2a":24,"\ud83d\ude25":25,"\ud83d\ude30":26,"\ud83d\ude05":27,"\ud83d\ude13":28,"\ud83d\ude29":29,"\ud83d\ude2b":30,"\ud83d\ude28":31,"\ud83d\ude31":32,"\ud83d\ude20":33,"\ud83d\ude21":34,"\ud83d\ude24":35,"\ud83d\ude16":36,"\ud83d\ude06":37,"\ud83d\ude0b":38,"\ud83d\ude37":39,"\ud83d\ude0e":40,"\ud83d\ude34":41,"\ud83d\ude35":42,"\ud83d\ude32":43,"\ud83d\ude1f":44,"\ud83d\ude26":45,"\ud83d\ude27":46,"\ud83d\ude08":47,"\ud83d\udc7f":48,"\ud83d\ude2e":49,"\ud83d\ude2c":50,"\ud83d\ude10":51,"\ud83d\ude15":52,"\ud83d\ude2f":53,"\ud83d\ude36":54,"\ud83d\ude07":55,"\ud83d\ude0f":56,"\ud83d\ude11":57,"\ud83d\udc72":58,"\ud83d\udc73":59,"\ud83d\udc6e":60,"\ud83d\udc77":61,"\ud83d\udc82":62,"\ud83d\udc76":63,"\ud83d\udc66":64,"\ud83d\udc67":65,"\ud83d\udc68":66,"\ud83d\udc69":67,"\ud83d\udc74":68,"\ud83d\udc75":69,"\ud83d\udc71":70,"\ud83d\udc7c":71,"\ud83d\udc78":72,"\ud83d\ude3a":73,"\ud83d\ude38":74,"\ud83d\ude3b":75,"\ud83d\ude3d":76,"\ud83d\ude3c":77,"\ud83d\ude40":78,"\ud83d\ude3f":79,"\ud83d\ude39":80,"\ud83d\ude3e":81,"\ud83d\udc79":82,"\ud83d\udc7a":83,"\ud83d\ude48":84,"\ud83d\ude49":85,"\ud83d\ude4a":86,"\ud83d\udc80":87,"\ud83d\udc7d":88,"\ud83d\udca9":89,"\ud83d\udd25":90,"\u2728":91,"\ud83c\udf1f":92,"\ud83d\udcab":93,"\ud83d\udca5":94,"\ud83d\udca2":95,"\ud83d\udca6":96,"\ud83d\udca7":97,"\ud83d\udca4":98,"\ud83d\udca8":99,    "\ud83d\udc42":100,"\ud83d\udc40":101,"\ud83d\udc43":102,"\ud83d\udc45":103,"\ud83d\udc44":104,"\ud83d\udc4d":105,"\ud83d\udc4e":106,"\ud83d\udc4c":107,"\ud83d\udc4a":108,"\u270a":109,"\u270c\ufe0f":110,"\ud83d\udc4b":111,"\u270b":112,"\ud83d\udc50":113,"\ud83d\udc46":114,"\ud83d\udc47":115,"\ud83d\udc49":116,"\ud83d\udc48":117,"\ud83d\ude4c":118,"\ud83d\ude4f":119,"\u261d\ufe0f":120,"\ud83d\udc4f":121,"\ud83d\udcaa":122,"\ud83d\udeb6":123,"\ud83c\udfc3":124,"\ud83d\udc83":125,"\ud83d\udc6b":126,"\ud83d\udc6a":127,"\ud83d\udc6c":128,"\ud83d\udc6d":129,"\ud83d\udc8f":130,"\ud83d\udc91":131,"\ud83d\udc6f":132,"\ud83d\ude46":133,"\ud83d\ude45":134,"\ud83d\udc81":135,"\ud83d\ude4b":136,"\ud83d\udc86":137,"\ud83d\udc87":138,"\ud83d\udc85":139,"\ud83d\udc70":140,"\ud83d\ude4e":141,"\ud83d\ude4d":142,"\ud83d\ude47":143,"\ud83c\udfa9":144,"\ud83d\udc51":145,"\ud83d\udc52":146,"\ud83d\udc5f":147,"\ud83d\udc5e":148,"\ud83d\udc61":149,"\ud83d\udc60":150,"\ud83d\udc62":151,"\ud83d\udc55":152,"\ud83d\udc54":153,"\ud83d\udc5a":154,"\ud83d\udc57":155,"\ud83c\udfbd":156,"\ud83d\udc56":157,"\ud83d\udc58":158,"\ud83d\udc59":159,"\ud83d\udcbc":160,"\ud83d\udc5c":161,"\ud83d\udc5d":162,"\ud83d\udc5b":163,"\ud83d\udc53":164,"\ud83c\udf80":165,"\ud83c\udf02":166,"\ud83d\udc84":167,"\ud83d\udc9b":168,"\ud83d\udc99":169,"\ud83d\udc9c":170,"\ud83d\udc9a":171,"\u2764\ufe0f":172,"\ud83d\udc94":173,"\ud83d\udc97":174,"\ud83d\udc93":175,"\ud83d\udc95":176,"\ud83d\udc96":177,"\ud83d\udc9e":178,"\ud83d\udc98":179,"\ud83d\udc8c":180,"\ud83d\udc8b":181,"\ud83d\udc8d":182,"\ud83d\udc8e":183,"\ud83d\udc64":184,"\ud83d\udc65":185,"\ud83d\udcac":186,"\ud83d\udc63":187,"\ud83d\udcad":188,"\ud83d\udc36":189,"\ud83d\udc3a":190,"\ud83d\udc31":191,"\ud83d\udc2d":192,"\ud83d\udc39":193,"\ud83d\udc30":194,"\ud83d\udc38":195,"\ud83d\udc2f":196,"\ud83d\udc28":197,"\ud83d\udc3b":198,"\ud83d\udc37":199,    "\ud83d\udc3d":200,"\ud83d\udc2e":201,"\ud83d\udc17":202,"\ud83d\udc35":203,"\ud83d\udc12":204,"\ud83d\udc34":205,"\ud83d\udc11":206,"\ud83d\udc18":207,"\ud83d\udc3c":208,"\ud83d\udc27":209,"\ud83d\udc26":210,"\ud83d\udc24":211,"\ud83d\udc25":212,"\ud83d\udc23":213,"\ud83d\udc14":214,"\ud83d\udc0d":215,"\ud83d\udc22":216,"\ud83d\udc1b":217,"\ud83d\udc1d":218,"\ud83d\udc1c":219,"\ud83d\udc1e":220,"\ud83d\udc0c":221,"\ud83d\udc19":222,"\ud83d\udc1a":223,"\ud83d\udc20":224,"\ud83d\udc1f":225,"\ud83d\udc2c":226,"\ud83d\udc33":227,"\ud83d\udc0b":228,"\ud83d\udc04":229,"\ud83d\udc0f":230,"\ud83d\udc00":231,"\ud83d\udc03":232,"\ud83d\udc05":233,"\ud83d\udc07":234,"\ud83d\udc09":235,"\ud83d\udc0e":236,"\ud83d\udc10":237,"\ud83d\udc13":238,"\ud83d\udc15":239,"\ud83d\udc16":240,"\ud83d\udc01":241,"\ud83d\udc02":242,"\ud83d\udc32":243,"\ud83d\udc21":244,"\ud83d\udc0a":245,"\ud83d\udc2b":246,"\ud83d\udc2a":247,"\ud83d\udc06":248,"\ud83d\udc08":249,"\ud83d\udc29":250,"\ud83d\udc3e":251,"\ud83d\udc90":252,"\ud83c\udf38":253,"\ud83c\udf37":254,"\ud83c\udf40":255,"\ud83c\udf39":256,"\ud83c\udf3b":257,"\ud83c\udf3a":258,"\ud83c\udf41":259,"\ud83c\udf43":260,"\ud83c\udf42":261,"\ud83c\udf3f":262,"\ud83c\udf3e":263,"\ud83c\udf44":264,"\ud83c\udf35":265,"\ud83c\udf34":266,"\ud83c\udf32":267,"\ud83c\udf33":268,"\ud83c\udf30":269,"\ud83c\udf31":270,"\ud83c\udf3c":271,"\ud83c\udf10":272,"\ud83c\udf1e":273,"\ud83c\udf1d":274,"\ud83c\udf1a":275,"\ud83c\udf11":276,"\ud83c\udf12":277,"\ud83c\udf13":278,"\ud83c\udf14":279,"\ud83c\udf15":280,"\ud83c\udf16":281,"\ud83c\udf17":282,"\ud83c\udf18":283,"\ud83c\udf1c":284,"\ud83c\udf1b":285,"\ud83c\udf19":286,"\ud83c\udf0d":287,"\ud83c\udf0e":288,"\ud83c\udf0f":289,"\ud83c\udf0b":290,"\ud83c\udf0c":291,"\ud83c\udf20":292,"\u2b50\ufe0f":293,"\u2600\ufe0f":294,"\u26c5\ufe0f":295,"\u2601\ufe0f":296,"\u26a1\ufe0f":297,"\u2614\ufe0f":298,"\u2744\ufe0f":299,    "\u26c4\ufe0f":300,"\ud83c\udf00":301,"\ud83c\udf01":302,"\ud83c\udf08":303,"\ud83c\udf0a":304,"\ud83c\udf8d":305,"\ud83d\udc9d":306,"\ud83c\udf8e":307,"\ud83c\udf92":308,"\ud83c\udf93":309,"\ud83c\udf8f":310,"\ud83c\udf86":311,"\ud83c\udf87":312,"\ud83c\udf90":313,"\ud83c\udf91":314,"\ud83c\udf83":315,"\ud83d\udc7b":316,"\ud83c\udf85":317,"\ud83c\udf84":318,"\ud83c\udf81":319,"\ud83c\udf8b":320,"\ud83c\udf89":321,"\ud83c\udf8a":322,"\ud83c\udf88":323,"\ud83c\udf8c":324,"\ud83d\udd2e":325,"\ud83c\udfa5":326,"\ud83d\udcf7":327,"\ud83d\udcf9":328,"\ud83d\udcfc":329,"\ud83d\udcbf":330,"\ud83d\udcc0":331,"\ud83d\udcbd":332,"\ud83d\udcbe":333,"\ud83d\udcbb":334,"\ud83d\udcf1":335,"\u260e\ufe0f":336,"\ud83d\udcde":337,"\ud83d\udcdf":338,"\ud83d\udce0":339,"\ud83d\udce1":340,"\ud83d\udcfa":341,"\ud83d\udcfb":342,"\ud83d\udd0a":343,"\ud83d\udd09":344,"\ud83d\udd08":345,"\ud83d\udd07":346,"\ud83d\udd14":347,"\ud83d\udd15":348,"\ud83d\udce2":349,"\ud83d\udce3":350,"\u23f3":351,"\u231b\ufe0f":352,"\u23f0":353,"\u231a\ufe0f":354,"\ud83d\udd13":355,"\ud83d\udd12":356,"\ud83d\udd0f":357,"\ud83d\udd10":358,"\ud83d\udd11":359,"\ud83d\udd0e":360,"\ud83d\udca1":361,"\ud83d\udd26":362,"\ud83d\udd06":363,"\ud83d\udd05":364,"\ud83d\udd0c":365,"\ud83d\udd0b":366,"\ud83d\udd0d":367,"\ud83d\udec1":368,"\ud83d\udec0":369,"\ud83d\udebf":370,"\ud83d\udebd":371,"\ud83d\udd27":372,"\ud83d\udd29":373,"\ud83d\udd28":374,"\ud83d\udeaa":375,"\ud83d\udeac":376,"\ud83d\udca3":377,"\ud83d\udd2b":378,"\ud83d\udd2a":379,"\ud83d\udc8a":380,"\ud83d\udc89":381,"\ud83d\udcb0":382,"\ud83d\udcb4":383,"\ud83d\udcb5":384,"\ud83d\udcb7":385,"\ud83d\udcb6":386,"\ud83d\udcb3":387,"\ud83d\udcb8":388,"\ud83d\udcf2":389,"\ud83d\udce7":390,"\ud83d\udce5":391,"\ud83d\udce4":392,"\u2709\ufe0f":393,"\ud83d\udce9":394,"\ud83d\udce8":395,"\ud83d\udcef":396,"\ud83d\udceb":397,"\ud83d\udcea":398,"\ud83d\udcec":399,    "\ud83d\udced":400,"\ud83d\udcee":401,"\ud83d\udce6":402,"\ud83d\udcdd":403,"\ud83d\udcc4":404,"\ud83d\udcc3":405,"\ud83d\udcd1":406,"\ud83d\udcca":407,"\ud83d\udcc8":408,"\ud83d\udcc9":409,"\ud83d\udcdc":410,"\ud83d\udccb":411,"\ud83d\udcc5":412,"\ud83d\udcc6":413,"\ud83d\udcc7":414,"\ud83d\udcc1":415,"\ud83d\udcc2":416,"\u2702\ufe0f":417,"\ud83d\udccc":418,"\ud83d\udcce":419,"\u2712\ufe0f":420,"\u270f\ufe0f":421,"\ud83d\udccf":422,"\ud83d\udcd0":423,"\ud83d\udcd5":424,"\ud83d\udcd7":425,"\ud83d\udcd8":426,"\ud83d\udcd9":427,"\ud83d\udcd3":428,"\ud83d\udcd4":429,"\ud83d\udcd2":430,"\ud83d\udcda":431,"\ud83d\udcd6":432,"\ud83d\udd16":433,"\ud83d\udcdb":434,"\ud83d\udd2c":435,"\ud83d\udd2d":436,"\ud83d\udcf0":437,"\ud83c\udfa8":438,"\ud83c\udfac":439,"\ud83c\udfa4":440,"\ud83c\udfa7":441,"\ud83c\udfbc":442,"\ud83c\udfb5":443,"\ud83c\udfb6":444,"\ud83c\udfb9":445,"\ud83c\udfbb":446,"\ud83c\udfba":447,"\ud83c\udfb7":448,"\ud83c\udfb8":449,"\ud83d\udc7e":450,"\ud83c\udfae":451,"\ud83c\udccf":452,"\ud83c\udfb4":453,"\ud83c\udc04\ufe0f":454,"\ud83c\udfb2":455,"\ud83c\udfaf":456,"\ud83c\udfc8":457,"\ud83c\udfc0":458,"\u26bd\ufe0f":459,"\u26be\ufe0f":460,"\ud83c\udfbe":461,"\ud83c\udfb1":462,"\ud83c\udfc9":463,"\ud83c\udfb3":464,"\u26f3\ufe0f":465,"\ud83d\udeb5":466,"\ud83d\udeb4":467,"\ud83c\udfc1":468,"\ud83c\udfc7":469,"\ud83c\udfc6":470,"\ud83c\udfbf":471,"\ud83c\udfc2":472,"\ud83c\udfca":473,"\ud83c\udfc4":474,"\ud83c\udfa3":475,"\u2615\ufe0f":476,"\ud83c\udf75":477,"\ud83c\udf76":478,"\ud83c\udf7c":479,"\ud83c\udf7a":480,"\ud83c\udf7b":481,"\ud83c\udf78":482,"\ud83c\udf79":483,"\ud83c\udf77":484,"\ud83c\udf74":485,"\ud83c\udf55":486,"\ud83c\udf54":487,"\ud83c\udf5f":488,"\ud83c\udf57":489,"\ud83c\udf56":490,"\ud83c\udf5d":491,"\ud83c\udf5b":492,"\ud83c\udf64":493,"\ud83c\udf71":494,"\ud83c\udf63":495,"\ud83c\udf65":496,"\ud83c\udf59":497,"\ud83c\udf58":498,"\ud83c\udf5a":499,    "\ud83c\udf5c":500,"\ud83c\udf72":501,"\ud83c\udf62":502,"\ud83c\udf61":503,"\ud83c\udf73":504,"\ud83c\udf5e":505,"\ud83c\udf69":506,"\ud83c\udf6e":507,"\ud83c\udf66":508,"\ud83c\udf68":509,"\ud83c\udf67":510,"\ud83c\udf82":511,"\ud83c\udf70":512,"\ud83c\udf6a":513,"\ud83c\udf6b":514,"\ud83c\udf6c":515,"\ud83c\udf6d":516,"\ud83c\udf6f":517,"\ud83c\udf4e":518,"\ud83c\udf4f":519,"\ud83c\udf4a":520,"\ud83c\udf4b":521,"\ud83c\udf52":522,"\ud83c\udf47":523,"\ud83c\udf49":524,"\ud83c\udf53":525,"\ud83c\udf51":526,"\ud83c\udf48":527,"\ud83c\udf4c":528,"\ud83c\udf50":529,"\ud83c\udf4d":530,"\ud83c\udf60":531,"\ud83c\udf46":532,"\ud83c\udf45":533,"\ud83c\udf3d":534,"\ud83c\udfe0":535,"\ud83c\udfe1":536,"\ud83c\udfeb":537,"\ud83c\udfe2":538,"\ud83c\udfe3":539,"\ud83c\udfe5":540,"\ud83c\udfe6":541,"\ud83c\udfea":542,"\ud83c\udfe9":543,"\ud83c\udfe8":544,"\ud83d\udc92":545,"\u26ea\ufe0f":546,"\ud83c\udfec":547,"\ud83c\udfe4":548,"\ud83c\udf07":549,"\ud83c\udf06":550,"\ud83c\udfef":551,"\ud83c\udff0":552,"\u26fa\ufe0f":553,"\ud83c\udfed":554,"\ud83d\uddfc":555,"\ud83d\uddfe":556,"\ud83d\uddfb":557,"\ud83c\udf04":558,"\ud83c\udf05":559,"\ud83c\udf03":560,"\ud83d\uddfd":561,"\ud83c\udf09":562,"\ud83c\udfa0":563,"\ud83c\udfa1":564,"\u26f2\ufe0f":565,"\ud83c\udfa2":566,"\ud83d\udea2":567,"\u26f5\ufe0f":568,"\ud83d\udea4":569,"\ud83d\udea3":570,"\u2693\ufe0f":571,"\ud83d\ude80":572,"\u2708\ufe0f":573,"\ud83d\udcba":574,"\ud83d\ude81":575,"\ud83d\ude82":576,"\ud83d\ude8a":577,"\ud83d\ude89":578,"\ud83d\ude9e":579,"\ud83d\ude86":580,"\ud83d\ude84":581,"\ud83d\ude85":582,"\ud83d\ude88":583,"\ud83d\ude87":584,"\ud83d\ude9d":585,"\ud83d\ude8b":586,"\ud83d\ude83":587,"\ud83d\ude8e":588,"\ud83d\ude8c":589,"\ud83d\ude8d":590,"\ud83d\ude99":591,"\ud83d\ude98":592,"\ud83d\ude97":593,"\ud83d\ude95":594,"\ud83d\ude96":595,"\ud83d\ude9b":596,"\ud83d\ude9a":597,"\ud83d\udea8":598,"\ud83d\ude93":599,    "\ud83d\ude94":600,"\ud83d\ude92":601,"\ud83d\ude91":602,"\ud83d\ude90":603,"\ud83d\udeb2":604,"\ud83d\udea1":605,"\ud83d\ude9f":606,"\ud83d\udea0":607,"\ud83d\ude9c":608,"\ud83d\udc88":609,"\ud83d\ude8f":610,"\ud83c\udfab":611,"\ud83d\udea6":612,"\ud83d\udea5":613,"\u26a0\ufe0f":614,"\ud83d\udea7":615,"\ud83d\udd30":616,"\u26fd\ufe0f":617,"\ud83c\udfee":618,"\ud83c\udfb0":619,"\u2668\ufe0f":620,"\ud83d\uddff":621,"\ud83c\udfaa":622,"\ud83c\udfad":623,"\ud83d\udccd":624,"\ud83d\udea9":625,"\ud83c\uddef\ud83c\uddf5":626,"\ud83c\uddf0\ud83c\uddf7":627,"\ud83c\udde9\ud83c\uddea":628,"\ud83c\udde8\ud83c\uddf3":629,"\ud83c\uddfa\ud83c\uddf8":630,"\ud83c\uddeb\ud83c\uddf7":631,"\ud83c\uddea\ud83c\uddf8":632,"\ud83c\uddee\ud83c\uddf9":633,"\ud83c\uddf7\ud83c\uddfa":634,"\ud83c\uddec\ud83c\udde7":635,"1\u20e3":636,"2\u20e3":637,"3\u20e3":638,"4\u20e3":639,"5\u20e3":640,"6\u20e3":641,"7\u20e3":642,"8\u20e3":643,"9\u20e3":644,"0\u20e3":645,"\ud83d\udd1f":646,"\ud83d\udd22":647,"\u0023\u20e3":648,"\ud83d\udd23":649,"\u2b06\ufe0f":650,"\u2b07\ufe0f":651,"\u2b05\ufe0f":652,"\u27a1\ufe0f":653,"\ud83d\udd20":654,"\ud83d\udd21":655,"\ud83d\udd24":656,"\u2197\ufe0f":657,"\u2196\ufe0f":658,"\u2198\ufe0f":659,"\u2199\ufe0f":660,"\u2194\ufe0f":661,"\u2195\ufe0f":662,"\ud83d\udd04":663,"\u25c0\ufe0f":664,"\u25b6\ufe0f":665,"\ud83d\udd3c":666,"\ud83d\udd3d":667,"\u21a9\ufe0f":668,"\u21aa\ufe0f":669,"\u2139\ufe0f":670,"\u23ea":671,"\u23e9":672,"\u23eb":673,"\u23ec":674,"\u2935\ufe0f":675,"\u2934\ufe0f":676,"\ud83c\udd97":677,"\ud83d\udd00":678,"\ud83d\udd01":679,"\ud83d\udd02":680,"\ud83c\udd95":681,"\ud83c\udd99":682,"\ud83c\udd92":683,"\ud83c\udd93":684,"\ud83c\udd96":685,"\ud83d\udcf6":686,"\ud83c\udfa6":687,"\ud83c\ude01":688,"\ud83c\ude2f\ufe0f":689,"\ud83c\ude33":690,"\ud83c\ude35":691,"\ud83c\ude34":692,"\ud83c\ude32":693,"\ud83c\ude50":694,"\ud83c\ude39":695,"\ud83c\ude3a":696,"\ud83c\ude36":697,"\ud83c\ude1a\ufe0f":698,"\ud83d\udebb":699,    "\ud83d\udeb9":700,"\ud83d\udeba":701,"\ud83d\udebc":702,"\ud83d\udebe":703,"\ud83d\udeb0":704,"\ud83d\udeae":705,"\ud83c\udd7f\ufe0f":706,"\u267f\ufe0f":707,"\ud83d\udead":708,"\ud83c\ude37":709,"\ud83c\ude38":710,"\ud83c\ude02":711,"\u24c2\ufe0f":712,"\ud83d\udec2":713,"\ud83d\udec4":714,"\ud83d\udec5":715,"\ud83d\udec3":716,"\ud83c\ude51":717,"\u3299\ufe0f":718,"\u3297\ufe0f":719,"\ud83c\udd91":720,"\ud83c\udd98":721,"\ud83c\udd94":722,"\ud83d\udeab":723,"\ud83d\udd1e":724,"\ud83d\udcf5":725,"\ud83d\udeaf":726,"\ud83d\udeb1":727,"\ud83d\udeb3":728,"\ud83d\udeb7":729,"\ud83d\udeb8":730,"\u26d4\ufe0f":731,"\u2733\ufe0f":732,"\u2747\ufe0f":733,"\u274e":734,"\u2705":735,"\u2734\ufe0f":736,"\ud83d\udc9f":737,"\ud83c\udd9a":738,"\ud83d\udcf3":739,"\ud83d\udcf4":740,"\ud83c\udd70":741,"\ud83c\udd71":742,"\ud83c\udd8e":743,"\ud83c\udd7e":744,"\ud83d\udca0":745,"\u27bf":746,"\u267b\ufe0f":747,"\u2648\ufe0f":748,"\u2649\ufe0f":749,"\u264a\ufe0f":750,"\u264b\ufe0f":751,"\u264c\ufe0f":752,"\u264d\ufe0f":753,"\u264e\ufe0f":754,"\u264f\ufe0f":755,"\u2650\ufe0f":756,"\u2651\ufe0f":757,"\u2652\ufe0f":758,"\u2653\ufe0f":759,"\u26ce":760,"\ud83d\udd2f":761,"\ud83c\udfe7":762,"\ud83d\udcb9":763,"\ud83d\udcb2":764,"\ud83d\udcb1":765,"\u00a9":766,"\u00ae":767,"\u2122":768,"\u274c":769,"\u203c\ufe0f":770,"\u2049\ufe0f":771,"\u2757\ufe0f":772,"\u2753":773,"\u2755":774,"\u2754":775,"\u2b55\ufe0f":776,"\ud83d\udd1d":777,"\ud83d\udd1a":778,"\ud83d\udd19":779,"\ud83d\udd1b":780,"\ud83d\udd1c":781,"\ud83d\udd03":782,"\ud83d\udd5b":783,"\ud83d\udd67":784,"\ud83d\udd50":785,"\ud83d\udd5c":786,"\ud83d\udd51":787,"\ud83d\udd5d":788,"\ud83d\udd52":789,"\ud83d\udd5e":790,"\ud83d\udd53":791,"\ud83d\udd5f":792,"\ud83d\udd54":793,"\ud83d\udd60":794,"\ud83d\udd55":795,"\ud83d\udd56":796,"\ud83d\udd57":797,"\ud83d\udd58":798,"\ud83d\udd59":799,    "\ud83d\udd5a":800,"\ud83d\udd61":801,"\ud83d\udd62":802,"\ud83d\udd63":803,"\ud83d\udd64":804,"\ud83d\udd65":805,"\ud83d\udd66":806,"\u2716\ufe0f":807,"\u2795":808,"\u2796":809,"\u2797":810,"\u2660\ufe0f":811,"\u2665\ufe0f":812,"\u2663\ufe0f":813,"\u2666\ufe0f":814,"\ud83d\udcae":815,"\ud83d\udcaf":816,"\u2714\ufe0f":817,"\u2611\ufe0f":818,"\ud83d\udd18":819,"\ud83d\udd17":820,"\u27b0":821,"\u3030":822,"\u303d\ufe0f":823,"\ud83d\udd31":824,"\u25fc\ufe0f":825,"\u25fb\ufe0f":826,"\u25fe\ufe0f":827,"\u25fd\ufe0f":828,"\u25aa\ufe0f":829,"\u25ab\ufe0f":830,"\ud83d\udd3a":831,"\ud83d\udd32":832,"\ud83d\udd33":833,"\u26ab\ufe0f":834,"\u26aa\ufe0f":835,"\ud83d\udd34":836,"\ud83d\udd35":837,"\ud83d\udd3b":838,"\u2b1c\ufe0f":839,"\u2b1b\ufe0f":840,"\ud83d\udd36":841,"\ud83d\udd37":842,"\ud83d\udd38":843,"\ud83d\udd39":844
+    ,"\u263a":4,"\u270c":110,"\u261d":120,"\u2764":172,"\u2b50":293,"\u2600":294,"\u26c5":295,"\u2601":296,"\u26a1":297,"\u2614":298,"\u2744":299,"\u26c4":300,"\u260e":336,"\u231b":352,"\u231a":354,"\u2709":393,"\u2702":417,"\u2712":420,"\u270f":421,"\ud83c\udc04":454,"\u26bd":459,"\u26be":460,"\u26f3":465,"\u2615":476,"\u26ea":546,"\u26fa":553,"\u26f2":565,"\u26f5":568,"\u2693":571,"\u2708":573,"\u26a0":614,"\u26fd":617,"\u2668":620,"\u2b06":650,"\u2b07":651,"\u2b05":652,"\u27a1":653,"\u2197":657,"\u2196":658,"\u2198":659,"\u2199":660,"\u2194":661,"\u2195":662,"\u25c0":664,"\u25b6":665,"\u21a9":668,"\u21aa":669,"\u2139":670,"\u2935":675,"\u2934":676,"\ud83c\ude2f":689,"\ud83c\ude1a":698,"\ud83c\udd7f":706,"\u267f":707,"\u24c2":712,"\u3299":718,"\u3297":719,"\u26d4":731,"\u2733":732,"\u2747":733,"\u2734":736,"\u267b":747,"\u2648":748,"\u2649":749,"\u264a":750,"\u264b":751,"\u264c":752,"\u264d":753,"\u264e":754,"\u264f":755,"\u2650":756,"\u2651":757,"\u2652":758,"\u2653":759,"\u203c":770,"\u2049":771,"\u2757":772,"\u2b55":776,"\u2716":807,"\u2660":811,"\u2665":812,"\u2663":813,"\u2666":814,"\u2714":817,"\u2611":818,"\u303d":823,"\u25fc":825,"\u25fb":826,"\u25fe":827,"\u25fd":828,"\u25aa":829,"\u25ab":830,"\u26ab":834,"\u26aa":835,"\u2b1c":839,"\u2b1b":840
+  };
+  var regx_arr=[];
+  for(var k in emoji){
+    regx_arr.push(k);
+  }
+  var regx = new RegExp('(' + regx_arr.join('|') + ')', 'g');
+  regx_arr = null;
+  return str.replace(regx, function (a, b) {
+    return '<span class="vco-emoji emj'+emoji[b]+'"></span>';
+  });
 }
 
 /* **********************************************
@@ -2726,17 +2726,17 @@ VCO.Emoji = function(str) {
  *
  * KeySpline - use bezier curve for transition easing function
  * Copyright (c) 2012 Gaetan Renaudeau <renaudeau.gaetan@gmail.com>
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
  * to deal in the Software without restriction, including without limitation
  * the rights to use, copy, modify, merge, publish, distribute, sublicense,
  * and/or sell copies of the Software, and to permit persons to whom the
  * Software is furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
@@ -2754,7 +2754,7 @@ VCO.Emoji = function(str) {
  */
 
 VCO.Easings = {
-    ease:        [0.25, 0.1, 0.25, 1.0], 
+    ease:        [0.25, 0.1, 0.25, 1.0],
     linear:      [0.00, 0.0, 1.00, 1.0],
     easein:     [0.42, 0.0, 1.00, 1.0],
     easeout:    [0.00, 0.0, 0.58, 1.0],
@@ -2762,198 +2762,198 @@ VCO.Easings = {
 };
 
 VCO.Ease = {
-	KeySpline: function(a) {
-	//KeySpline: function(mX1, mY1, mX2, mY2) {
-		this.get = function(aX) {
-			if (a[0] == a[1] && a[2] == a[3]) return aX; // linear
-			return CalcBezier(GetTForX(aX), a[1], a[3]);
-		}
+  KeySpline: function(a) {
+  //KeySpline: function(mX1, mY1, mX2, mY2) {
+    this.get = function(aX) {
+      if (a[0] == a[1] && a[2] == a[3]) return aX; // linear
+      return CalcBezier(GetTForX(aX), a[1], a[3]);
+    }
 
-		function A(aA1, aA2) {
-			return 1.0 - 3.0 * aA2 + 3.0 * aA1;
-		}
+    function A(aA1, aA2) {
+      return 1.0 - 3.0 * aA2 + 3.0 * aA1;
+    }
 
-		function B(aA1, aA2) {
-			return 3.0 * aA2 - 6.0 * aA1;
-		}
+    function B(aA1, aA2) {
+      return 3.0 * aA2 - 6.0 * aA1;
+    }
 
-		function C(aA1) {
-			return 3.0 * aA1;
-		}
+    function C(aA1) {
+      return 3.0 * aA1;
+    }
 
-		// Returns x(t) given t, x1, and x2, or y(t) given t, y1, and y2.
+    // Returns x(t) given t, x1, and x2, or y(t) given t, y1, and y2.
 
-		function CalcBezier(aT, aA1, aA2) {
-			return ((A(aA1, aA2) * aT + B(aA1, aA2)) * aT + C(aA1)) * aT;
-		}
+    function CalcBezier(aT, aA1, aA2) {
+      return ((A(aA1, aA2) * aT + B(aA1, aA2)) * aT + C(aA1)) * aT;
+    }
 
-		// Returns dx/dt given t, x1, and x2, or dy/dt given t, y1, and y2.
+    // Returns dx/dt given t, x1, and x2, or dy/dt given t, y1, and y2.
 
-		function GetSlope(aT, aA1, aA2) {
-			return 3.0 * A(aA1, aA2) * aT * aT + 2.0 * B(aA1, aA2) * aT + C(aA1);
-		}
+    function GetSlope(aT, aA1, aA2) {
+      return 3.0 * A(aA1, aA2) * aT * aT + 2.0 * B(aA1, aA2) * aT + C(aA1);
+    }
 
-		function GetTForX(aX) {
-			// Newton raphson iteration
-			var aGuessT = aX;
-			for (var i = 0; i < 4; ++i) {
-				var currentSlope = GetSlope(aGuessT, a[0], a[2]);
-				if (currentSlope == 0.0) return aGuessT;
-				var currentX = CalcBezier(aGuessT, a[0], a[2]) - aX;
-				aGuessT -= currentX / currentSlope;
-			}
-			return aGuessT;
-		}
-	},
-	
-	easeInSpline: function(t) {
-		var spline = new VCO.Ease.KeySpline(VCO.Easings.easein);
-		return spline.get(t);
-	},
-	
-	easeInOutExpo: function(t) {
-		var spline = new VCO.Ease.KeySpline(VCO.Easings.easein);
-		return spline.get(t);
-	},
-	
-	easeOut: function(t) {
-		return Math.sin(t * Math.PI / 2);
-	},
-	easeOutStrong: function(t) {
-		return (t == 1) ? 1 : 1 - Math.pow(2, - 10 * t);
-	},
-	easeIn: function(t) {
-		return t * t;
-	},
-	easeInStrong: function(t) {
-		return (t == 0) ? 0 : Math.pow(2, 10 * (t - 1));
-	},
-	easeOutBounce: function(pos) {
-		if ((pos) < (1 / 2.75)) {
-			return (7.5625 * pos * pos);
-		} else if (pos < (2 / 2.75)) {
-			return (7.5625 * (pos -= (1.5 / 2.75)) * pos + .75);
-		} else if (pos < (2.5 / 2.75)) {
-			return (7.5625 * (pos -= (2.25 / 2.75)) * pos + .9375);
-		} else {
-			return (7.5625 * (pos -= (2.625 / 2.75)) * pos + .984375);
-		}
-	},
-	easeInBack: function(pos) {
-		var s = 1.70158;
-		return (pos) * pos * ((s + 1) * pos - s);
-	},
-	easeOutBack: function(pos) {
-		var s = 1.70158;
-		return (pos = pos - 1) * pos * ((s + 1) * pos + s) + 1;
-	},
-	bounce: function(t) {
-		if (t < (1 / 2.75)) {
-			return 7.5625 * t * t;
-		}
-		if (t < (2 / 2.75)) {
-			return 7.5625 * (t -= (1.5 / 2.75)) * t + 0.75;
-		}
-		if (t < (2.5 / 2.75)) {
-			return 7.5625 * (t -= (2.25 / 2.75)) * t + 0.9375;
-		}
-		return 7.5625 * (t -= (2.625 / 2.75)) * t + 0.984375;
-	},
-	bouncePast: function(pos) {
-		if (pos < (1 / 2.75)) {
-			return (7.5625 * pos * pos);
-		} else if (pos < (2 / 2.75)) {
-			return 2 - (7.5625 * (pos -= (1.5 / 2.75)) * pos + .75);
-		} else if (pos < (2.5 / 2.75)) {
-			return 2 - (7.5625 * (pos -= (2.25 / 2.75)) * pos + .9375);
-		} else {
-			return 2 - (7.5625 * (pos -= (2.625 / 2.75)) * pos + .984375);
-		}
-	},
-	swingTo: function(pos) {
-		var s = 1.70158;
-		return (pos -= 1) * pos * ((s + 1) * pos + s) + 1;
-	},
-	swingFrom: function(pos) {
-		var s = 1.70158;
-		return pos * pos * ((s + 1) * pos - s);
-	},
-	elastic: function(pos) {
-		return -1 * Math.pow(4, - 8 * pos) * Math.sin((pos * 6 - 1) * (2 * Math.PI) / 2) + 1;
-	},
-	spring: function(pos) {
-		return 1 - (Math.cos(pos * 4.5 * Math.PI) * Math.exp(-pos * 6));
-	},
-	blink: function(pos, blinks) {
-		return Math.round(pos * (blinks || 5)) % 2;
-	},
-	pulse: function(pos, pulses) {
-		return (-Math.cos((pos * ((pulses || 5) - .5) * 2) * Math.PI) / 2) + .5;
-	},
-	wobble: function(pos) {
-		return (-Math.cos(pos * Math.PI * (9 * pos)) / 2) + 0.5;
-	},
-	sinusoidal: function(pos) {
-		return (-Math.cos(pos * Math.PI) / 2) + 0.5;
-	},
-	flicker: function(pos) {
-		var pos = pos + (Math.random() - 0.5) / 5;
-		return easings.sinusoidal(pos < 0 ? 0 : pos > 1 ? 1 : pos);
-	},
-	mirror: function(pos) {
-		if (pos < 0.5) return easings.sinusoidal(pos * 2);
-		else return easings.sinusoidal(1 - (pos - 0.5) * 2);
-	},
-	// accelerating from zero velocity
-	easeInQuad: function (t) { return t*t },
-	// decelerating to zero velocity
-	easeOutQuad: function (t) { return t*(2-t) },
-	// acceleration until halfway, then deceleration
-	easeInOutQuad: function (t) { return t<.5 ? 2*t*t : -1+(4-2*t)*t },
-	// accelerating from zero velocity 
-	easeInCubic: function (t) { return t*t*t },
-	// decelerating to zero velocity 
-	easeOutCubic: function (t) { return (--t)*t*t+1 },
-	// acceleration until halfway, then deceleration 
-	easeInOutCubic: function (t) { return t<.5 ? 4*t*t*t : (t-1)*(2*t-2)*(2*t-2)+1 },
-	// accelerating from zero velocity 
-	easeInQuart: function (t) { return t*t*t*t },
-	// decelerating to zero velocity 
-	easeOutQuart: function (t) { return 1-(--t)*t*t*t },
-	// acceleration until halfway, then deceleration
-	easeInOutQuart: function (t) { return t<.5 ? 8*t*t*t*t : 1-8*(--t)*t*t*t },
-	// accelerating from zero velocity
-	easeInQuint: function (t) { return t*t*t*t*t },
-	// decelerating to zero velocity
-	easeOutQuint: function (t) { return 1+(--t)*t*t*t*t },
-	// acceleration until halfway, then deceleration 
-	easeInOutQuint: function (t) { return t<.5 ? 16*t*t*t*t*t : 1+16*(--t)*t*t*t*t }
+    function GetTForX(aX) {
+      // Newton raphson iteration
+      var aGuessT = aX;
+      for (var i = 0; i < 4; ++i) {
+        var currentSlope = GetSlope(aGuessT, a[0], a[2]);
+        if (currentSlope == 0.0) return aGuessT;
+        var currentX = CalcBezier(aGuessT, a[0], a[2]) - aX;
+        aGuessT -= currentX / currentSlope;
+      }
+      return aGuessT;
+    }
+  },
+
+  easeInSpline: function(t) {
+    var spline = new VCO.Ease.KeySpline(VCO.Easings.easein);
+    return spline.get(t);
+  },
+
+  easeInOutExpo: function(t) {
+    var spline = new VCO.Ease.KeySpline(VCO.Easings.easein);
+    return spline.get(t);
+  },
+
+  easeOut: function(t) {
+    return Math.sin(t * Math.PI / 2);
+  },
+  easeOutStrong: function(t) {
+    return (t == 1) ? 1 : 1 - Math.pow(2, - 10 * t);
+  },
+  easeIn: function(t) {
+    return t * t;
+  },
+  easeInStrong: function(t) {
+    return (t == 0) ? 0 : Math.pow(2, 10 * (t - 1));
+  },
+  easeOutBounce: function(pos) {
+    if ((pos) < (1 / 2.75)) {
+      return (7.5625 * pos * pos);
+    } else if (pos < (2 / 2.75)) {
+      return (7.5625 * (pos -= (1.5 / 2.75)) * pos + .75);
+    } else if (pos < (2.5 / 2.75)) {
+      return (7.5625 * (pos -= (2.25 / 2.75)) * pos + .9375);
+    } else {
+      return (7.5625 * (pos -= (2.625 / 2.75)) * pos + .984375);
+    }
+  },
+  easeInBack: function(pos) {
+    var s = 1.70158;
+    return (pos) * pos * ((s + 1) * pos - s);
+  },
+  easeOutBack: function(pos) {
+    var s = 1.70158;
+    return (pos = pos - 1) * pos * ((s + 1) * pos + s) + 1;
+  },
+  bounce: function(t) {
+    if (t < (1 / 2.75)) {
+      return 7.5625 * t * t;
+    }
+    if (t < (2 / 2.75)) {
+      return 7.5625 * (t -= (1.5 / 2.75)) * t + 0.75;
+    }
+    if (t < (2.5 / 2.75)) {
+      return 7.5625 * (t -= (2.25 / 2.75)) * t + 0.9375;
+    }
+    return 7.5625 * (t -= (2.625 / 2.75)) * t + 0.984375;
+  },
+  bouncePast: function(pos) {
+    if (pos < (1 / 2.75)) {
+      return (7.5625 * pos * pos);
+    } else if (pos < (2 / 2.75)) {
+      return 2 - (7.5625 * (pos -= (1.5 / 2.75)) * pos + .75);
+    } else if (pos < (2.5 / 2.75)) {
+      return 2 - (7.5625 * (pos -= (2.25 / 2.75)) * pos + .9375);
+    } else {
+      return 2 - (7.5625 * (pos -= (2.625 / 2.75)) * pos + .984375);
+    }
+  },
+  swingTo: function(pos) {
+    var s = 1.70158;
+    return (pos -= 1) * pos * ((s + 1) * pos + s) + 1;
+  },
+  swingFrom: function(pos) {
+    var s = 1.70158;
+    return pos * pos * ((s + 1) * pos - s);
+  },
+  elastic: function(pos) {
+    return -1 * Math.pow(4, - 8 * pos) * Math.sin((pos * 6 - 1) * (2 * Math.PI) / 2) + 1;
+  },
+  spring: function(pos) {
+    return 1 - (Math.cos(pos * 4.5 * Math.PI) * Math.exp(-pos * 6));
+  },
+  blink: function(pos, blinks) {
+    return Math.round(pos * (blinks || 5)) % 2;
+  },
+  pulse: function(pos, pulses) {
+    return (-Math.cos((pos * ((pulses || 5) - .5) * 2) * Math.PI) / 2) + .5;
+  },
+  wobble: function(pos) {
+    return (-Math.cos(pos * Math.PI * (9 * pos)) / 2) + 0.5;
+  },
+  sinusoidal: function(pos) {
+    return (-Math.cos(pos * Math.PI) / 2) + 0.5;
+  },
+  flicker: function(pos) {
+    var pos = pos + (Math.random() - 0.5) / 5;
+    return easings.sinusoidal(pos < 0 ? 0 : pos > 1 ? 1 : pos);
+  },
+  mirror: function(pos) {
+    if (pos < 0.5) return easings.sinusoidal(pos * 2);
+    else return easings.sinusoidal(1 - (pos - 0.5) * 2);
+  },
+  // accelerating from zero velocity
+  easeInQuad: function (t) { return t*t },
+  // decelerating to zero velocity
+  easeOutQuad: function (t) { return t*(2-t) },
+  // acceleration until halfway, then deceleration
+  easeInOutQuad: function (t) { return t<.5 ? 2*t*t : -1+(4-2*t)*t },
+  // accelerating from zero velocity
+  easeInCubic: function (t) { return t*t*t },
+  // decelerating to zero velocity
+  easeOutCubic: function (t) { return (--t)*t*t+1 },
+  // acceleration until halfway, then deceleration
+  easeInOutCubic: function (t) { return t<.5 ? 4*t*t*t : (t-1)*(2*t-2)*(2*t-2)+1 },
+  // accelerating from zero velocity
+  easeInQuart: function (t) { return t*t*t*t },
+  // decelerating to zero velocity
+  easeOutQuart: function (t) { return 1-(--t)*t*t*t },
+  // acceleration until halfway, then deceleration
+  easeInOutQuart: function (t) { return t<.5 ? 8*t*t*t*t : 1-8*(--t)*t*t*t },
+  // accelerating from zero velocity
+  easeInQuint: function (t) { return t*t*t*t*t },
+  // decelerating to zero velocity
+  easeOutQuint: function (t) { return 1+(--t)*t*t*t*t },
+  // acceleration until halfway, then deceleration
+  easeInOutQuint: function (t) { return t<.5 ? 16*t*t*t*t*t : 1+16*(--t)*t*t*t*t }
 };
 
 /*
 Math.easeInExpo = function (t, b, c, d) {
-	return c * Math.pow( 2, 10 * (t/d - 1) ) + b;
+  return c * Math.pow( 2, 10 * (t/d - 1) ) + b;
 };
 
-		
+
 
 // exponential easing out - decelerating to zero velocity
 
 
 Math.easeOutExpo = function (t, b, c, d) {
-	return c * ( -Math.pow( 2, -10 * t/d ) + 1 ) + b;
+  return c * ( -Math.pow( 2, -10 * t/d ) + 1 ) + b;
 };
 
-		
+
 
 // exponential easing in/out - accelerating until halfway, then decelerating
 
 
 Math.easeInOutExpo = function (t, b, c, d) {
-	t /= d/2;
-	if (t < 1) return c/2 * Math.pow( 2, 10 * (t - 1) ) + b;
-	t--;
-	return c/2 * ( -Math.pow( 2, -10 * t) + 2 ) + b;
+  t /= d/2;
+  if (t < 1) return c/2 * Math.pow( 2, 10 * (t - 1) ) + b;
+  t--;
+  return c/2 * ( -Math.pow( 2, -10 * t) + 2 ) + b;
 };
 */
 
@@ -2961,101 +2961,101 @@ Math.easeInOutExpo = function (t, b, c, d) {
      Begin VCO.Animate.js
 ********************************************** */
 
-/*	VCO.Animate
-	Basic animation
+/*  VCO.Animate
+  Basic animation
 ================================================== */
 
 VCO.Animate = function(el, options) {
-	var animation = new vcoanimate(el, options),
-		webkit_timeout;
-		/*
-		// POSSIBLE ISSUE WITH WEBKIT FUTURE BUILDS
-	var onWebKitTimeout = function() {
+  var animation = new vcoanimate(el, options),
+    webkit_timeout;
+    /*
+    // POSSIBLE ISSUE WITH WEBKIT FUTURE BUILDS
+  var onWebKitTimeout = function() {
 
-		animation.stop(true);
-	}
-	if (VCO.Browser.webkit) {
-		webkit_timeout = setTimeout(function(){onWebKitTimeout()}, options.duration);
-	}
-	*/
-	return animation;
+    animation.stop(true);
+  }
+  if (VCO.Browser.webkit) {
+    webkit_timeout = setTimeout(function(){onWebKitTimeout()}, options.duration);
+  }
+  */
+  return animation;
 };
 
 
-/*	Based on: Morpheus
-	https://github.com/ded/morpheus - (c) Dustin Diaz 2011
-	License MIT
+/*  Based on: Morpheus
+  https://github.com/ded/morpheus - (c) Dustin Diaz 2011
+  License MIT
 ================================================== */
 window.vcoanimate = (function() {
 
-	var doc = document,
-		win = window,
-		perf = win.performance,
-		perfNow = perf && (perf.now || perf.webkitNow || perf.msNow || perf.mozNow),
-		now = perfNow ? function () { return perfNow.call(perf) } : function () { return +new Date() },
-		html = doc.documentElement,
-		fixTs = false, // feature detected below
-		thousand = 1000,
-		rgbOhex = /^rgb\(|#/,
-		relVal = /^([+\-])=([\d\.]+)/,
-		numUnit = /^(?:[\+\-]=?)?\d+(?:\.\d+)?(%|in|cm|mm|em|ex|pt|pc|px)$/,
-		rotate = /rotate\(((?:[+\-]=)?([\-\d\.]+))deg\)/,
-		scale = /scale\(((?:[+\-]=)?([\d\.]+))\)/,
-		skew = /skew\(((?:[+\-]=)?([\-\d\.]+))deg, ?((?:[+\-]=)?([\-\d\.]+))deg\)/,
-		translate = /translate\(((?:[+\-]=)?([\-\d\.]+))px, ?((?:[+\-]=)?([\-\d\.]+))px\)/,
-		// these elements do not require 'px'
-		unitless = { lineHeight: 1, zoom: 1, zIndex: 1, opacity: 1, transform: 1};
+  var doc = document,
+    win = window,
+    perf = win.performance,
+    perfNow = perf && (perf.now || perf.webkitNow || perf.msNow || perf.mozNow),
+    now = perfNow ? function () { return perfNow.call(perf) } : function () { return +new Date() },
+    html = doc.documentElement,
+    fixTs = false, // feature detected below
+    thousand = 1000,
+    rgbOhex = /^rgb\(|#/,
+    relVal = /^([+\-])=([\d\.]+)/,
+    numUnit = /^(?:[\+\-]=?)?\d+(?:\.\d+)?(%|in|cm|mm|em|ex|pt|pc|px)$/,
+    rotate = /rotate\(((?:[+\-]=)?([\-\d\.]+))deg\)/,
+    scale = /scale\(((?:[+\-]=)?([\d\.]+))\)/,
+    skew = /skew\(((?:[+\-]=)?([\-\d\.]+))deg, ?((?:[+\-]=)?([\-\d\.]+))deg\)/,
+    translate = /translate\(((?:[+\-]=)?([\-\d\.]+))px, ?((?:[+\-]=)?([\-\d\.]+))px\)/,
+    // these elements do not require 'px'
+    unitless = { lineHeight: 1, zoom: 1, zIndex: 1, opacity: 1, transform: 1};
 
   // which property name does this browser use for transform
-	var transform = function () {
-		var styles = doc.createElement('a').style,
-			props = ['webkitTransform', 'MozTransform', 'OTransform', 'msTransform', 'Transform'],
-			i;
+  var transform = function () {
+    var styles = doc.createElement('a').style,
+      props = ['webkitTransform', 'MozTransform', 'OTransform', 'msTransform', 'Transform'],
+      i;
 
-		for (i = 0; i < props.length; i++) {
-			if (props[i] in styles) return props[i]
-		};
-	}();
+    for (i = 0; i < props.length; i++) {
+      if (props[i] in styles) return props[i]
+    };
+  }();
 
-	// does this browser support the opacity property?
-	var opacity = function () {
-		return typeof doc.createElement('a').style.opacity !== 'undefined'
-	}();
+  // does this browser support the opacity property?
+  var opacity = function () {
+    return typeof doc.createElement('a').style.opacity !== 'undefined'
+  }();
 
-	// initial style is determined by the elements themselves
-	var getStyle = doc.defaultView && doc.defaultView.getComputedStyle ?
-	function (el, property) {
-		property = property == 'transform' ? transform : property
-		property = camelize(property)
-		var value = null,
-			computed = doc.defaultView.getComputedStyle(el, '');
+  // initial style is determined by the elements themselves
+  var getStyle = doc.defaultView && doc.defaultView.getComputedStyle ?
+  function (el, property) {
+    property = property == 'transform' ? transform : property
+    property = camelize(property)
+    var value = null,
+      computed = doc.defaultView.getComputedStyle(el, '');
 
-		computed && (value = computed[property]);
-		return el.style[property] || value;
-	} : html.currentStyle ?
-
-    function (el, property) {
-		property = camelize(property)
-
-		if (property == 'opacity') {
-			var val = 100
-			try {
-				val = el.filters['DXImageTransform.Microsoft.Alpha'].opacity
-			} catch (e1) {
-				try {
-					val = el.filters('alpha').opacity
-				} catch (e2) {
-
-				}
-			}
-			return val / 100
-		}
-		var value = el.currentStyle ? el.currentStyle[property] : null
-		return el.style[property] || value
-	} :
+    computed && (value = computed[property]);
+    return el.style[property] || value;
+  } : html.currentStyle ?
 
     function (el, property) {
-		return el.style[camelize(property)]
+    property = camelize(property)
+
+    if (property == 'opacity') {
+      var val = 100
+      try {
+        val = el.filters['DXImageTransform.Microsoft.Alpha'].opacity
+      } catch (e1) {
+        try {
+          val = el.filters('alpha').opacity
+        } catch (e2) {
+
+        }
+      }
+      return val / 100
+    }
+    var value = el.currentStyle ? el.currentStyle[property] : null
+    return el.style[property] || value
+  } :
+
+    function (el, property) {
+    return el.style[camelize(property)]
     }
 
   var frame = function () {
@@ -3076,11 +3076,11 @@ window.vcoanimate = (function() {
 
   var children = []
 
-	frame(function(timestamp) {
-	  	// feature-detect if rAF and now() are of the same scale (epoch or high-res),
-		// if not, we have to do a timestamp fix on each frame
-		fixTs = timestamp > 1e12 != now() > 1e12
-	})
+  frame(function(timestamp) {
+      // feature-detect if rAF and now() are of the same scale (epoch or high-res),
+    // if not, we have to do a timestamp fix on each frame
+    fixTs = timestamp > 1e12 != now() > 1e12
+  })
 
   function has(array, elem, i) {
     if (Array.prototype.indexOf) return array.indexOf(elem)
@@ -3094,7 +3094,7 @@ window.vcoanimate = (function() {
     // if we're using a high res timer, make sure timestamp is not the old epoch-based value.
     // http://updates.html5rocks.com/2012/05/requestAnimationFrame-API-now-with-sub-millisecond-precision
     if (perfNow && timestamp > 1e12) timestamp = now()
-	if (fixTs) timestamp = now()
+  if (fixTs) timestamp = now()
     for (i = count; i--;) {
       children[i](timestamp)
     }
@@ -3397,171 +3397,171 @@ window.vcoanimate = (function() {
      Begin VCO.Point.js
 ********************************************** */
 
-/*	VCO.Point
-	Inspired by Leaflet
-	VCO.Point represents a point with x and y coordinates.
+/*  VCO.Point
+  Inspired by Leaflet
+  VCO.Point represents a point with x and y coordinates.
 ================================================== */
 
 VCO.Point = function (/*Number*/ x, /*Number*/ y, /*Boolean*/ round) {
-	this.x = (round ? Math.round(x) : x);
-	this.y = (round ? Math.round(y) : y);
+  this.x = (round ? Math.round(x) : x);
+  this.y = (round ? Math.round(y) : y);
 };
 
 VCO.Point.prototype = {
-	add: function (point) {
-		return this.clone()._add(point);
-	},
+  add: function (point) {
+    return this.clone()._add(point);
+  },
 
-	_add: function (point) {
-		this.x += point.x;
-		this.y += point.y;
-		return this;
-	},
+  _add: function (point) {
+    this.x += point.x;
+    this.y += point.y;
+    return this;
+  },
 
-	subtract: function (point) {
-		return this.clone()._subtract(point);
-	},
+  subtract: function (point) {
+    return this.clone()._subtract(point);
+  },
 
-	// destructive subtract (faster)
-	_subtract: function (point) {
-		this.x -= point.x;
-		this.y -= point.y;
-		return this;
-	},
+  // destructive subtract (faster)
+  _subtract: function (point) {
+    this.x -= point.x;
+    this.y -= point.y;
+    return this;
+  },
 
-	divideBy: function (num, round) {
-		return new VCO.Point(this.x / num, this.y / num, round);
-	},
+  divideBy: function (num, round) {
+    return new VCO.Point(this.x / num, this.y / num, round);
+  },
 
-	multiplyBy: function (num) {
-		return new VCO.Point(this.x * num, this.y * num);
-	},
+  multiplyBy: function (num) {
+    return new VCO.Point(this.x * num, this.y * num);
+  },
 
-	distanceTo: function (point) {
-		var x = point.x - this.x,
-			y = point.y - this.y;
-		return Math.sqrt(x * x + y * y);
-	},
+  distanceTo: function (point) {
+    var x = point.x - this.x,
+      y = point.y - this.y;
+    return Math.sqrt(x * x + y * y);
+  },
 
-	round: function () {
-		return this.clone()._round();
-	},
+  round: function () {
+    return this.clone()._round();
+  },
 
-	// destructive round
-	_round: function () {
-		this.x = Math.round(this.x);
-		this.y = Math.round(this.y);
-		return this;
-	},
+  // destructive round
+  _round: function () {
+    this.x = Math.round(this.x);
+    this.y = Math.round(this.y);
+    return this;
+  },
 
-	clone: function () {
-		return new VCO.Point(this.x, this.y);
-	},
+  clone: function () {
+    return new VCO.Point(this.x, this.y);
+  },
 
-	toString: function () {
-		return 'Point(' +
-				VCO.Util.formatNum(this.x) + ', ' +
-				VCO.Util.formatNum(this.y) + ')';
-	}
+  toString: function () {
+    return 'Point(' +
+        VCO.Util.formatNum(this.x) + ', ' +
+        VCO.Util.formatNum(this.y) + ')';
+  }
 };
 
 /* **********************************************
      Begin VCO.DomMixins.js
 ********************************************** */
 
-/*	VCO.DomMixins
-	DOM methods used regularly
-	Assumes there is a _el.container and animator
+/*  VCO.DomMixins
+  DOM methods used regularly
+  Assumes there is a _el.container and animator
 ================================================== */
 VCO.DomMixins = {
-	
-	/*	Adding, Hiding, Showing etc
-	================================================== */
-	show: function(animate) {
-		if (animate) {
-			/*
-			this.animator = VCO.Animate(this._el.container, {
-				left: 		-(this._el.container.offsetWidth * n) + "px",
-				duration: 	this.options.duration,
-				easing: 	this.options.ease
-			});
-			*/
-		} else {
-			this._el.container.style.display = "block";
-		}
-	},
-	
-	hide: function(animate) {
-		this._el.container.style.display = "none";
-	},
-	
-	addTo: function(container) {
-		container.appendChild(this._el.container);
-		this.onAdd();
-	},
-	
-	removeFrom: function(container) {
-		container.removeChild(this._el.container);
-		this.onRemove();
-	},
-	
-	/*	Animate to Position
-	================================================== */
-	animatePosition: function(pos, el, use_percent) {
-		var ani = {
-			duration: 	this.options.duration,
-			easing: 	this.options.ease
-		};
-		for (var name in pos) {
-			if (pos.hasOwnProperty(name)) {
-				if (use_percent) {
-					ani[name] = pos[name] + "%";
-				} else {
-					ani[name] = pos[name] + "px";
-				}
-				
-			}
-		}
-		
-		if (this.animator) {
-			this.animator.stop();
-		}
-		this.animator = VCO.Animate(el, ani);
-	},
-	
-	/*	Events
-	================================================== */
-	
-	onLoaded: function() {
-		this.fire("loaded", this.data);
-	},
-	
-	onAdd: function() {
-		this.fire("added", this.data);
-	},
 
-	onRemove: function() {
-		this.fire("removed", this.data);
-	},
-	
-	/*	Set the Position
-	================================================== */
-	setPosition: function(pos, el) {
-		for (var name in pos) {
-			if (pos.hasOwnProperty(name)) {
-				if (el) {
-					el.style[name] = pos[name] + "px";
-				} else {
-					this._el.container.style[name] = pos[name] + "px";
-				};
-			}
-		}
-	},
-	
-	getPosition: function() {
-		return VCO.Dom.getPosition(this._el.container);
-	}
-	
+  /*  Adding, Hiding, Showing etc
+  ================================================== */
+  show: function(animate) {
+    if (animate) {
+      /*
+      this.animator = VCO.Animate(this._el.container, {
+        left:     -(this._el.container.offsetWidth * n) + "px",
+        duration:   this.options.duration,
+        easing:   this.options.ease
+      });
+      */
+    } else {
+      this._el.container.style.display = "block";
+    }
+  },
+
+  hide: function(animate) {
+    this._el.container.style.display = "none";
+  },
+
+  addTo: function(container) {
+    container.appendChild(this._el.container);
+    this.onAdd();
+  },
+
+  removeFrom: function(container) {
+    container.removeChild(this._el.container);
+    this.onRemove();
+  },
+
+  /*  Animate to Position
+  ================================================== */
+  animatePosition: function(pos, el, use_percent) {
+    var ani = {
+      duration:   this.options.duration,
+      easing:   this.options.ease
+    };
+    for (var name in pos) {
+      if (pos.hasOwnProperty(name)) {
+        if (use_percent) {
+          ani[name] = pos[name] + "%";
+        } else {
+          ani[name] = pos[name] + "px";
+        }
+
+      }
+    }
+
+    if (this.animator) {
+      this.animator.stop();
+    }
+    this.animator = VCO.Animate(el, ani);
+  },
+
+  /*  Events
+  ================================================== */
+
+  onLoaded: function() {
+    this.fire("loaded", this.data);
+  },
+
+  onAdd: function() {
+    this.fire("added", this.data);
+  },
+
+  onRemove: function() {
+    this.fire("removed", this.data);
+  },
+
+  /*  Set the Position
+  ================================================== */
+  setPosition: function(pos, el) {
+    for (var name in pos) {
+      if (pos.hasOwnProperty(name)) {
+        if (el) {
+          el.style[name] = pos[name] + "px";
+        } else {
+          this._el.container.style[name] = pos[name] + "px";
+        };
+      }
+    }
+  },
+
+  getPosition: function() {
+    return VCO.Dom.getPosition(this._el.container);
+  }
+
 };
 
 
@@ -3569,92 +3569,92 @@ VCO.DomMixins = {
      Begin VCO.Dom.js
 ********************************************** */
 
-/*	VCO.Dom
-	Utilities for working with the DOM
+/*  VCO.Dom
+  Utilities for working with the DOM
 ================================================== */
 
 VCO.Dom = {
 
-	get: function(id) {
-		return (typeof id === 'string' ? document.getElementById(id) : id);
-	},
-	
-	getByClass: function(id) {
-		if (id) {
-			return document.getElementsByClassName(id);
-		}
-	},
-	
-	create: function(tagName, className, container) {
-		var el = document.createElement(tagName);
-		el.className = className;
-		if (container) {
-			container.appendChild(el);
-		}
-		return el;
-	},
-	
-	createText: function(content, container) {
-		var el = document.createTextNode(content);
-		if (container) {
-			container.appendChild(el);
-		}
-		return el;
-	},
-	
-	getTranslateString: function (point) {
-		return VCO.Dom.TRANSLATE_OPEN +
-				point.x + 'px,' + point.y + 'px' +
-				VCO.Dom.TRANSLATE_CLOSE;
-	},
-	
-	setPosition: function (el, point) {
-		el._vco_pos = point;
-		if (VCO.Browser.webkit3d) {
-			el.style[VCO.Dom.TRANSFORM] =  VCO.Dom.getTranslateString(point);
+  get: function(id) {
+    return (typeof id === 'string' ? document.getElementById(id) : id);
+  },
 
-			if (VCO.Browser.android) {
-				el.style['-webkit-perspective'] = '1000';
-				el.style['-webkit-backface-visibility'] = 'hidden';
-			}
-		} else {
-			el.style.left = point.x + 'px';
-			el.style.top = point.y + 'px';
-		}
-	},
-	
-	getPosition: function(el){
-	    var pos = {
-	    	x: 0,
-			y: 0
-	    }
-	    while( el && !isNaN( el.offsetLeft ) && !isNaN( el.offsetTop ) ) {
-	        pos.x += el.offsetLeft// - el.scrollLeft;
-	        pos.y += el.offsetTop// - el.scrollTop;
-	        el = el.offsetParent;
-	    }
-	    return pos;
-	},
+  getByClass: function(id) {
+    if (id) {
+      return document.getElementsByClassName(id);
+    }
+  },
 
-	testProp: function(props) {
-		var style = document.documentElement.style;
+  create: function(tagName, className, container) {
+    var el = document.createElement(tagName);
+    el.className = className;
+    if (container) {
+      container.appendChild(el);
+    }
+    return el;
+  },
 
-		for (var i = 0; i < props.length; i++) {
-			if (props[i] in style) {
-				return props[i];
-			}
-		}
-		return false;
-	}
-	
+  createText: function(content, container) {
+    var el = document.createTextNode(content);
+    if (container) {
+      container.appendChild(el);
+    }
+    return el;
+  },
+
+  getTranslateString: function (point) {
+    return VCO.Dom.TRANSLATE_OPEN +
+        point.x + 'px,' + point.y + 'px' +
+        VCO.Dom.TRANSLATE_CLOSE;
+  },
+
+  setPosition: function (el, point) {
+    el._vco_pos = point;
+    if (VCO.Browser.webkit3d) {
+      el.style[VCO.Dom.TRANSFORM] =  VCO.Dom.getTranslateString(point);
+
+      if (VCO.Browser.android) {
+        el.style['-webkit-perspective'] = '1000';
+        el.style['-webkit-backface-visibility'] = 'hidden';
+      }
+    } else {
+      el.style.left = point.x + 'px';
+      el.style.top = point.y + 'px';
+    }
+  },
+
+  getPosition: function(el){
+      var pos = {
+        x: 0,
+      y: 0
+      }
+      while( el && !isNaN( el.offsetLeft ) && !isNaN( el.offsetTop ) ) {
+          pos.x += el.offsetLeft// - el.scrollLeft;
+          pos.y += el.offsetTop// - el.scrollTop;
+          el = el.offsetParent;
+      }
+      return pos;
+  },
+
+  testProp: function(props) {
+    var style = document.documentElement.style;
+
+    for (var i = 0; i < props.length; i++) {
+      if (props[i] in style) {
+        return props[i];
+      }
+    }
+    return false;
+  }
+
 };
 
 VCO.Util.extend(VCO.Dom, {
-	TRANSITION: VCO.Dom.testProp(['transition', 'webkitTransition', 'OTransition', 'MozTransition', 'msTransition']),
-	TRANSFORM: VCO.Dom.testProp(['transformProperty', 'WebkitTransform', 'OTransform', 'MozTransform', 'msTransform']),
+  TRANSITION: VCO.Dom.testProp(['transition', 'webkitTransition', 'OTransition', 'MozTransition', 'msTransition']),
+  TRANSFORM: VCO.Dom.testProp(['transformProperty', 'WebkitTransform', 'OTransform', 'MozTransform', 'msTransform']),
 
-	TRANSLATE_OPEN: 'translate' + (VCO.Browser.webkit3d ? '3d(' : '('),
-	TRANSLATE_CLOSE: VCO.Browser.webkit3d ? ',0)' : ')'
+  TRANSLATE_OPEN: 'translate' + (VCO.Browser.webkit3d ? '3d(' : '('),
+  TRANSLATE_CLOSE: VCO.Browser.webkit3d ? ',0)' : ')'
 });
 
 
@@ -3662,311 +3662,311 @@ VCO.Util.extend(VCO.Dom, {
      Begin VCO.DomUtil.js
 ********************************************** */
 
-/*	VCO.DomUtil
-	Inspired by Leaflet
-	VCO.DomUtil contains various utility functions for working with DOM
+/*  VCO.DomUtil
+  Inspired by Leaflet
+  VCO.DomUtil contains various utility functions for working with DOM
 ================================================== */
 
 
 VCO.DomUtil = {
-	get: function (id) {
-		return (typeof id === 'string' ? document.getElementById(id) : id);
-	},
+  get: function (id) {
+    return (typeof id === 'string' ? document.getElementById(id) : id);
+  },
 
-	getStyle: function (el, style) {
-		var value = el.style[style];
-		if (!value && el.currentStyle) {
-			value = el.currentStyle[style];
-		}
-		if (!value || value === 'auto') {
-			var css = document.defaultView.getComputedStyle(el, null);
-			value = css ? css[style] : null;
-		}
-		return (value === 'auto' ? null : value);
-	},
+  getStyle: function (el, style) {
+    var value = el.style[style];
+    if (!value && el.currentStyle) {
+      value = el.currentStyle[style];
+    }
+    if (!value || value === 'auto') {
+      var css = document.defaultView.getComputedStyle(el, null);
+      value = css ? css[style] : null;
+    }
+    return (value === 'auto' ? null : value);
+  },
 
-	getViewportOffset: function (element) {
-		var top = 0,
-			left = 0,
-			el = element,
-			docBody = document.body;
+  getViewportOffset: function (element) {
+    var top = 0,
+      left = 0,
+      el = element,
+      docBody = document.body;
 
-		do {
-			top += el.offsetTop || 0;
-			left += el.offsetLeft || 0;
+    do {
+      top += el.offsetTop || 0;
+      left += el.offsetLeft || 0;
 
-			if (el.offsetParent === docBody &&
-					VCO.DomUtil.getStyle(el, 'position') === 'absolute') {
-				break;
-			}
-			el = el.offsetParent;
-		} while (el);
+      if (el.offsetParent === docBody &&
+          VCO.DomUtil.getStyle(el, 'position') === 'absolute') {
+        break;
+      }
+      el = el.offsetParent;
+    } while (el);
 
-		el = element;
+    el = element;
 
-		do {
-			if (el === docBody) {
-				break;
-			}
+    do {
+      if (el === docBody) {
+        break;
+      }
 
-			top -= el.scrollTop || 0;
-			left -= el.scrollLeft || 0;
+      top -= el.scrollTop || 0;
+      left -= el.scrollLeft || 0;
 
-			el = el.parentNode;
-		} while (el);
+      el = el.parentNode;
+    } while (el);
 
-		return new VCO.Point(left, top);
-	},
+    return new VCO.Point(left, top);
+  },
 
-	create: function (tagName, className, container) {
-		var el = document.createElement(tagName);
-		el.className = className;
-		if (container) {
-			container.appendChild(el);
-		}
-		return el;
-	},
+  create: function (tagName, className, container) {
+    var el = document.createElement(tagName);
+    el.className = className;
+    if (container) {
+      container.appendChild(el);
+    }
+    return el;
+  },
 
-	disableTextSelection: function () {
-		if (document.selection && document.selection.empty) {
-			document.selection.empty();
-		}
-		if (!this._onselectstart) {
-			this._onselectstart = document.onselectstart;
-			document.onselectstart = VCO.Util.falseFn;
-		}
-	},
+  disableTextSelection: function () {
+    if (document.selection && document.selection.empty) {
+      document.selection.empty();
+    }
+    if (!this._onselectstart) {
+      this._onselectstart = document.onselectstart;
+      document.onselectstart = VCO.Util.falseFn;
+    }
+  },
 
-	enableTextSelection: function () {
-		document.onselectstart = this._onselectstart;
-		this._onselectstart = null;
-	},
+  enableTextSelection: function () {
+    document.onselectstart = this._onselectstart;
+    this._onselectstart = null;
+  },
 
-	hasClass: function (el, name) {
-		return (el.className.length > 0) &&
-				new RegExp("(^|\\s)" + name + "(\\s|$)").test(el.className);
-	},
+  hasClass: function (el, name) {
+    return (el.className.length > 0) &&
+        new RegExp("(^|\\s)" + name + "(\\s|$)").test(el.className);
+  },
 
-	addClass: function (el, name) {
-		if (!VCO.DomUtil.hasClass(el, name)) {
-			el.className += (el.className ? ' ' : '') + name;
-		}
-	},
+  addClass: function (el, name) {
+    if (!VCO.DomUtil.hasClass(el, name)) {
+      el.className += (el.className ? ' ' : '') + name;
+    }
+  },
 
-	removeClass: function (el, name) {
-		el.className = el.className.replace(/(\S+)\s*/g, function (w, match) {
-			if (match === name) {
-				return '';
-			}
-			return w;
-		}).replace(/^\s+/, '');
-	},
+  removeClass: function (el, name) {
+    el.className = el.className.replace(/(\S+)\s*/g, function (w, match) {
+      if (match === name) {
+        return '';
+      }
+      return w;
+    }).replace(/^\s+/, '');
+  },
 
-	setOpacity: function (el, value) {
-		if (VCO.Browser.ie) {
-			el.style.filter = 'alpha(opacity=' + Math.round(value * 100) + ')';
-		} else {
-			el.style.opacity = value;
-		}
-	},
+  setOpacity: function (el, value) {
+    if (VCO.Browser.ie) {
+      el.style.filter = 'alpha(opacity=' + Math.round(value * 100) + ')';
+    } else {
+      el.style.opacity = value;
+    }
+  },
 
 
-	testProp: function (props) {
-		var style = document.documentElement.style;
+  testProp: function (props) {
+    var style = document.documentElement.style;
 
-		for (var i = 0; i < props.length; i++) {
-			if (props[i] in style) {
-				return props[i];
-			}
-		}
-		return false;
-	},
+    for (var i = 0; i < props.length; i++) {
+      if (props[i] in style) {
+        return props[i];
+      }
+    }
+    return false;
+  },
 
-	getTranslateString: function (point) {
+  getTranslateString: function (point) {
 
-		return VCO.DomUtil.TRANSLATE_OPEN +
-				point.x + 'px,' + point.y + 'px' +
-				VCO.DomUtil.TRANSLATE_CLOSE;
-	},
+    return VCO.DomUtil.TRANSLATE_OPEN +
+        point.x + 'px,' + point.y + 'px' +
+        VCO.DomUtil.TRANSLATE_CLOSE;
+  },
 
-	getScaleString: function (scale, origin) {
-		var preTranslateStr = VCO.DomUtil.getTranslateString(origin),
-			scaleStr = ' scale(' + scale + ') ',
-			postTranslateStr = VCO.DomUtil.getTranslateString(origin.multiplyBy(-1));
+  getScaleString: function (scale, origin) {
+    var preTranslateStr = VCO.DomUtil.getTranslateString(origin),
+      scaleStr = ' scale(' + scale + ') ',
+      postTranslateStr = VCO.DomUtil.getTranslateString(origin.multiplyBy(-1));
 
-		return preTranslateStr + scaleStr + postTranslateStr;
-	},
+    return preTranslateStr + scaleStr + postTranslateStr;
+  },
 
-	setPosition: function (el, point) {
-		el._vco_pos = point;
-		if (VCO.Browser.webkit3d) {
-			el.style[VCO.DomUtil.TRANSFORM] =  VCO.DomUtil.getTranslateString(point);
+  setPosition: function (el, point) {
+    el._vco_pos = point;
+    if (VCO.Browser.webkit3d) {
+      el.style[VCO.DomUtil.TRANSFORM] =  VCO.DomUtil.getTranslateString(point);
 
-			if (VCO.Browser.android) {
-				el.style['-webkit-perspective'] = '1000';
-				el.style['-webkit-backface-visibility'] = 'hidden';
-			}
-		} else {
-			el.style.left = point.x + 'px';
-			el.style.top = point.y + 'px';
-		}
-	},
+      if (VCO.Browser.android) {
+        el.style['-webkit-perspective'] = '1000';
+        el.style['-webkit-backface-visibility'] = 'hidden';
+      }
+    } else {
+      el.style.left = point.x + 'px';
+      el.style.top = point.y + 'px';
+    }
+  },
 
-	getPosition: function (el) {
-		return el._vco_pos;
-	}
+  getPosition: function (el) {
+    return el._vco_pos;
+  }
 };
 
 /* **********************************************
      Begin VCO.DomEvent.js
 ********************************************** */
 
-/*	VCO.DomEvent
-	Inspired by Leaflet 
-	DomEvent contains functions for working with DOM events.
+/*  VCO.DomEvent
+  Inspired by Leaflet
+  DomEvent contains functions for working with DOM events.
 ================================================== */
 // TODO stamp
 
 VCO.DomEvent = {
-	/* inpired by John Resig, Dean Edwards and YUI addEvent implementations */
-	addListener: function (/*HTMLElement*/ obj, /*String*/ type, /*Function*/ fn, /*Object*/ context) {
-		var id = VCO.Util.stamp(fn),
-			key = '_vco_' + type + id;
+  /* inpired by John Resig, Dean Edwards and YUI addEvent implementations */
+  addListener: function (/*HTMLElement*/ obj, /*String*/ type, /*Function*/ fn, /*Object*/ context) {
+    var id = VCO.Util.stamp(fn),
+      key = '_vco_' + type + id;
 
-		if (obj[key]) {
-			return;
-		}
+    if (obj[key]) {
+      return;
+    }
 
-		var handler = function (e) {
-			return fn.call(context || obj, e || VCO.DomEvent._getEvent());
-		};
+    var handler = function (e) {
+      return fn.call(context || obj, e || VCO.DomEvent._getEvent());
+    };
 
-		if (VCO.Browser.touch && (type === 'dblclick') && this.addDoubleTapListener) {
-			this.addDoubleTapListener(obj, handler, id);
-		} else if ('addEventListener' in obj) {
-			if (type === 'mousewheel') {
-				obj.addEventListener('DOMMouseScroll', handler, false);
-				obj.addEventListener(type, handler, false);
-			} else if ((type === 'mouseenter') || (type === 'mouseleave')) {
-				var originalHandler = handler,
-					newType = (type === 'mouseenter' ? 'mouseover' : 'mouseout');
-				handler = function (e) {
-					if (!VCO.DomEvent._checkMouse(obj, e)) {
-						return;
-					}
-					return originalHandler(e);
-				};
-				obj.addEventListener(newType, handler, false);
-			} else {
-				obj.addEventListener(type, handler, false);
-			}
-		} else if ('attachEvent' in obj) {
-			obj.attachEvent("on" + type, handler);
-		}
+    if (VCO.Browser.touch && (type === 'dblclick') && this.addDoubleTapListener) {
+      this.addDoubleTapListener(obj, handler, id);
+    } else if ('addEventListener' in obj) {
+      if (type === 'mousewheel') {
+        obj.addEventListener('DOMMouseScroll', handler, false);
+        obj.addEventListener(type, handler, false);
+      } else if ((type === 'mouseenter') || (type === 'mouseleave')) {
+        var originalHandler = handler,
+          newType = (type === 'mouseenter' ? 'mouseover' : 'mouseout');
+        handler = function (e) {
+          if (!VCO.DomEvent._checkMouse(obj, e)) {
+            return;
+          }
+          return originalHandler(e);
+        };
+        obj.addEventListener(newType, handler, false);
+      } else {
+        obj.addEventListener(type, handler, false);
+      }
+    } else if ('attachEvent' in obj) {
+      obj.attachEvent("on" + type, handler);
+    }
 
-		obj[key] = handler;
-	},
+    obj[key] = handler;
+  },
 
-	removeListener: function (/*HTMLElement*/ obj, /*String*/ type, /*Function*/ fn) {
-		var id = VCO.Util.stamp(fn),
-			key = '_vco_' + type + id,
-			handler = obj[key];
+  removeListener: function (/*HTMLElement*/ obj, /*String*/ type, /*Function*/ fn) {
+    var id = VCO.Util.stamp(fn),
+      key = '_vco_' + type + id,
+      handler = obj[key];
 
-		if (!handler) {
-			return;
-		}
+    if (!handler) {
+      return;
+    }
 
-		if (VCO.Browser.touch && (type === 'dblclick') && this.removeDoubleTapListener) {
-			this.removeDoubleTapListener(obj, id);
-		} else if ('removeEventListener' in obj) {
-			if (type === 'mousewheel') {
-				obj.removeEventListener('DOMMouseScroll', handler, false);
-				obj.removeEventListener(type, handler, false);
-			} else if ((type === 'mouseenter') || (type === 'mouseleave')) {
-				obj.removeEventListener((type === 'mouseenter' ? 'mouseover' : 'mouseout'), handler, false);
-			} else {
-				obj.removeEventListener(type, handler, false);
-			}
-		} else if ('detachEvent' in obj) {
-			obj.detachEvent("on" + type, handler);
-		}
-		obj[key] = null;
-	},
+    if (VCO.Browser.touch && (type === 'dblclick') && this.removeDoubleTapListener) {
+      this.removeDoubleTapListener(obj, id);
+    } else if ('removeEventListener' in obj) {
+      if (type === 'mousewheel') {
+        obj.removeEventListener('DOMMouseScroll', handler, false);
+        obj.removeEventListener(type, handler, false);
+      } else if ((type === 'mouseenter') || (type === 'mouseleave')) {
+        obj.removeEventListener((type === 'mouseenter' ? 'mouseover' : 'mouseout'), handler, false);
+      } else {
+        obj.removeEventListener(type, handler, false);
+      }
+    } else if ('detachEvent' in obj) {
+      obj.detachEvent("on" + type, handler);
+    }
+    obj[key] = null;
+  },
 
-	_checkMouse: function (el, e) {
-		var related = e.relatedTarget;
+  _checkMouse: function (el, e) {
+    var related = e.relatedTarget;
 
-		if (!related) {
-			return true;
-		}
+    if (!related) {
+      return true;
+    }
 
-		try {
-			while (related && (related !== el)) {
-				related = related.parentNode;
-			}
-		} catch (err) {
-			return false;
-		}
+    try {
+      while (related && (related !== el)) {
+        related = related.parentNode;
+      }
+    } catch (err) {
+      return false;
+    }
 
-		return (related !== el);
-	},
+    return (related !== el);
+  },
 
-	/*jshint noarg:false */ // evil magic for IE
-	_getEvent: function () {
-		var e = window.event;
-		if (!e) {
-			var caller = arguments.callee.caller;
-			while (caller) {
-				e = caller['arguments'][0];
-				if (e && window.Event === e.constructor) {
-					break;
-				}
-				caller = caller.caller;
-			}
-		}
-		return e;
-	},
-	/*jshint noarg:false */
+  /*jshint noarg:false */ // evil magic for IE
+  _getEvent: function () {
+    var e = window.event;
+    if (!e) {
+      var caller = arguments.callee.caller;
+      while (caller) {
+        e = caller['arguments'][0];
+        if (e && window.Event === e.constructor) {
+          break;
+        }
+        caller = caller.caller;
+      }
+    }
+    return e;
+  },
+  /*jshint noarg:false */
 
-	stopPropagation: function (/*Event*/ e) {
-		if (e.stopPropagation) {
-			e.stopPropagation();
-		} else {
-			e.cancelBubble = true;
-		}
-	},
-	
-	// TODO VCO.Draggable.START
-	disableClickPropagation: function (/*HTMLElement*/ el) {
-		VCO.DomEvent.addListener(el, VCO.Draggable.START, VCO.DomEvent.stopPropagation);
-		VCO.DomEvent.addListener(el, 'click', VCO.DomEvent.stopPropagation);
-		VCO.DomEvent.addListener(el, 'dblclick', VCO.DomEvent.stopPropagation);
-	},
+  stopPropagation: function (/*Event*/ e) {
+    if (e.stopPropagation) {
+      e.stopPropagation();
+    } else {
+      e.cancelBubble = true;
+    }
+  },
 
-	preventDefault: function (/*Event*/ e) {
-		if (e.preventDefault) {
-			e.preventDefault();
-		} else {
-			e.returnValue = false;
-		}
-	},
+  // TODO VCO.Draggable.START
+  disableClickPropagation: function (/*HTMLElement*/ el) {
+    VCO.DomEvent.addListener(el, VCO.Draggable.START, VCO.DomEvent.stopPropagation);
+    VCO.DomEvent.addListener(el, 'click', VCO.DomEvent.stopPropagation);
+    VCO.DomEvent.addListener(el, 'dblclick', VCO.DomEvent.stopPropagation);
+  },
 
-	stop: function (e) {
-		VCO.DomEvent.preventDefault(e);
-		VCO.DomEvent.stopPropagation(e);
-	},
+  preventDefault: function (/*Event*/ e) {
+    if (e.preventDefault) {
+      e.preventDefault();
+    } else {
+      e.returnValue = false;
+    }
+  },
+
+  stop: function (e) {
+    VCO.DomEvent.preventDefault(e);
+    VCO.DomEvent.stopPropagation(e);
+  },
 
 
-	getWheelDelta: function (e) {
-		var delta = 0;
-		if (e.wheelDelta) {
-			delta = e.wheelDelta / 120;
-		}
-		if (e.detail) {
-			delta = -e.detail / 3;
-		}
-		return delta;
-	}
+  getWheelDelta: function (e) {
+    var delta = 0;
+    if (e.wheelDelta) {
+      delta = e.wheelDelta / 120;
+    }
+    if (e.detail) {
+      delta = -e.detail / 3;
+    }
+    return delta;
+  }
 };
 
 
@@ -3976,330 +3976,330 @@ VCO.DomEvent = {
      Begin VCO.Draggable.js
 ********************************************** */
 
-/*	VCO.Draggable
-	VCO.Draggable allows you to add dragging capabilities to any element. Supports mobile devices too.
-	TODO Enable constraints
+/*  VCO.Draggable
+  VCO.Draggable allows you to add dragging capabilities to any element. Supports mobile devices too.
+  TODO Enable constraints
 ================================================== */
 
 VCO.Draggable = VCO.Class.extend({
-	
-	includes: VCO.Events,
-	
-	_el: {},
-	
-	mousedrag: {
-		down:		"mousedown",
-		up:			"mouseup",
-		leave:		"mouseleave",
-		move:		"mousemove"
-	},
-	
-	touchdrag: {
-		down:		"touchstart",
-		up:			"touchend",
-		leave:		"mouseleave",
-		move:		"touchmove"
-	},
 
-	initialize: function (drag_elem, options, move_elem) {
-		
-		// DOM ELements 
-		this._el = {
-			drag: drag_elem,
-			move: drag_elem
-		};
-		
-		if (move_elem) {
-			this._el.move = move_elem;
-		}
-		
-		
-		//Options
-		this.options = {
-			enable:	{
-				x: true,
-				y: true
-			},
-			constraint: {
-				top: false,
-				bottom: false,
-				left: false,
-				right: false
-			},
-			momentum_multiplier: 	2000,
-			duration: 				1000,
-			ease: 					VCO.Ease.easeInOutQuint
-		};
-		
-		
-		// Animation Object
-		this.animator = null;
-		
-		// Drag Event Type
-		this.dragevent = this.mousedrag;
-		
-		if (VCO.Browser.touch) {
-			this.dragevent = this.touchdrag;
-		}
-		
-		// Draggable Data
-		this.data = {
-			sliding:		false,
-			direction: 		"none",
-			pagex: {
-				start:		0,
-				end:		0
-			},
-			pagey: {
-				start:		0,
-				end:		0
-			},
-			pos: {
-				start: {
-					x: 0,
-					y:0
-				},
-				end: {
-					x: 0,
-					y:0
-				}
-			},
-			new_pos: {
-				x: 0,
-				y: 0
-			},
-			new_pos_parent: {
-				x: 0,
-				y: 0
-			},
-			time: {
-				start:		0,
-				end:		0
-			},
-			touch:			false
-		};
-		
-		// Merge Data and Options
-		VCO.Util.mergeData(this.options, options);
-		
-		
-	},
-	
-	enable: function(e) {
-		// Temporarily disableing this until I have time to fix some issues.
-		//VCO.DomEvent.addListener(this._el.drag, this.dragevent.down, this._onDragStart, this);
-		//VCO.DomEvent.addListener(this._el.drag, this.dragevent.up, this._onDragEnd, this);
-		
-		this.data.pos.start = 0; //VCO.Dom.getPosition(this._el.move);
-		this._el.move.style.left = this.data.pos.start.x + "px";
-		this._el.move.style.top = this.data.pos.start.y + "px";
-		this._el.move.style.position = "absolute";
-		//this._el.move.style.zIndex = "11";
-		//this._el.move.style.cursor = "move";
-	},
-	
-	disable: function() {
-		VCO.DomEvent.removeListener(this._el.drag, this.dragevent.down, this._onDragStart, this);
-		VCO.DomEvent.removeListener(this._el.drag, this.dragevent.up, this._onDragEnd, this);
-	},
-	
-	stopMomentum: function() {
-		if (this.animator) {
-			this.animator.stop();
-		}
+  includes: VCO.Events,
 
-	},
-	
-	updateConstraint: function(c) {
-		this.options.constraint = c;
-		
-		// Temporary until issues are fixed
-		
-	},
-	
-	/*	Private Methods
-	================================================== */
-	_onDragStart: function(e) {
-		if (VCO.Browser.touch) {
-			if (e.originalEvent) {
-				this.data.pagex.start = e.originalEvent.touches[0].screenX;
-				this.data.pagey.start = e.originalEvent.touches[0].screenY;
-			} else {
-				this.data.pagex.start = e.targetTouches[0].screenX;
-				this.data.pagey.start = e.targetTouches[0].screenY;
-			}
-		} else {
-			this.data.pagex.start = e.pageX;
-			this.data.pagey.start = e.pageY;
-		}
-		
-		// Center element to finger or mouse
-		if (this.options.enable.x) {
-			this._el.move.style.left = this.data.pagex.start - (this._el.move.offsetWidth / 2) + "px";
-		}
-		
-		if (this.options.enable.y) {
-			this._el.move.style.top = this.data.pagey.start - (this._el.move.offsetHeight / 2) + "px";
-		}
-		
-		this.data.pos.start = VCO.Dom.getPosition(this._el.drag);
-		this.data.time.start = new Date().getTime();
-		
-		this.fire("dragstart", this.data);
-		VCO.DomEvent.addListener(this._el.drag, this.dragevent.move, this._onDragMove, this);
-		VCO.DomEvent.addListener(this._el.drag, this.dragevent.leave, this._onDragEnd, this);
-	},
-	
-	_onDragEnd: function(e) {
-		this.data.sliding = false;
-		VCO.DomEvent.removeListener(this._el.drag, this.dragevent.move, this._onDragMove, this);
-		VCO.DomEvent.removeListener(this._el.drag, this.dragevent.leave, this._onDragEnd, this);
-		this.fire("dragend", this.data);
-		
-		//  momentum
-		this._momentum();
-	},
-	
-	_onDragMove: function(e) {
-		e.preventDefault();
-		this.data.sliding = true;
-		
-		if (VCO.Browser.touch) {
-			if (e.originalEvent) {
-				this.data.pagex.end = e.originalEvent.touches[0].screenX;
-				this.data.pagey.end = e.originalEvent.touches[0].screenY;
-			} else {
-				this.data.pagex.end = e.targetTouches[0].screenX;
-				this.data.pagey.end = e.targetTouches[0].screenY;
-			}
+  _el: {},
 
-		} else {
-			this.data.pagex.end = e.pageX;
-			this.data.pagey.end = e.pageY;
-		}
-		
-		this.data.pos.end = VCO.Dom.getPosition(this._el.drag);
-		this.data.new_pos.x = -(this.data.pagex.start - this.data.pagex.end - this.data.pos.start.x)//-(this.data.pagex.start - this.data.pagex.end - this.data.pos.end.x);
-		this.data.new_pos.y = -(this.data.pagey.start - this.data.pagey.end - this.data.pos.start.y );
-		
-		if (this.options.enable.x) {
-			this._el.move.style.left = this.data.new_pos.x + "px";
-		}
-		
-		if (this.options.enable.y) {
-			this._el.move.style.top = this.data.new_pos.y + "px";
-		}
-		
-		this.fire("dragmove", this.data);
-	},
-	
-	_momentum: function() {
-		var pos_adjust = {
-				x: 0,
-				y: 0,
-				time: 0
-			},
-			pos_change = {
-				x: 0,
-				y: 0,
-				time: 0
-			},
-			swipe = false,
-			swipe_direction = "";
-		
-		
-		if (VCO.Browser.touch) {
-			//this.options.momentum_multiplier = this.options.momentum_multiplier * 2;
-		}
-		
-		pos_adjust.time = (new Date().getTime() - this.data.time.start) * 10;
-		pos_change.time = (new Date().getTime() - this.data.time.start) * 10;
-		
-		pos_change.x = this.options.momentum_multiplier * (Math.abs(this.data.pagex.end) - Math.abs(this.data.pagex.start));
-		pos_change.y = this.options.momentum_multiplier * (Math.abs(this.data.pagey.end) - Math.abs(this.data.pagey.start));
-		
-		pos_adjust.x = Math.round(pos_change.x / pos_change.time);
-		pos_adjust.y = Math.round(pos_change.y / pos_change.time);
-		
-		this.data.new_pos.x = Math.min(this.data.pos.end.x + pos_adjust.x);
-		this.data.new_pos.y = Math.min(this.data.pos.end.y + pos_adjust.y);
+  mousedrag: {
+    down:   "mousedown",
+    up:     "mouseup",
+    leave:    "mouseleave",
+    move:   "mousemove"
+  },
 
-		
-		if (!this.options.enable.x) {
-			this.data.new_pos.x = this.data.pos.start.x;
-		} else if (this.data.new_pos.x < 0) {
-			this.data.new_pos.x = 0;
-		}
-		
-		if (!this.options.enable.y) {
-			this.data.new_pos.y = this.data.pos.start.y;
-		} else if (this.data.new_pos.y < 0) {
-			this.data.new_pos.y = 0;
-		}
-		
-		// Detect Swipe
-		if (pos_change.time < 3000) {
-			swipe = true;
-		}
-		
-		// Detect Direction
-		if (Math.abs(pos_change.x) > 10000) {
-			this.data.direction = "left";
-			if (pos_change.x > 0) {
-				this.data.direction = "right";
-			}
-		}
-		// Detect Swipe
-		if (Math.abs(pos_change.y) > 10000) {
-			this.data.direction = "up";
-			if (pos_change.y > 0) {
-				this.data.direction = "down";
-			}
-		}
-		this._animateMomentum();
-		if (swipe) {
-			this.fire("swipe_" + this.data.direction, this.data);
-		}
-		
-	},
-	
-	
-	_animateMomentum: function() {
-		var pos = {
-				x: this.data.new_pos.x,
-				y: this.data.new_pos.y
-			},
-			animate = {
-				duration: 	this.options.duration,
-				easing: 	VCO.Ease.easeOutStrong
-			};
-		
-		if (this.options.enable.y) {
-			if (this.options.constraint.top || this.options.constraint.bottom) {
-				if (pos.y > this.options.constraint.bottom) {
-					pos.y = this.options.constraint.bottom;
-				} else if (pos.y < this.options.constraint.top) {
-					pos.y = this.options.constraint.top;
-				}
-			}
-			animate.top = Math.floor(pos.y) + "px";
-		}
-		
-		if (this.options.enable.x) {
-			if (this.options.constraint.left || this.options.constraint.right) {
-				if (pos.x > this.options.constraint.left) {
-					pos.x = this.options.constraint.left;
-				} else if (pos.x < this.options.constraint.right) {
-					pos.x = this.options.constraint.right;
-				}
-			}
-			animate.left = Math.floor(pos.x) + "px";
-		}
-		
-		this.animator = VCO.Animate(this._el.move, animate);
-		
-		this.fire("momentum", this.data);
-	}
+  touchdrag: {
+    down:   "touchstart",
+    up:     "touchend",
+    leave:    "mouseleave",
+    move:   "touchmove"
+  },
+
+  initialize: function (drag_elem, options, move_elem) {
+
+    // DOM ELements
+    this._el = {
+      drag: drag_elem,
+      move: drag_elem
+    };
+
+    if (move_elem) {
+      this._el.move = move_elem;
+    }
+
+
+    //Options
+    this.options = {
+      enable: {
+        x: true,
+        y: true
+      },
+      constraint: {
+        top: false,
+        bottom: false,
+        left: false,
+        right: false
+      },
+      momentum_multiplier:  2000,
+      duration:         1000,
+      ease:           VCO.Ease.easeInOutQuint
+    };
+
+
+    // Animation Object
+    this.animator = null;
+
+    // Drag Event Type
+    this.dragevent = this.mousedrag;
+
+    if (VCO.Browser.touch) {
+      this.dragevent = this.touchdrag;
+    }
+
+    // Draggable Data
+    this.data = {
+      sliding:    false,
+      direction:    "none",
+      pagex: {
+        start:    0,
+        end:    0
+      },
+      pagey: {
+        start:    0,
+        end:    0
+      },
+      pos: {
+        start: {
+          x: 0,
+          y:0
+        },
+        end: {
+          x: 0,
+          y:0
+        }
+      },
+      new_pos: {
+        x: 0,
+        y: 0
+      },
+      new_pos_parent: {
+        x: 0,
+        y: 0
+      },
+      time: {
+        start:    0,
+        end:    0
+      },
+      touch:      false
+    };
+
+    // Merge Data and Options
+    VCO.Util.mergeData(this.options, options);
+
+
+  },
+
+  enable: function(e) {
+    // Temporarily disableing this until I have time to fix some issues.
+    //VCO.DomEvent.addListener(this._el.drag, this.dragevent.down, this._onDragStart, this);
+    //VCO.DomEvent.addListener(this._el.drag, this.dragevent.up, this._onDragEnd, this);
+
+    this.data.pos.start = 0; //VCO.Dom.getPosition(this._el.move);
+    this._el.move.style.left = this.data.pos.start.x + "px";
+    this._el.move.style.top = this.data.pos.start.y + "px";
+    this._el.move.style.position = "absolute";
+    //this._el.move.style.zIndex = "11";
+    //this._el.move.style.cursor = "move";
+  },
+
+  disable: function() {
+    VCO.DomEvent.removeListener(this._el.drag, this.dragevent.down, this._onDragStart, this);
+    VCO.DomEvent.removeListener(this._el.drag, this.dragevent.up, this._onDragEnd, this);
+  },
+
+  stopMomentum: function() {
+    if (this.animator) {
+      this.animator.stop();
+    }
+
+  },
+
+  updateConstraint: function(c) {
+    this.options.constraint = c;
+
+    // Temporary until issues are fixed
+
+  },
+
+  /*  Private Methods
+  ================================================== */
+  _onDragStart: function(e) {
+    if (VCO.Browser.touch) {
+      if (e.originalEvent) {
+        this.data.pagex.start = e.originalEvent.touches[0].screenX;
+        this.data.pagey.start = e.originalEvent.touches[0].screenY;
+      } else {
+        this.data.pagex.start = e.targetTouches[0].screenX;
+        this.data.pagey.start = e.targetTouches[0].screenY;
+      }
+    } else {
+      this.data.pagex.start = e.pageX;
+      this.data.pagey.start = e.pageY;
+    }
+
+    // Center element to finger or mouse
+    if (this.options.enable.x) {
+      this._el.move.style.left = this.data.pagex.start - (this._el.move.offsetWidth / 2) + "px";
+    }
+
+    if (this.options.enable.y) {
+      this._el.move.style.top = this.data.pagey.start - (this._el.move.offsetHeight / 2) + "px";
+    }
+
+    this.data.pos.start = VCO.Dom.getPosition(this._el.drag);
+    this.data.time.start = new Date().getTime();
+
+    this.fire("dragstart", this.data);
+    VCO.DomEvent.addListener(this._el.drag, this.dragevent.move, this._onDragMove, this);
+    VCO.DomEvent.addListener(this._el.drag, this.dragevent.leave, this._onDragEnd, this);
+  },
+
+  _onDragEnd: function(e) {
+    this.data.sliding = false;
+    VCO.DomEvent.removeListener(this._el.drag, this.dragevent.move, this._onDragMove, this);
+    VCO.DomEvent.removeListener(this._el.drag, this.dragevent.leave, this._onDragEnd, this);
+    this.fire("dragend", this.data);
+
+    //  momentum
+    this._momentum();
+  },
+
+  _onDragMove: function(e) {
+    e.preventDefault();
+    this.data.sliding = true;
+
+    if (VCO.Browser.touch) {
+      if (e.originalEvent) {
+        this.data.pagex.end = e.originalEvent.touches[0].screenX;
+        this.data.pagey.end = e.originalEvent.touches[0].screenY;
+      } else {
+        this.data.pagex.end = e.targetTouches[0].screenX;
+        this.data.pagey.end = e.targetTouches[0].screenY;
+      }
+
+    } else {
+      this.data.pagex.end = e.pageX;
+      this.data.pagey.end = e.pageY;
+    }
+
+    this.data.pos.end = VCO.Dom.getPosition(this._el.drag);
+    this.data.new_pos.x = -(this.data.pagex.start - this.data.pagex.end - this.data.pos.start.x)//-(this.data.pagex.start - this.data.pagex.end - this.data.pos.end.x);
+    this.data.new_pos.y = -(this.data.pagey.start - this.data.pagey.end - this.data.pos.start.y );
+
+    if (this.options.enable.x) {
+      this._el.move.style.left = this.data.new_pos.x + "px";
+    }
+
+    if (this.options.enable.y) {
+      this._el.move.style.top = this.data.new_pos.y + "px";
+    }
+
+    this.fire("dragmove", this.data);
+  },
+
+  _momentum: function() {
+    var pos_adjust = {
+        x: 0,
+        y: 0,
+        time: 0
+      },
+      pos_change = {
+        x: 0,
+        y: 0,
+        time: 0
+      },
+      swipe = false,
+      swipe_direction = "";
+
+
+    if (VCO.Browser.touch) {
+      //this.options.momentum_multiplier = this.options.momentum_multiplier * 2;
+    }
+
+    pos_adjust.time = (new Date().getTime() - this.data.time.start) * 10;
+    pos_change.time = (new Date().getTime() - this.data.time.start) * 10;
+
+    pos_change.x = this.options.momentum_multiplier * (Math.abs(this.data.pagex.end) - Math.abs(this.data.pagex.start));
+    pos_change.y = this.options.momentum_multiplier * (Math.abs(this.data.pagey.end) - Math.abs(this.data.pagey.start));
+
+    pos_adjust.x = Math.round(pos_change.x / pos_change.time);
+    pos_adjust.y = Math.round(pos_change.y / pos_change.time);
+
+    this.data.new_pos.x = Math.min(this.data.pos.end.x + pos_adjust.x);
+    this.data.new_pos.y = Math.min(this.data.pos.end.y + pos_adjust.y);
+
+
+    if (!this.options.enable.x) {
+      this.data.new_pos.x = this.data.pos.start.x;
+    } else if (this.data.new_pos.x < 0) {
+      this.data.new_pos.x = 0;
+    }
+
+    if (!this.options.enable.y) {
+      this.data.new_pos.y = this.data.pos.start.y;
+    } else if (this.data.new_pos.y < 0) {
+      this.data.new_pos.y = 0;
+    }
+
+    // Detect Swipe
+    if (pos_change.time < 3000) {
+      swipe = true;
+    }
+
+    // Detect Direction
+    if (Math.abs(pos_change.x) > 10000) {
+      this.data.direction = "left";
+      if (pos_change.x > 0) {
+        this.data.direction = "right";
+      }
+    }
+    // Detect Swipe
+    if (Math.abs(pos_change.y) > 10000) {
+      this.data.direction = "up";
+      if (pos_change.y > 0) {
+        this.data.direction = "down";
+      }
+    }
+    this._animateMomentum();
+    if (swipe) {
+      this.fire("swipe_" + this.data.direction, this.data);
+    }
+
+  },
+
+
+  _animateMomentum: function() {
+    var pos = {
+        x: this.data.new_pos.x,
+        y: this.data.new_pos.y
+      },
+      animate = {
+        duration:   this.options.duration,
+        easing:   VCO.Ease.easeOutStrong
+      };
+
+    if (this.options.enable.y) {
+      if (this.options.constraint.top || this.options.constraint.bottom) {
+        if (pos.y > this.options.constraint.bottom) {
+          pos.y = this.options.constraint.bottom;
+        } else if (pos.y < this.options.constraint.top) {
+          pos.y = this.options.constraint.top;
+        }
+      }
+      animate.top = Math.floor(pos.y) + "px";
+    }
+
+    if (this.options.enable.x) {
+      if (this.options.constraint.left || this.options.constraint.right) {
+        if (pos.x > this.options.constraint.left) {
+          pos.x = this.options.constraint.left;
+        } else if (pos.x < this.options.constraint.right) {
+          pos.x = this.options.constraint.right;
+        }
+      }
+      animate.left = Math.floor(pos.x) + "px";
+    }
+
+    this.animator = VCO.Animate(this._el.move, animate);
+
+    this.fire("momentum", this.data);
+  }
 });
 
 
@@ -4307,395 +4307,395 @@ VCO.Draggable = VCO.Class.extend({
      Begin VCO.Swipable.js
 ********************************************** */
 
-/*	VCO.Swipable
-	VCO.Draggable allows you to add dragging capabilities to any element. Supports mobile devices too.
-	TODO Enable constraints
+/*  VCO.Swipable
+  VCO.Draggable allows you to add dragging capabilities to any element. Supports mobile devices too.
+  TODO Enable constraints
 ================================================== */
 
 VCO.Swipable = VCO.Class.extend({
-	
-	includes: VCO.Events,
-	
-	_el: {},
-	
-	mousedrag: {
-		down:		"mousedown",
-		up:			"mouseup",
-		leave:		"mouseleave",
-		move:		"mousemove"
-	},
-	
-	touchdrag: {
-		down:		"touchstart",
-		up:			"touchend",
-		leave:		"mouseleave",
-		move:		"touchmove"
-	},
 
-	initialize: function (drag_elem, move_elem, options) {
-		
-		// DOM ELements 
-		this._el = {
-			drag: drag_elem,
-			move: drag_elem
-		};
-		
-		if (move_elem) {
-			this._el.move = move_elem;
-		}
-		
-		
-		//Options
-		this.options = {
-			snap: false,
-			enable:	{
-				x: true,
-				y: true
-			},
-			constraint: {
-				top: false,
-				bottom: false,
-				left: 0,
-				right: false
-			},
-			momentum_multiplier: 	2000,
-			duration: 				1000,
-			ease: 					VCO.Ease.easeInOutQuint
-		};
-		
-		
-		// Animation Object
-		this.animator = null;
-		
-		// Drag Event Type
-		this.dragevent = this.mousedrag;
-		
-		if (VCO.Browser.touch) {
-			this.dragevent = this.touchdrag;
-		}
-		
-		// Draggable Data
-		this.data = {
-			sliding:		false,
-			direction: 		"none",
-			pagex: {
-				start:		0,
-				end:		0
-			},
-			pagey: {
-				start:		0,
-				end:		0
-			},
-			pos: {
-				start: {
-					x: 0,
-					y:0
-				},
-				end: {
-					x: 0,
-					y:0
-				}
-			},
-			new_pos: {
-				x: 0,
-				y: 0
-			},
-			new_pos_parent: {
-				x: 0,
-				y: 0
-			},
-			time: {
-				start:		0,
-				end:		0
-			},
-			touch:			false
-		};
-		
-		// Merge Data and Options
-		VCO.Util.mergeData(this.options, options);
-		
-		
-	},
-	
-	enable: function(e) {
-		VCO.DomEvent.addListener(this._el.drag, this.dragevent.down, this._onDragStart, this);
-		VCO.DomEvent.addListener(this._el.drag, this.dragevent.up, this._onDragEnd, this);
-		
-		this.data.pos.start = 0; //VCO.Dom.getPosition(this._el.move);
-		this._el.move.style.left = this.data.pos.start.x + "px";
-		this._el.move.style.top = this.data.pos.start.y + "px";
-		this._el.move.style.position = "absolute";
-		//this._el.move.style.zIndex = "11";
-		//this._el.move.style.cursor = "move";
-	},
-	
-	disable: function() {
-		VCO.DomEvent.removeListener(this._el.drag, this.dragevent.down, this._onDragStart, this);
-		VCO.DomEvent.removeListener(this._el.drag, this.dragevent.up, this._onDragEnd, this);
-	},
-	
-	stopMomentum: function() {
-		if (this.animator) {
-			this.animator.stop();
-		}
+  includes: VCO.Events,
 
-	},
-	
-	updateConstraint: function(c) {
-		this.options.constraint = c;
-		
-		// Temporary until issues are fixed
-		
-	},
-	
-	/*	Private Methods
-	================================================== */
-	_onDragStart: function(e) {
-		
-		if (this.animator) {
-			this.animator.stop();
-		}
-		
-		if (VCO.Browser.touch) {
-			if (e.originalEvent) {
-				this.data.pagex.start = e.originalEvent.touches[0].screenX;
-				this.data.pagey.start = e.originalEvent.touches[0].screenY;
-			} else {
-				this.data.pagex.start = e.targetTouches[0].screenX;
-				this.data.pagey.start = e.targetTouches[0].screenY;
-			}
-		} else {
-			this.data.pagex.start = e.pageX;
-			this.data.pagey.start = e.pageY;
-		}
-		
-		// Center element to finger or mouse
-		if (this.options.enable.x) {
-			//this._el.move.style.left = this.data.pagex.start - (this._el.move.offsetWidth / 2) + "px";
-		}
-		
-		if (this.options.enable.y) {
-			//this._el.move.style.top = this.data.pagey.start - (this._el.move.offsetHeight / 2) + "px";
-		}
-		
-		this.data.pos.start = {x:this._el.move.offsetLeft, y:this._el.move.offsetTop};
-		
-		
-		this.data.time.start 			= new Date().getTime();
-		
-		this.fire("dragstart", this.data);
-		VCO.DomEvent.addListener(this._el.drag, this.dragevent.move, this._onDragMove, this);
-		VCO.DomEvent.addListener(this._el.drag, this.dragevent.leave, this._onDragEnd, this);
-	},
-	
-	_onDragEnd: function(e) {
-		this.data.sliding = false;
-		VCO.DomEvent.removeListener(this._el.drag, this.dragevent.move, this._onDragMove, this);
-		VCO.DomEvent.removeListener(this._el.drag, this.dragevent.leave, this._onDragEnd, this);
-		this.fire("dragend", this.data);
-		
-		//  momentum
-		this._momentum();
-	},
-	
-	_onDragMove: function(e) {
-		var change = {
-			x:0,
-			y:0
-		}
-		//e.preventDefault();
-		this.data.sliding = true;
-		
-		if (VCO.Browser.touch) {
-			if (e.originalEvent) {
-				this.data.pagex.end = e.originalEvent.touches[0].screenX;
-				this.data.pagey.end = e.originalEvent.touches[0].screenY;
-			} else {
-				this.data.pagex.end = e.targetTouches[0].screenX;
-				this.data.pagey.end = e.targetTouches[0].screenY;
-			}
+  _el: {},
 
-		} else {
-			this.data.pagex.end = e.pageX;
-			this.data.pagey.end = e.pageY;
-		}
-		
-		change.x = this.data.pagex.start - this.data.pagex.end;
-		change.y = this.data.pagey.start - this.data.pagey.end;
-		
-		this.data.pos.end = {x:this._el.drag.offsetLeft, y:this._el.drag.offsetTop};
-		
-		this.data.new_pos.x = -(change.x - this.data.pos.start.x);
-		this.data.new_pos.y = -(change.y - this.data.pos.start.y );
-		
-		
-		if (this.options.enable.x && ( Math.abs(change.x) > Math.abs(change.y) ) ) {
-			e.preventDefault();
-			this._el.move.style.left = this.data.new_pos.x + "px";
-		}
-		
-		if (this.options.enable.y && ( Math.abs(change.y) > Math.abs(change.y) ) ) {
-			e.preventDefault();
-			this._el.move.style.top = this.data.new_pos.y + "px";
-		}
-		
-		this.fire("dragmove", this.data);
-	},
-	
-	_momentum: function() {
-		var pos_adjust = {
-				x: 0,
-				y: 0,
-				time: 0
-			},
-			pos_change = {
-				x: 0,
-				y: 0,
-				time: 0
-			},
-			swipe_detect = {
-				x: false,
-				y: false
-			},
-			swipe = false,
-			swipe_direction = "";
-		
-		
-		this.data.direction = null;
-		
-		pos_adjust.time = (new Date().getTime() - this.data.time.start) * 10;
-		pos_change.time = (new Date().getTime() - this.data.time.start) * 10;
-		
-		pos_change.x = this.options.momentum_multiplier * (Math.abs(this.data.pagex.end) - Math.abs(this.data.pagex.start));
-		pos_change.y = this.options.momentum_multiplier * (Math.abs(this.data.pagey.end) - Math.abs(this.data.pagey.start));
-		
-		pos_adjust.x = Math.round(pos_change.x / pos_change.time);
-		pos_adjust.y = Math.round(pos_change.y / pos_change.time);
-		
-		this.data.new_pos.x = Math.min(this.data.pos.end.x + pos_adjust.x);
-		this.data.new_pos.y = Math.min(this.data.pos.end.y + pos_adjust.y);
+  mousedrag: {
+    down:   "mousedown",
+    up:     "mouseup",
+    leave:    "mouseleave",
+    move:   "mousemove"
+  },
 
-		
-		if (!this.options.enable.x) {
-			this.data.new_pos.x = this.data.pos.start.x;
-		} else if (this.data.new_pos.x > 0) {
-			this.data.new_pos.x = 0;
-		}
-		
-		if (!this.options.enable.y) {
-			this.data.new_pos.y = this.data.pos.start.y;
-		} else if (this.data.new_pos.y < 0) {
-			this.data.new_pos.y = 0;
-		}
-		
-		// Detect Swipe
-		if (pos_change.time < 2000) {
-			swipe = true;
-		}
-		
-		
-		if (this.options.enable.x && this.options.enable.y) {
-			if (Math.abs(pos_change.x) > Math.abs(pos_change.y)) {
-				swipe_detect.x = true;
-			} else {
-				swipe_detect.y = true;
-			}
-		} else if (this.options.enable.x) {
-			if (Math.abs(pos_change.x) > Math.abs(pos_change.y)) {
-				swipe_detect.x = true;
-			}
-		} else {
-			if (Math.abs(pos_change.y) > Math.abs(pos_change.x)) {
-				swipe_detect.y = true;
-			}
-		}
-		
-		// Detect Direction and long swipe
-		if (swipe_detect.x) {
-			
-			// Long Swipe
-			if (Math.abs(pos_change.x) > (this._el.drag.offsetWidth/2)) {
-				swipe = true;
-			}
-			
-			if (Math.abs(pos_change.x) > 10000) {
-				this.data.direction = "left";
-				if (pos_change.x > 0) {
-					this.data.direction = "right";
-				}
-			}
-		}
-		
-		if (swipe_detect.y) {
-			
-			// Long Swipe
-			if (Math.abs(pos_change.y) > (this._el.drag.offsetHeight/2)) {
-				swipe = true;
-			}
-			
-			if (Math.abs(pos_change.y) > 10000) {
-				this.data.direction = "up";
-				if (pos_change.y > 0) {
-					this.data.direction = "down";
-				}
-			}
-		}
-		
-		this._animateMomentum();
-		if (swipe && this.data.direction) {
-			this.fire("swipe_" + this.data.direction, this.data);
-		} else if (this.data.direction) {
-			this.fire("swipe_nodirection", this.data);
-		} else if (this.options.snap) {
-			this.animator.stop();
-			
-			this.animator = VCO.Animate(this._el.move, {
-				top: 		this.data.pos.start.y,
-				left: 		this.data.pos.start.x,
-				duration: 	this.options.duration,
-				easing: 	VCO.Ease.easeOutStrong
-			});
-		}
-		
-	},
-	
-	
-	_animateMomentum: function() {
-		var pos = {
-				x: this.data.new_pos.x,
-				y: this.data.new_pos.y
-			},
-			animate = {
-				duration: 	this.options.duration,
-				easing: 	VCO.Ease.easeOutStrong
-			};
-		
-		if (this.options.enable.y) {
-			if (this.options.constraint.top || this.options.constraint.bottom) {
-				if (pos.y > this.options.constraint.bottom) {
-					pos.y = this.options.constraint.bottom;
-				} else if (pos.y < this.options.constraint.top) {
-					pos.y = this.options.constraint.top;
-				}
-			}
-			animate.top = Math.floor(pos.y) + "px";
-		}
-		
-		if (this.options.enable.x) {
-			if (this.options.constraint.left || this.options.constraint.right) {
-				if (pos.x >= this.options.constraint.left) {
-					pos.x = this.options.constraint.left;
-				} else if (pos.x < this.options.constraint.right) {
-					pos.x = this.options.constraint.right;
-				}
-			}
-			animate.left = Math.floor(pos.x) + "px";
-		}
-		
-		this.animator = VCO.Animate(this._el.move, animate);
-		
-		this.fire("momentum", this.data);
-	}
+  touchdrag: {
+    down:   "touchstart",
+    up:     "touchend",
+    leave:    "mouseleave",
+    move:   "touchmove"
+  },
+
+  initialize: function (drag_elem, move_elem, options) {
+
+    // DOM ELements
+    this._el = {
+      drag: drag_elem,
+      move: drag_elem
+    };
+
+    if (move_elem) {
+      this._el.move = move_elem;
+    }
+
+
+    //Options
+    this.options = {
+      snap: false,
+      enable: {
+        x: true,
+        y: true
+      },
+      constraint: {
+        top: false,
+        bottom: false,
+        left: 0,
+        right: false
+      },
+      momentum_multiplier:  2000,
+      duration:         1000,
+      ease:           VCO.Ease.easeInOutQuint
+    };
+
+
+    // Animation Object
+    this.animator = null;
+
+    // Drag Event Type
+    this.dragevent = this.mousedrag;
+
+    if (VCO.Browser.touch) {
+      this.dragevent = this.touchdrag;
+    }
+
+    // Draggable Data
+    this.data = {
+      sliding:    false,
+      direction:    "none",
+      pagex: {
+        start:    0,
+        end:    0
+      },
+      pagey: {
+        start:    0,
+        end:    0
+      },
+      pos: {
+        start: {
+          x: 0,
+          y:0
+        },
+        end: {
+          x: 0,
+          y:0
+        }
+      },
+      new_pos: {
+        x: 0,
+        y: 0
+      },
+      new_pos_parent: {
+        x: 0,
+        y: 0
+      },
+      time: {
+        start:    0,
+        end:    0
+      },
+      touch:      false
+    };
+
+    // Merge Data and Options
+    VCO.Util.mergeData(this.options, options);
+
+
+  },
+
+  enable: function(e) {
+    VCO.DomEvent.addListener(this._el.drag, this.dragevent.down, this._onDragStart, this);
+    VCO.DomEvent.addListener(this._el.drag, this.dragevent.up, this._onDragEnd, this);
+
+    this.data.pos.start = 0; //VCO.Dom.getPosition(this._el.move);
+    this._el.move.style.left = this.data.pos.start.x + "px";
+    this._el.move.style.top = this.data.pos.start.y + "px";
+    this._el.move.style.position = "absolute";
+    //this._el.move.style.zIndex = "11";
+    //this._el.move.style.cursor = "move";
+  },
+
+  disable: function() {
+    VCO.DomEvent.removeListener(this._el.drag, this.dragevent.down, this._onDragStart, this);
+    VCO.DomEvent.removeListener(this._el.drag, this.dragevent.up, this._onDragEnd, this);
+  },
+
+  stopMomentum: function() {
+    if (this.animator) {
+      this.animator.stop();
+    }
+
+  },
+
+  updateConstraint: function(c) {
+    this.options.constraint = c;
+
+    // Temporary until issues are fixed
+
+  },
+
+  /*  Private Methods
+  ================================================== */
+  _onDragStart: function(e) {
+
+    if (this.animator) {
+      this.animator.stop();
+    }
+
+    if (VCO.Browser.touch) {
+      if (e.originalEvent) {
+        this.data.pagex.start = e.originalEvent.touches[0].screenX;
+        this.data.pagey.start = e.originalEvent.touches[0].screenY;
+      } else {
+        this.data.pagex.start = e.targetTouches[0].screenX;
+        this.data.pagey.start = e.targetTouches[0].screenY;
+      }
+    } else {
+      this.data.pagex.start = e.pageX;
+      this.data.pagey.start = e.pageY;
+    }
+
+    // Center element to finger or mouse
+    if (this.options.enable.x) {
+      //this._el.move.style.left = this.data.pagex.start - (this._el.move.offsetWidth / 2) + "px";
+    }
+
+    if (this.options.enable.y) {
+      //this._el.move.style.top = this.data.pagey.start - (this._el.move.offsetHeight / 2) + "px";
+    }
+
+    this.data.pos.start = {x:this._el.move.offsetLeft, y:this._el.move.offsetTop};
+
+
+    this.data.time.start      = new Date().getTime();
+
+    this.fire("dragstart", this.data);
+    VCO.DomEvent.addListener(this._el.drag, this.dragevent.move, this._onDragMove, this);
+    VCO.DomEvent.addListener(this._el.drag, this.dragevent.leave, this._onDragEnd, this);
+  },
+
+  _onDragEnd: function(e) {
+    this.data.sliding = false;
+    VCO.DomEvent.removeListener(this._el.drag, this.dragevent.move, this._onDragMove, this);
+    VCO.DomEvent.removeListener(this._el.drag, this.dragevent.leave, this._onDragEnd, this);
+    this.fire("dragend", this.data);
+
+    //  momentum
+    this._momentum();
+  },
+
+  _onDragMove: function(e) {
+    var change = {
+      x:0,
+      y:0
+    }
+    //e.preventDefault();
+    this.data.sliding = true;
+
+    if (VCO.Browser.touch) {
+      if (e.originalEvent) {
+        this.data.pagex.end = e.originalEvent.touches[0].screenX;
+        this.data.pagey.end = e.originalEvent.touches[0].screenY;
+      } else {
+        this.data.pagex.end = e.targetTouches[0].screenX;
+        this.data.pagey.end = e.targetTouches[0].screenY;
+      }
+
+    } else {
+      this.data.pagex.end = e.pageX;
+      this.data.pagey.end = e.pageY;
+    }
+
+    change.x = this.data.pagex.start - this.data.pagex.end;
+    change.y = this.data.pagey.start - this.data.pagey.end;
+
+    this.data.pos.end = {x:this._el.drag.offsetLeft, y:this._el.drag.offsetTop};
+
+    this.data.new_pos.x = -(change.x - this.data.pos.start.x);
+    this.data.new_pos.y = -(change.y - this.data.pos.start.y );
+
+
+    if (this.options.enable.x && ( Math.abs(change.x) > Math.abs(change.y) ) ) {
+      e.preventDefault();
+      this._el.move.style.left = this.data.new_pos.x + "px";
+    }
+
+    if (this.options.enable.y && ( Math.abs(change.y) > Math.abs(change.y) ) ) {
+      e.preventDefault();
+      this._el.move.style.top = this.data.new_pos.y + "px";
+    }
+
+    this.fire("dragmove", this.data);
+  },
+
+  _momentum: function() {
+    var pos_adjust = {
+        x: 0,
+        y: 0,
+        time: 0
+      },
+      pos_change = {
+        x: 0,
+        y: 0,
+        time: 0
+      },
+      swipe_detect = {
+        x: false,
+        y: false
+      },
+      swipe = false,
+      swipe_direction = "";
+
+
+    this.data.direction = null;
+
+    pos_adjust.time = (new Date().getTime() - this.data.time.start) * 10;
+    pos_change.time = (new Date().getTime() - this.data.time.start) * 10;
+
+    pos_change.x = this.options.momentum_multiplier * (Math.abs(this.data.pagex.end) - Math.abs(this.data.pagex.start));
+    pos_change.y = this.options.momentum_multiplier * (Math.abs(this.data.pagey.end) - Math.abs(this.data.pagey.start));
+
+    pos_adjust.x = Math.round(pos_change.x / pos_change.time);
+    pos_adjust.y = Math.round(pos_change.y / pos_change.time);
+
+    this.data.new_pos.x = Math.min(this.data.pos.end.x + pos_adjust.x);
+    this.data.new_pos.y = Math.min(this.data.pos.end.y + pos_adjust.y);
+
+
+    if (!this.options.enable.x) {
+      this.data.new_pos.x = this.data.pos.start.x;
+    } else if (this.data.new_pos.x > 0) {
+      this.data.new_pos.x = 0;
+    }
+
+    if (!this.options.enable.y) {
+      this.data.new_pos.y = this.data.pos.start.y;
+    } else if (this.data.new_pos.y < 0) {
+      this.data.new_pos.y = 0;
+    }
+
+    // Detect Swipe
+    if (pos_change.time < 2000) {
+      swipe = true;
+    }
+
+
+    if (this.options.enable.x && this.options.enable.y) {
+      if (Math.abs(pos_change.x) > Math.abs(pos_change.y)) {
+        swipe_detect.x = true;
+      } else {
+        swipe_detect.y = true;
+      }
+    } else if (this.options.enable.x) {
+      if (Math.abs(pos_change.x) > Math.abs(pos_change.y)) {
+        swipe_detect.x = true;
+      }
+    } else {
+      if (Math.abs(pos_change.y) > Math.abs(pos_change.x)) {
+        swipe_detect.y = true;
+      }
+    }
+
+    // Detect Direction and long swipe
+    if (swipe_detect.x) {
+
+      // Long Swipe
+      if (Math.abs(pos_change.x) > (this._el.drag.offsetWidth/2)) {
+        swipe = true;
+      }
+
+      if (Math.abs(pos_change.x) > 10000) {
+        this.data.direction = "left";
+        if (pos_change.x > 0) {
+          this.data.direction = "right";
+        }
+      }
+    }
+
+    if (swipe_detect.y) {
+
+      // Long Swipe
+      if (Math.abs(pos_change.y) > (this._el.drag.offsetHeight/2)) {
+        swipe = true;
+      }
+
+      if (Math.abs(pos_change.y) > 10000) {
+        this.data.direction = "up";
+        if (pos_change.y > 0) {
+          this.data.direction = "down";
+        }
+      }
+    }
+
+    this._animateMomentum();
+    if (swipe && this.data.direction) {
+      this.fire("swipe_" + this.data.direction, this.data);
+    } else if (this.data.direction) {
+      this.fire("swipe_nodirection", this.data);
+    } else if (this.options.snap) {
+      this.animator.stop();
+
+      this.animator = VCO.Animate(this._el.move, {
+        top:    this.data.pos.start.y,
+        left:     this.data.pos.start.x,
+        duration:   this.options.duration,
+        easing:   VCO.Ease.easeOutStrong
+      });
+    }
+
+  },
+
+
+  _animateMomentum: function() {
+    var pos = {
+        x: this.data.new_pos.x,
+        y: this.data.new_pos.y
+      },
+      animate = {
+        duration:   this.options.duration,
+        easing:   VCO.Ease.easeOutStrong
+      };
+
+    if (this.options.enable.y) {
+      if (this.options.constraint.top || this.options.constraint.bottom) {
+        if (pos.y > this.options.constraint.bottom) {
+          pos.y = this.options.constraint.bottom;
+        } else if (pos.y < this.options.constraint.top) {
+          pos.y = this.options.constraint.top;
+        }
+      }
+      animate.top = Math.floor(pos.y) + "px";
+    }
+
+    if (this.options.enable.x) {
+      if (this.options.constraint.left || this.options.constraint.right) {
+        if (pos.x >= this.options.constraint.left) {
+          pos.x = this.options.constraint.left;
+        } else if (pos.x < this.options.constraint.right) {
+          pos.x = this.options.constraint.right;
+        }
+      }
+      animate.left = Math.floor(pos.x) + "px";
+    }
+
+    this.animator = VCO.Animate(this._el.move, animate);
+
+    this.fire("momentum", this.data);
+  }
 });
 
 
@@ -4703,465 +4703,465 @@ VCO.Swipable = VCO.Class.extend({
      Begin VCO.MenuBar.js
 ********************************************** */
 
-/*	VCO.MenuBar
-	Draggable component to control size
+/*  VCO.MenuBar
+  Draggable component to control size
 ================================================== */
- 
+
 VCO.MenuBar = VCO.Class.extend({
-	
-	includes: [VCO.Events, VCO.DomMixins],
-	
-	_el: {},
-	
-	/*	Constructor
-	================================================== */
-	initialize: function(elem, parent_elem, options) {
-		// DOM ELEMENTS
-		this._el = {
-			parent: {},
-			container: {},
-			button_overview: {},
-			button_backtostart: {},
-			button_collapse_toggle: {},
-			arrow: {},
-			line: {},
-			coverbar: {},
-			grip: {}
-		};
-		
-		this.collapsed = false;
-		
-		if (typeof elem === 'object') {
-			this._el.container = elem;
-		} else {
-			this._el.container = VCO.Dom.get(elem);
-		}
-		
-		if (parent_elem) {
-			this._el.parent = parent_elem;
-		}
-	
-		//Options
-		this.options = {
-			width: 					600,
-			height: 				600,
-			duration: 				1000,
-			ease: 					VCO.Ease.easeInOutQuint,
-			menubar_default_y: 		0
-		};
-		
-		// Animation
-		this.animator = {};
-		
-		// Merge Data and Options
-		VCO.Util.mergeData(this.options, options);
-		
-		this._initLayout();
-		this._initEvents();
-	},
-	
-	/*	Public
-	================================================== */
-	show: function(d) {
-		
-		var duration = this.options.duration;
-		if (d) {
-			duration = d;
-		}
-		/*
-		this.animator = VCO.Animate(this._el.container, {
-			top: 		this.options.menubar_default_y + "px",
-			duration: 	duration,
-			easing: 	VCO.Ease.easeOutStrong
-		});
-		*/
-	},
-	
-	hide: function(top) {
-		/*
-		this.animator = VCO.Animate(this._el.container, {
-			top: 		top,
-			duration: 	this.options.duration,
-			easing: 	VCO.Ease.easeOutStrong
-		});
-		*/
-	},
-		
-	
-	setSticky: function(y) {
-		this.options.menubar_default_y = y;
-	},
-	
-	/*	Color
-	================================================== */
-	setColor: function(inverted) {
-		if (inverted) {
-			this._el.container.className = 'vco-menubar vco-menubar-inverted';
-		} else {
-			this._el.container.className = 'vco-menubar';
-		}
-	},
-	
-	/*	Update Display
-	================================================== */
-	updateDisplay: function(w, h, a, l) {
-		this._updateDisplay(w, h, a, l);
-	},
-	
 
-	/*	Events
-	================================================== */
+  includes: [VCO.Events, VCO.DomMixins],
 
-	
-	_onButtonOverview: function(e) {
-		this.fire("overview", e);
-	},
-	
-	_onButtonBackToStart: function(e) {
-		this.fire("back_to_start", e);
-	},
-	
-	_onButtonCollapseMap: function(e) {
-		if (this.collapsed) {
-			this.collapsed = false;
-			this.show();
-			this._el.button_overview.style.display = "inline";
-			this.fire("collapse", {y:this.options.menubar_default_y});
-			if (VCO.Browser.mobile) {
-				this._el.button_collapse_toggle.innerHTML	= "<span class='vco-icon-arrow-up'></span>";
-			} else {
-				this._el.button_collapse_toggle.innerHTML	= VCO.Language.buttons.collapse_toggle + "<span class='vco-icon-arrow-up'></span>";
-			}
-		} else {
-			this.collapsed = true;
-			this.hide(25);
-			this._el.button_overview.style.display = "none";
-			this.fire("collapse", {y:1});
-			if (VCO.Browser.mobile) {
-				this._el.button_collapse_toggle.innerHTML	= "<span class='vco-icon-arrow-down'></span>";
-			} else {
-				this._el.button_collapse_toggle.innerHTML	= VCO.Language.buttons.uncollapse_toggle + "<span class='vco-icon-arrow-down'></span>";
-			}
-		}
-	},
-	
-	/*	Private Methods
-	================================================== */
-	_initLayout: function () {
-		// Create Layout
-		
-		// Buttons
-		this._el.button_overview 						= VCO.Dom.create('span', 'vco-menubar-button', this._el.container);
-		VCO.DomEvent.addListener(this._el.button_overview, 'click', this._onButtonOverview, this);
-		
-		this._el.button_backtostart 					= VCO.Dom.create('span', 'vco-menubar-button', this._el.container);
-		VCO.DomEvent.addListener(this._el.button_backtostart, 'click', this._onButtonBackToStart, this);
-		
-		this._el.button_collapse_toggle 				= VCO.Dom.create('span', 'vco-menubar-button', this._el.container);
-		VCO.DomEvent.addListener(this._el.button_collapse_toggle, 'click', this._onButtonCollapseMap, this);
-		
-		if (this.options.map_as_image) {
-			this._el.button_overview.innerHTML			= VCO.Language.buttons.overview;
-		} else {
-			this._el.button_overview.innerHTML			= VCO.Language.buttons.map_overview;
-		}
-		
-		if (VCO.Browser.mobile) {
-			
-			this._el.button_backtostart.innerHTML		= "<span class='vco-icon-goback'></span>";
-			this._el.button_collapse_toggle.innerHTML	= "<span class='vco-icon-arrow-up'></span>";
-			this._el.container.setAttribute("ontouchstart"," ");
-		} else {
-			
-			this._el.button_backtostart.innerHTML		= VCO.Language.buttons.backtostart + " <span class='vco-icon-goback'></span>";
-			this._el.button_collapse_toggle.innerHTML	= VCO.Language.buttons.collapse_toggle + "<span class='vco-icon-arrow-up'></span>";
-		}
-		
-		if (this.options.layout == "landscape") {
-			this._el.button_collapse_toggle.style.display = "none";
-		}
-		
-	},
-	
-	_initEvents: function () {
-		
-	},
-	
-	// Update Display
-	_updateDisplay: function(width, height, animate) {
-		
-		if (width) {
-			this.options.width = width;
-		}
-		if (height) {
-			this.options.height = height;
-		}
-	}
-	
+  _el: {},
+
+  /*  Constructor
+  ================================================== */
+  initialize: function(elem, parent_elem, options) {
+    // DOM ELEMENTS
+    this._el = {
+      parent: {},
+      container: {},
+      button_overview: {},
+      button_backtostart: {},
+      button_collapse_toggle: {},
+      arrow: {},
+      line: {},
+      coverbar: {},
+      grip: {}
+    };
+
+    this.collapsed = false;
+
+    if (typeof elem === 'object') {
+      this._el.container = elem;
+    } else {
+      this._el.container = VCO.Dom.get(elem);
+    }
+
+    if (parent_elem) {
+      this._el.parent = parent_elem;
+    }
+
+    //Options
+    this.options = {
+      width:          600,
+      height:         600,
+      duration:         1000,
+      ease:           VCO.Ease.easeInOutQuint,
+      menubar_default_y:    0
+    };
+
+    // Animation
+    this.animator = {};
+
+    // Merge Data and Options
+    VCO.Util.mergeData(this.options, options);
+
+    this._initLayout();
+    this._initEvents();
+  },
+
+  /*  Public
+  ================================================== */
+  show: function(d) {
+
+    var duration = this.options.duration;
+    if (d) {
+      duration = d;
+    }
+    /*
+    this.animator = VCO.Animate(this._el.container, {
+      top:    this.options.menubar_default_y + "px",
+      duration:   duration,
+      easing:   VCO.Ease.easeOutStrong
+    });
+    */
+  },
+
+  hide: function(top) {
+    /*
+    this.animator = VCO.Animate(this._el.container, {
+      top:    top,
+      duration:   this.options.duration,
+      easing:   VCO.Ease.easeOutStrong
+    });
+    */
+  },
+
+
+  setSticky: function(y) {
+    this.options.menubar_default_y = y;
+  },
+
+  /*  Color
+  ================================================== */
+  setColor: function(inverted) {
+    if (inverted) {
+      this._el.container.className = 'vco-menubar vco-menubar-inverted';
+    } else {
+      this._el.container.className = 'vco-menubar';
+    }
+  },
+
+  /*  Update Display
+  ================================================== */
+  updateDisplay: function(w, h, a, l) {
+    this._updateDisplay(w, h, a, l);
+  },
+
+
+  /*  Events
+  ================================================== */
+
+
+  _onButtonOverview: function(e) {
+    this.fire("overview", e);
+  },
+
+  _onButtonBackToStart: function(e) {
+    this.fire("back_to_start", e);
+  },
+
+  _onButtonCollapseMap: function(e) {
+    if (this.collapsed) {
+      this.collapsed = false;
+      this.show();
+      this._el.button_overview.style.display = "inline";
+      this.fire("collapse", {y:this.options.menubar_default_y});
+      if (VCO.Browser.mobile) {
+        this._el.button_collapse_toggle.innerHTML = "<span class='vco-icon-arrow-up'></span>";
+      } else {
+        this._el.button_collapse_toggle.innerHTML = VCO.Language.buttons.collapse_toggle + "<span class='vco-icon-arrow-up'></span>";
+      }
+    } else {
+      this.collapsed = true;
+      this.hide(25);
+      this._el.button_overview.style.display = "none";
+      this.fire("collapse", {y:1});
+      if (VCO.Browser.mobile) {
+        this._el.button_collapse_toggle.innerHTML = "<span class='vco-icon-arrow-down'></span>";
+      } else {
+        this._el.button_collapse_toggle.innerHTML = VCO.Language.buttons.uncollapse_toggle + "<span class='vco-icon-arrow-down'></span>";
+      }
+    }
+  },
+
+  /*  Private Methods
+  ================================================== */
+  _initLayout: function () {
+    // Create Layout
+
+    // Buttons
+    this._el.button_overview            = VCO.Dom.create('span', 'vco-menubar-button', this._el.container);
+    VCO.DomEvent.addListener(this._el.button_overview, 'click', this._onButtonOverview, this);
+
+    this._el.button_backtostart           = VCO.Dom.create('span', 'vco-menubar-button', this._el.container);
+    VCO.DomEvent.addListener(this._el.button_backtostart, 'click', this._onButtonBackToStart, this);
+
+    this._el.button_collapse_toggle         = VCO.Dom.create('span', 'vco-menubar-button', this._el.container);
+    VCO.DomEvent.addListener(this._el.button_collapse_toggle, 'click', this._onButtonCollapseMap, this);
+
+    if (this.options.map_as_image) {
+      this._el.button_overview.innerHTML      = VCO.Language.buttons.overview;
+    } else {
+      this._el.button_overview.innerHTML      = VCO.Language.buttons.map_overview;
+    }
+
+    if (VCO.Browser.mobile) {
+
+      this._el.button_backtostart.innerHTML   = "<span class='vco-icon-goback'></span>";
+      this._el.button_collapse_toggle.innerHTML = "<span class='vco-icon-arrow-up'></span>";
+      this._el.container.setAttribute("ontouchstart"," ");
+    } else {
+
+      this._el.button_backtostart.innerHTML   = VCO.Language.buttons.backtostart + " <span class='vco-icon-goback'></span>";
+      this._el.button_collapse_toggle.innerHTML = VCO.Language.buttons.collapse_toggle + "<span class='vco-icon-arrow-up'></span>";
+    }
+
+    if (this.options.layout == "landscape") {
+      this._el.button_collapse_toggle.style.display = "none";
+    }
+
+  },
+
+  _initEvents: function () {
+
+  },
+
+  // Update Display
+  _updateDisplay: function(width, height, animate) {
+
+    if (width) {
+      this.options.width = width;
+    }
+    if (height) {
+      this.options.height = height;
+    }
+  }
+
 });
 
 /* **********************************************
      Begin VCO.Message.js
 ********************************************** */
 
-/*	VCO.SizeBar
-	Draggable component to control size
+/*  VCO.SizeBar
+  Draggable component to control size
 ================================================== */
- 
+
 VCO.Message = VCO.Class.extend({
-	
-	includes: [VCO.Events, VCO.DomMixins],
-	
-	_el: {},
-	
-	/*	Constructor
-	================================================== */
-	initialize: function(data, options, add_to_container) {
-		// DOM ELEMENTS
-		this._el = {
-			parent: {},
-			container: {},
-			message_container: {},
-			loading_icon: {},
-			message: {}
-		};
-	
-		//Options
-		this.options = {
-			width: 					600,
-			height: 				600,
-			message_class: 			"vco-message",
-			message_icon_class: 	"vco-loading-icon"
-		};
-		
-		// Merge Data and Options
-		VCO.Util.mergeData(this.data, data);
-		VCO.Util.mergeData(this.options, options);
-		
-		this._el.container = VCO.Dom.create("div", this.options.message_class);
-		
-		if (add_to_container) {
-			add_to_container.appendChild(this._el.container);
-			this._el.parent = add_to_container;
-		};
-		
-		
-		// Animation
-		this.animator = {};
-		
-		
-		this._initLayout();
-		this._initEvents();
-	},
-	
-	/*	Public
-	================================================== */
-	updateMessage: function(t) {
-		this._updateMessage(t);
-	},
-	
-	
-	/*	Update Display
-	================================================== */
-	updateDisplay: function(w, h) {
-		this._updateDisplay(w, h);
-	},
-	
-	_updateMessage: function(t) {
-		if (!t) {
-			if (VCO.Language) {
-				this._el.message.innerHTML = VCO.Language.messages.loading;
-			} else {
-				this._el.message.innerHTML = "Loading";
-			}
-		} else {
-			this._el.message.innerHTML = t;
-		}
-	},
-	
 
-	/*	Events
-	================================================== */
+  includes: [VCO.Events, VCO.DomMixins],
 
-	
-	_onMouseClick: function() {
-		this.fire("clicked", this.options);
-	},
+  _el: {},
 
-	
-	/*	Private Methods
-	================================================== */
-	_initLayout: function () {
-		
-		// Create Layout
-		this._el.message_container = VCO.Dom.create("div", "vco-message-container", this._el.container);
-		this._el.loading_icon = VCO.Dom.create("div", this.options.message_icon_class, this._el.message_container);
-		this._el.message = VCO.Dom.create("div", "vco-message-content", this._el.message_container);
-		
-		this._updateMessage();
-		
-	},
-	
-	_initEvents: function () {
-		VCO.DomEvent.addListener(this._el.container, 'click', this._onMouseClick, this);
-	},
-	
-	// Update Display
-	_updateDisplay: function(width, height, animate) {
-		
-	}
-	
+  /*  Constructor
+  ================================================== */
+  initialize: function(data, options, add_to_container) {
+    // DOM ELEMENTS
+    this._el = {
+      parent: {},
+      container: {},
+      message_container: {},
+      loading_icon: {},
+      message: {}
+    };
+
+    //Options
+    this.options = {
+      width:          600,
+      height:         600,
+      message_class:      "vco-message",
+      message_icon_class:   "vco-loading-icon"
+    };
+
+    // Merge Data and Options
+    VCO.Util.mergeData(this.data, data);
+    VCO.Util.mergeData(this.options, options);
+
+    this._el.container = VCO.Dom.create("div", this.options.message_class);
+
+    if (add_to_container) {
+      add_to_container.appendChild(this._el.container);
+      this._el.parent = add_to_container;
+    };
+
+
+    // Animation
+    this.animator = {};
+
+
+    this._initLayout();
+    this._initEvents();
+  },
+
+  /*  Public
+  ================================================== */
+  updateMessage: function(t) {
+    this._updateMessage(t);
+  },
+
+
+  /*  Update Display
+  ================================================== */
+  updateDisplay: function(w, h) {
+    this._updateDisplay(w, h);
+  },
+
+  _updateMessage: function(t) {
+    if (!t) {
+      if (VCO.Language) {
+        this._el.message.innerHTML = VCO.Language.messages.loading;
+      } else {
+        this._el.message.innerHTML = "Loading";
+      }
+    } else {
+      this._el.message.innerHTML = t;
+    }
+  },
+
+
+  /*  Events
+  ================================================== */
+
+
+  _onMouseClick: function() {
+    this.fire("clicked", this.options);
+  },
+
+
+  /*  Private Methods
+  ================================================== */
+  _initLayout: function () {
+
+    // Create Layout
+    this._el.message_container = VCO.Dom.create("div", "vco-message-container", this._el.container);
+    this._el.loading_icon = VCO.Dom.create("div", this.options.message_icon_class, this._el.message_container);
+    this._el.message = VCO.Dom.create("div", "vco-message-content", this._el.message_container);
+
+    this._updateMessage();
+
+  },
+
+  _initEvents: function () {
+    VCO.DomEvent.addListener(this._el.container, 'click', this._onMouseClick, this);
+  },
+
+  // Update Display
+  _updateDisplay: function(width, height, animate) {
+
+  }
+
 });
 
 /* **********************************************
      Begin VCO.MediaType.js
 ********************************************** */
 
-/*	VCO.MediaType
-	Determines the type of media the url string is.
-	returns an object with .type and .id
-	You can add new media types by adding a regex 
-	to match and the media class name to use to 
-	render the media 
+/*  VCO.MediaType
+  Determines the type of media the url string is.
+  returns an object with .type and .id
+  You can add new media types by adding a regex
+  to match and the media class name to use to
+  render the media
 
-	TODO
-	Allow array so a slideshow can be a mediatype
+  TODO
+  Allow array so a slideshow can be a mediatype
 ================================================== */
 VCO.MediaType = function(m) {
-	var media = {}, 
-		media_types = 	[
-			{
-				type: 		"youtube",
-				name: 		"YouTube", 
-				match_str: 	"(www.)?youtube|youtu\.be",
-				cls: 		VCO.Media.YouTube
-			},
-			{
-				type: 		"vimeo",
-				name: 		"Vimeo", 
-				match_str: 	"(player.)?vimeo\.com",
-				cls: 		VCO.Media.Vimeo
-			},
-			{
-				type: 		"dailymotion",
-				name: 		"DailyMotion", 
-				match_str: 	"(www.)?dailymotion\.com",
-				cls: 		VCO.Media.DailyMotion
-			},
-			{
-				type: 		"vine",
-				name: 		"Vine", 
-				match_str: 	"(www.)?vine\.co",
-				cls: 		VCO.Media.Vine
-			},
-			{
-				type: 		"soundcloud",
-				name: 		"SoundCloud", 
-				match_str: 	"(player.)?soundcloud\.com",
-				cls: 		VCO.Media.SoundCloud
-			},
-			{
-				type: 		"twitter",
-				name: 		"Twitter", 
-				match_str: 	"(www.)?twitter\.com",
-				cls: 		VCO.Media.Twitter
-			},
-			{
-				type: 		"googlemaps",
-				name: 		"Google Map", 
-				match_str: 	"maps.google",
-				cls: 		VCO.Media.Map
-			},
-			{
-				type: 		"googleplus",
-				name: 		"Google+", 
-				match_str: 	"plus.google",
-				cls: 		VCO.Media.GooglePlus
-			},
-			{
-				type: 		"flickr",
-				name: 		"Flickr", 
-				match_str: 	"flickr.com/photos",
-				cls: 		VCO.Media.Flickr
-			},
-			{
-				type: 		"instagram",
-				name: 		"Instagram", 
-				match_str: 	/(instagr.am|instagram.com)\/p\//,
-				cls: 		VCO.Media.Instagram
-			},
-			{
-				type: 		"profile",
-				name: 		"Profile", 
-				match_str: 	/((instagr.am|instagram.com)(\/profiles\/|[-a-zA-Z0-9@:%_\+.~#?&//=]+instagramprofile))|[-a-zA-Z0-9@:%_\+.~#?&//=]+\?profile/,
-				cls: 		VCO.Media.Profile
-			},
-			{
-				type: 		"image",
-				name: 		"Image",
-				match_str: 	/jpg|jpeg|png|gif/i,
-				cls: 		VCO.Media.Image
-			},
-			{
-				type: 		"googledocs",
-				name: 		"Google Doc",
-				match_str: 	/\b.(doc|docx|xls|xlsx|ppt|pptx|pdf|pages|ai|psd|tiff|dxf|svg|eps|ps|ttf|xps|zip|tif)\b/,
-				cls: 		VCO.Media.GoogleDoc
-			},
-			{
-				type: 		"wikipedia",
-				name: 		"Wikipedia",
-				match_str: 	"(www.)?wikipedia\.org",
-				cls: 		VCO.Media.Wikipedia
-			},
-			{
-				type: 		"iframe",
-				name: 		"iFrame",
-				match_str: 	"iframe",
-				cls: 		VCO.Media.IFrame
-			},
-			{
-				type: 		"storify",
-				name: 		"Storify",
-				match_str: 	"storify",
-				cls: 		VCO.Media.Storify
-			},
-			{
-				type: 		"blockquote",
-				name: 		"Quote",
-				match_str: 	"blockquote",
-				cls: 		VCO.Media.Blockquote
-			},
-			{
-				type: 		"website",
-				name: 		"Website",
-				match_str: 	"http://",
-				cls: 		VCO.Media.Website
-			},
-			{
-				type: 		"",
-				name: 		"",
-				match_str: 	"",
-				cls: 		VCO.Media
-			}
-		];
-	
-	for (var i = 0; i < media_types.length; i++) {
-		if (m instanceof Array) {
-			return media = {
-				type: 		"slider",
-				cls: 		VCO.Media.Slider
-			};
-		} else if (m.url.match(media_types[i].match_str)) {
-			media 		= media_types[i];
-			media.url 	= m.url;
-			return media;
-			break;
-		}
-	};
-	
-	return false;
-	
+  var media = {},
+    media_types =   [
+      {
+        type:     "youtube",
+        name:     "YouTube",
+        match_str:  "(www.)?youtube|youtu\.be",
+        cls:    VCO.Media.YouTube
+      },
+      {
+        type:     "vimeo",
+        name:     "Vimeo",
+        match_str:  "(player.)?vimeo\.com",
+        cls:    VCO.Media.Vimeo
+      },
+      {
+        type:     "dailymotion",
+        name:     "DailyMotion",
+        match_str:  "(www.)?dailymotion\.com",
+        cls:    VCO.Media.DailyMotion
+      },
+      {
+        type:     "vine",
+        name:     "Vine",
+        match_str:  "(www.)?vine\.co",
+        cls:    VCO.Media.Vine
+      },
+      {
+        type:     "soundcloud",
+        name:     "SoundCloud",
+        match_str:  "(player.)?soundcloud\.com",
+        cls:    VCO.Media.SoundCloud
+      },
+      {
+        type:     "twitter",
+        name:     "Twitter",
+        match_str:  "(www.)?twitter\.com",
+        cls:    VCO.Media.Twitter
+      },
+      {
+        type:     "googlemaps",
+        name:     "Google Map",
+        match_str:  "maps.google",
+        cls:    VCO.Media.Map
+      },
+      {
+        type:     "googleplus",
+        name:     "Google+",
+        match_str:  "plus.google",
+        cls:    VCO.Media.GooglePlus
+      },
+      {
+        type:     "flickr",
+        name:     "Flickr",
+        match_str:  "flickr.com/photos",
+        cls:    VCO.Media.Flickr
+      },
+      {
+        type:     "instagram",
+        name:     "Instagram",
+        match_str:  /(instagr.am|instagram.com)\/p\//,
+        cls:    VCO.Media.Instagram
+      },
+      {
+        type:     "profile",
+        name:     "Profile",
+        match_str:  /((instagr.am|instagram.com)(\/profiles\/|[-a-zA-Z0-9@:%_\+.~#?&//=]+instagramprofile))|[-a-zA-Z0-9@:%_\+.~#?&//=]+\?profile/,
+        cls:    VCO.Media.Profile
+      },
+      {
+        type:     "image",
+        name:     "Image",
+        match_str:  /jpg|jpeg|png|gif/i,
+        cls:    VCO.Media.Image
+      },
+      {
+        type:     "googledocs",
+        name:     "Google Doc",
+        match_str:  /\b.(doc|docx|xls|xlsx|ppt|pptx|pdf|pages|ai|psd|tiff|dxf|svg|eps|ps|ttf|xps|zip|tif)\b/,
+        cls:    VCO.Media.GoogleDoc
+      },
+      {
+        type:     "wikipedia",
+        name:     "Wikipedia",
+        match_str:  "(www.)?wikipedia\.org",
+        cls:    VCO.Media.Wikipedia
+      },
+      {
+        type:     "iframe",
+        name:     "iFrame",
+        match_str:  "iframe",
+        cls:    VCO.Media.IFrame
+      },
+      {
+        type:     "storify",
+        name:     "Storify",
+        match_str:  "storify",
+        cls:    VCO.Media.Storify
+      },
+      {
+        type:     "blockquote",
+        name:     "Quote",
+        match_str:  "blockquote",
+        cls:    VCO.Media.Blockquote
+      },
+      {
+        type:     "website",
+        name:     "Website",
+        match_str:  "http://",
+        cls:    VCO.Media.Website
+      },
+      {
+        type:     "",
+        name:     "",
+        match_str:  "",
+        cls:    VCO.Media
+      }
+    ];
+
+  for (var i = 0; i < media_types.length; i++) {
+    if (m instanceof Array) {
+      return media = {
+        type:     "slider",
+        cls:    VCO.Media.Slider
+      };
+    } else if (m.url.match(media_types[i].match_str)) {
+      media     = media_types[i];
+      media.url   = m.url;
+      return media;
+      break;
+    }
+  };
+
+  return false;
+
 }
 
 
@@ -5169,357 +5169,357 @@ VCO.MediaType = function(m) {
      Begin VCO.Media.js
 ********************************************** */
 
-/*	VCO.Media
-	Main media template for media assets.
-	Takes a data object and populates a dom object
+/*  VCO.Media
+  Main media template for media assets.
+  Takes a data object and populates a dom object
 ================================================== */
 // TODO add link
 
 VCO.Media = VCO.Class.extend({
-	
-	includes: [VCO.Events],
-	
-	_el: {},
-	
-	/*	Constructor
-	================================================== */
-	initialize: function(data, options, add_to_container) {
-		// DOM ELEMENTS
-		this._el = {
-			container: {},
-			content_container: {},
-			content: {},
-			content_item: {},
-			content_link: {},
-			caption: null,
-			credit: null,
-			parent: {},
-			link: null
-		};
-		
-		// Player (If Needed)
-		this.player = null;
-		
-		// Timer (If Needed)
-		this.timer = null;
-		this.load_timer = null;
-		
-		// Message
-		this.message = null;
-		
-		// Media ID
-		this.media_id = null;
-		
-		// State
-		this._state = {
-			loaded: false,
-			show_meta: false,
-			media_loaded: false
-		};
-	
-		// Data
-		this.data = {
-			uniqueid: 			null,
-			url: 				null,
-			credit:				null,
-			caption:			null,
-			link: 				null,
-			link_target: 		null
-		};
-	
-		//Options
-		this.options = {
-			api_key_flickr: 		"f2cc870b4d233dd0a5bfe73fd0d64ef0",
-			credit_height: 			0,
-			caption_height: 		0
-		};
-	
-		this.animator = {};
-		
-		// Merge Data and Options
-		VCO.Util.mergeData(this.options, options);
-		VCO.Util.mergeData(this.data, data);
-		
-		this._el.container = VCO.Dom.create("div", "vco-media");
-		
-		if (this.data.uniqueid) {
-			this._el.container.id = this.data.uniqueid;
-		}
-		
-		
-		this._initLayout();
-		
-		if (add_to_container) {
-			add_to_container.appendChild(this._el.container);
-			this._el.parent = add_to_container;
-		};
-		
-	},
-	
-	loadMedia: function() {
-		var self = this;
-		
-		if (!this._state.loaded) {
-			try {
-				this.load_timer = setTimeout(function() {
-					self._loadMedia();
-					self._state.loaded = true;
-					self._updateDisplay();
-				}, 1200);
-			} catch (e) {
-				trace("Error loading media for ", this._media);
-				trace(e);
-			}
-			
-			//this._state.loaded = true;
-		}
-	},
-	
-	loadingMessage: function() {
-		this.message.updateMessage(this._('loading') + " " + this.options.media_name);
-	},
-	
-	updateMediaDisplay: function(layout) {
-		if (this._state.loaded) {
-			this._updateMediaDisplay(layout);
-			
-			if (!VCO.Browser.mobile && layout != "portrait") {
-				this._el.content_item.style.maxHeight = (this.options.height/2) + "px";
-			}
-			
-			if (this._state.media_loaded) {
-				if (this._el.credit) {
-					this._el.credit.style.width		= "auto";
-				}
-				if (this._el.caption) {
-					this._el.caption.style.width	= "auto";
-				}
-			}
-			
-			// Fix for max-width issues in Firefox
-			if (VCO.Browser.firefox) {
-				if (this._el.content_item.offsetWidth > this._el.content_item.offsetHeight) {
-					this._el.content_item.style.width = "100%";
-					this._el.content_item.style.maxWidth = "100%";
-					
-				}
-				
-				if (layout == "portrait") {
-					this._el.content_item.style.maxHeight = "none"; 
-				}
-			}
-			if (this._state.media_loaded) {
-				if (this._el.credit) {
-					this._el.credit.style.width		= this._el.content_item.offsetWidth + "px";
-				}
-				if (this._el.caption) {
-					this._el.caption.style.width	= this._el.content_item.offsetWidth + "px";
-				}
-			}
-			
-			
-		}
-	},
-	
-	/*	Media Specific
-	================================================== */
-		_loadMedia: function() {
-		
-		},
-		
-		_updateMediaDisplay: function(l) {
-			//this._el.content_item.style.maxHeight = (this.options.height - this.options.credit_height - this.options.caption_height - 16) + "px";
-		},
-	
-	/*	Public
-	================================================== */
-	show: function() {
-		
-	},
-	
-	hide: function() {
-		
-	},
-	
-	addTo: function(container) {
-		container.appendChild(this._el.container);
-		this.onAdd();
-	},
-	
-	removeFrom: function(container) {
-		container.removeChild(this._el.container);
-		this.onRemove();
-	},
-	
-	// Update Display
-	updateDisplay: function(w, h, l) {
-		this._updateDisplay(w, h, l);
-	},
-	
-	stopMedia: function() {
-		this._stopMedia();
-	},
-	
-	loadErrorDisplay: function(message) {
-		this._el.content.removeChild(this._el.content_item);
-		this._el.content_item	= VCO.Dom.create("div", "vco-media-item vco-media-loaderror", this._el.content);
-		this._el.content_item.innerHTML = "<div class='vco-icon-" + this.options.media_type + "'></div><p>" + message + "</p>";
-		
-		// After Loaded
-		this.onLoaded(true);
-	},
 
-	/*	Events
-	================================================== */
-	onLoaded: function(error) {
-		this._state.loaded = true;
-		this.fire("loaded", this.data);
-		if (this.message) {
-			this.message.hide();
-		}
-		if (!error) {
-			this.showMeta();
-		}
-		this.updateDisplay();
-	},
-	
-	onMediaLoaded: function(e) {
-		this._state.media_loaded = true;
-		this.fire("media_loaded", this.data);
-		if (this._el.credit) {
-			this._el.credit.style.width		= this._el.content_item.offsetWidth + "px";
-		}
-		if (this._el.caption) {
-			this._el.caption.style.width		= this._el.content_item.offsetWidth + "px";
-		}
-	},
-	
-	showMeta: function(credit, caption) {
-		this._state.show_meta = true;
-		// Credit
-		if (this.data.credit && this.data.credit != "" && !this._el.credit) {
-			this._el.credit					= VCO.Dom.create("div", "vco-credit", this._el.content_container);
-			this._el.credit.innerHTML		= this.data.credit;
-			this.options.credit_height 		= this._el.credit.offsetHeight;
-		}
-		
-		// Caption
-		if (this.data.caption && this.data.caption != "" && !this._el.caption) {
-			this._el.caption				= VCO.Dom.create("div", "vco-caption", this._el.content_container);
-			this._el.caption.innerHTML		= this.data.caption;
-			this.options.caption_height 	= this._el.caption.offsetHeight;
-		}
-	},
-	
-	onAdd: function() {
-		this.fire("added", this.data);
-	},
+  includes: [VCO.Events],
 
-	onRemove: function() {
-		this.fire("removed", this.data);
-	},
-	
-	/*	Private Methods
-	================================================== */
-	_initLayout: function () {
-		
-		// Message
-		this.message = new VCO.Message({}, this.options);
-		this.message.addTo(this._el.container);
-		
-		// Create Layout
-		this._el.content_container = VCO.Dom.create("div", "vco-media-content-container", this._el.container);
-		
-		// Link
-		if (this.data.link && this.data.link != "") {
-			
-			this._el.link = VCO.Dom.create("a", "vco-media-link", this._el.content_container);
-			this._el.link.href = this.data.link;
-			if (this.data.link_target && this.data.link_target != "") {
-				this._el.link.target = this.data.link_target;
-			} else {
-				this._el.link.target = "_blank";
-			}
-			
-			this._el.content = VCO.Dom.create("div", "vco-media-content", this._el.link);
-			
-		} else {
-			this._el.content = VCO.Dom.create("div", "vco-media-content", this._el.content_container);
-		}
-		
-		
-	},
-	
-	// Update Display
-	_updateDisplay: function(w, h, l) {
-		if (w) {
-			this.options.width = w;
-		}
-		if (h) {
-			this.options.height = h;
-		}
-		
-		if (l) {
-			this.options.layout = l;
-		} 
-		
-		if (this._el.credit) {
-			this.options.credit_height 		= this._el.credit.offsetHeight;
-		}
-		if (this._el.caption) {
-			this.options.caption_height 	= this._el.caption.offsetHeight + 5;
-		}
-		
-		this.updateMediaDisplay(this.options.layout);
-		
-	},
-	
-	_stopMedia: function() {
-		
-	}
-	
+  _el: {},
+
+  /*  Constructor
+  ================================================== */
+  initialize: function(data, options, add_to_container) {
+    // DOM ELEMENTS
+    this._el = {
+      container: {},
+      content_container: {},
+      content: {},
+      content_item: {},
+      content_link: {},
+      caption: null,
+      credit: null,
+      parent: {},
+      link: null
+    };
+
+    // Player (If Needed)
+    this.player = null;
+
+    // Timer (If Needed)
+    this.timer = null;
+    this.load_timer = null;
+
+    // Message
+    this.message = null;
+
+    // Media ID
+    this.media_id = null;
+
+    // State
+    this._state = {
+      loaded: false,
+      show_meta: false,
+      media_loaded: false
+    };
+
+    // Data
+    this.data = {
+      uniqueid:       null,
+      url:        null,
+      credit:       null,
+      caption:      null,
+      link:         null,
+      link_target:    null
+    };
+
+    //Options
+    this.options = {
+      api_key_flickr:     "f2cc870b4d233dd0a5bfe73fd0d64ef0",
+      credit_height:      0,
+      caption_height:     0
+    };
+
+    this.animator = {};
+
+    // Merge Data and Options
+    VCO.Util.mergeData(this.options, options);
+    VCO.Util.mergeData(this.data, data);
+
+    this._el.container = VCO.Dom.create("div", "vco-media");
+
+    if (this.data.uniqueid) {
+      this._el.container.id = this.data.uniqueid;
+    }
+
+
+    this._initLayout();
+
+    if (add_to_container) {
+      add_to_container.appendChild(this._el.container);
+      this._el.parent = add_to_container;
+    };
+
+  },
+
+  loadMedia: function() {
+    var self = this;
+
+    if (!this._state.loaded) {
+      try {
+        this.load_timer = setTimeout(function() {
+          self._loadMedia();
+          self._state.loaded = true;
+          self._updateDisplay();
+        }, 1200);
+      } catch (e) {
+        trace("Error loading media for ", this._media);
+        trace(e);
+      }
+
+      //this._state.loaded = true;
+    }
+  },
+
+  loadingMessage: function() {
+    this.message.updateMessage(this._('loading') + " " + this.options.media_name);
+  },
+
+  updateMediaDisplay: function(layout) {
+    if (this._state.loaded) {
+      this._updateMediaDisplay(layout);
+
+      if (!VCO.Browser.mobile && layout != "portrait") {
+        this._el.content_item.style.maxHeight = (this.options.height/2) + "px";
+      }
+
+      if (this._state.media_loaded) {
+        if (this._el.credit) {
+          this._el.credit.style.width   = "auto";
+        }
+        if (this._el.caption) {
+          this._el.caption.style.width  = "auto";
+        }
+      }
+
+      // Fix for max-width issues in Firefox
+      if (VCO.Browser.firefox) {
+        if (this._el.content_item.offsetWidth > this._el.content_item.offsetHeight) {
+          this._el.content_item.style.width = "100%";
+          this._el.content_item.style.maxWidth = "100%";
+
+        }
+
+        if (layout == "portrait") {
+          this._el.content_item.style.maxHeight = "none";
+        }
+      }
+      if (this._state.media_loaded) {
+        if (this._el.credit) {
+          this._el.credit.style.width   = this._el.content_item.offsetWidth + "px";
+        }
+        if (this._el.caption) {
+          this._el.caption.style.width  = this._el.content_item.offsetWidth + "px";
+        }
+      }
+
+
+    }
+  },
+
+  /*  Media Specific
+  ================================================== */
+    _loadMedia: function() {
+
+    },
+
+    _updateMediaDisplay: function(l) {
+      //this._el.content_item.style.maxHeight = (this.options.height - this.options.credit_height - this.options.caption_height - 16) + "px";
+    },
+
+  /*  Public
+  ================================================== */
+  show: function() {
+
+  },
+
+  hide: function() {
+
+  },
+
+  addTo: function(container) {
+    container.appendChild(this._el.container);
+    this.onAdd();
+  },
+
+  removeFrom: function(container) {
+    container.removeChild(this._el.container);
+    this.onRemove();
+  },
+
+  // Update Display
+  updateDisplay: function(w, h, l) {
+    this._updateDisplay(w, h, l);
+  },
+
+  stopMedia: function() {
+    this._stopMedia();
+  },
+
+  loadErrorDisplay: function(message) {
+    this._el.content.removeChild(this._el.content_item);
+    this._el.content_item = VCO.Dom.create("div", "vco-media-item vco-media-loaderror", this._el.content);
+    this._el.content_item.innerHTML = "<div class='vco-icon-" + this.options.media_type + "'></div><p>" + message + "</p>";
+
+    // After Loaded
+    this.onLoaded(true);
+  },
+
+  /*  Events
+  ================================================== */
+  onLoaded: function(error) {
+    this._state.loaded = true;
+    this.fire("loaded", this.data);
+    if (this.message) {
+      this.message.hide();
+    }
+    if (!error) {
+      this.showMeta();
+    }
+    this.updateDisplay();
+  },
+
+  onMediaLoaded: function(e) {
+    this._state.media_loaded = true;
+    this.fire("media_loaded", this.data);
+    if (this._el.credit) {
+      this._el.credit.style.width   = this._el.content_item.offsetWidth + "px";
+    }
+    if (this._el.caption) {
+      this._el.caption.style.width    = this._el.content_item.offsetWidth + "px";
+    }
+  },
+
+  showMeta: function(credit, caption) {
+    this._state.show_meta = true;
+    // Credit
+    if (this.data.credit && this.data.credit != "" && !this._el.credit) {
+      this._el.credit         = VCO.Dom.create("div", "vco-credit", this._el.content_container);
+      this._el.credit.innerHTML   = this.data.credit;
+      this.options.credit_height    = this._el.credit.offsetHeight;
+    }
+
+    // Caption
+    if (this.data.caption && this.data.caption != "" && !this._el.caption) {
+      this._el.caption        = VCO.Dom.create("div", "vco-caption", this._el.content_container);
+      this._el.caption.innerHTML    = this.data.caption;
+      this.options.caption_height   = this._el.caption.offsetHeight;
+    }
+  },
+
+  onAdd: function() {
+    this.fire("added", this.data);
+  },
+
+  onRemove: function() {
+    this.fire("removed", this.data);
+  },
+
+  /*  Private Methods
+  ================================================== */
+  _initLayout: function () {
+
+    // Message
+    this.message = new VCO.Message({}, this.options);
+    this.message.addTo(this._el.container);
+
+    // Create Layout
+    this._el.content_container = VCO.Dom.create("div", "vco-media-content-container", this._el.container);
+
+    // Link
+    if (this.data.link && this.data.link != "") {
+
+      this._el.link = VCO.Dom.create("a", "vco-media-link", this._el.content_container);
+      this._el.link.href = this.data.link;
+      if (this.data.link_target && this.data.link_target != "") {
+        this._el.link.target = this.data.link_target;
+      } else {
+        this._el.link.target = "_blank";
+      }
+
+      this._el.content = VCO.Dom.create("div", "vco-media-content", this._el.link);
+
+    } else {
+      this._el.content = VCO.Dom.create("div", "vco-media-content", this._el.content_container);
+    }
+
+
+  },
+
+  // Update Display
+  _updateDisplay: function(w, h, l) {
+    if (w) {
+      this.options.width = w;
+    }
+    if (h) {
+      this.options.height = h;
+    }
+
+    if (l) {
+      this.options.layout = l;
+    }
+
+    if (this._el.credit) {
+      this.options.credit_height    = this._el.credit.offsetHeight;
+    }
+    if (this._el.caption) {
+      this.options.caption_height   = this._el.caption.offsetHeight + 5;
+    }
+
+    this.updateMediaDisplay(this.options.layout);
+
+  },
+
+  _stopMedia: function() {
+
+  }
+
 });
 
 /* **********************************************
      Begin VCO.Media.Blockquote.js
 ********************************************** */
 
-/*	VCO.Media.Blockquote
+/*  VCO.Media.Blockquote
 ================================================== */
 
 VCO.Media.Blockquote = VCO.Media.extend({
-	
-	includes: [VCO.Events],
-	
-	/*	Load the media
-	================================================== */
-	_loadMedia: function() {
-		
-		// Loading Message
-		this.message.updateMessage(VCO.Language.messages.loading + " " + this.options.media_name);
-		
-		// Create Dom element
-		this._el.content_item	= VCO.Dom.create("div", "vco-media-item vco-media-blockquote", this._el.content);
-		
-		// Get Media ID
-		this.media_id = this.data.url;
-		
-		// API Call
-		this._el.content_item.innerHTML = this.media_id;
-		
-		// After Loaded
-		this.onLoaded();
-	},
-	
-	updateMediaDisplay: function() {
-		
-	},
-	
-	_updateMediaDisplay: function() {
-		
-	}
 
-	
+  includes: [VCO.Events],
+
+  /*  Load the media
+  ================================================== */
+  _loadMedia: function() {
+
+    // Loading Message
+    this.message.updateMessage(VCO.Language.messages.loading + " " + this.options.media_name);
+
+    // Create Dom element
+    this._el.content_item = VCO.Dom.create("div", "vco-media-item vco-media-blockquote", this._el.content);
+
+    // Get Media ID
+    this.media_id = this.data.url;
+
+    // API Call
+    this._el.content_item.innerHTML = this.media_id;
+
+    // After Loaded
+    this.onLoaded();
+  },
+
+  updateMediaDisplay: function() {
+
+  },
+
+  _updateMediaDisplay: function() {
+
+  }
+
+
 });
 
 
@@ -5527,101 +5527,101 @@ VCO.Media.Blockquote = VCO.Media.extend({
      Begin VCO.Media.Flickr.js
 ********************************************** */
 
-/*	VCO.Media.Flickr
+/*  VCO.Media.Flickr
 
 ================================================== */
 
 VCO.Media.Flickr = VCO.Media.extend({
-	
-	includes: [VCO.Events],
-	
-	/*	Load the media
-	================================================== */
-	_loadMedia: function() {
-		var api_url,
-			self = this;
-		
-		// Loading Message
-		this.message.updateMessage(VCO.Language.messages.loading + " " + this.options.media_name);
-		
-		// Create Dom element
-		this._el.content_item	= VCO.Dom.create("img", "vco-media-item vco-media-image vco-media-flickr vco-media-shadow", this._el.content);
-		
-		// Media Loaded Event
-		this._el.content_item.addEventListener('load', function(e) {
-			self.onMediaLoaded();
-		});
-		
-		// Get Media ID
-		this.establishMediaID();
-		
-		// API URL
-		api_url = "https://api.flickr.com/services/rest/?method=flickr.photos.getSizes&api_key=" + this.options.api_key_flickr + "&photo_id=" + this.media_id + "&format=json&jsoncallback=?";
-		
-		// API Call
-		VCO.getJSON(api_url, function(d) {
-			if (d.stat == "ok") {
-				self.createMedia(d);
-			} else {
-				self.loadErrorDisplay("Photo not found or private.");
-			}
-		});
-		
-	},
 
-	establishMediaID: function() {
-		var marker = 'flickr.com/photos/';
-		var idx = this.data.url.indexOf(marker);
-		if (idx == -1) { throw "Invalid Flickr URL"; }
-		var pos = idx + marker.length;
-		this.media_id = this.data.url.substr(pos).split("/")[1];
-	},
-	
-	createMedia: function(d) {
-		var best_size 	= this.sizes(this.options.height),
-			size 		= d.sizes.size[d.sizes.size.length - 2].source;
-		
-		for(var i = 0; i < d.sizes.size.length; i++) {
-			if (d.sizes.size[i].label == best_size) {
-				size = d.sizes.size[i].source;
-			}
-		}
-		
-		// Set Image Source
-		this._el.content_item.src			= size;
-		
-		// After Loaded
-		this.onLoaded();
-	},
-	
-	sizes: function(s) {
-		var _size = "";
-		
-		if (s <= 75) {
-			if (s <= 0) {
-				_size = "Large";
-			} else {
-				_size = "Thumbnail";
-			}
-		} else if (s <= 180) {
-			_size = "Small";
-		} else if (s <= 240) {
-			_size = "Small 320";
-		} else if (s <= 375) {
-			_size = "Medium";
-		} else if (s <= 480) {
-			_size = "Medium 640";
-		} else if (s <= 600) {
-			_size = "Large";
-		} else {
-			_size = "Large";
-		}
-		
-		return _size;
-	}
-	
-	
-	
+  includes: [VCO.Events],
+
+  /*  Load the media
+  ================================================== */
+  _loadMedia: function() {
+    var api_url,
+      self = this;
+
+    // Loading Message
+    this.message.updateMessage(VCO.Language.messages.loading + " " + this.options.media_name);
+
+    // Create Dom element
+    this._el.content_item = VCO.Dom.create("img", "vco-media-item vco-media-image vco-media-flickr vco-media-shadow", this._el.content);
+
+    // Media Loaded Event
+    this._el.content_item.addEventListener('load', function(e) {
+      self.onMediaLoaded();
+    });
+
+    // Get Media ID
+    this.establishMediaID();
+
+    // API URL
+    api_url = "https://api.flickr.com/services/rest/?method=flickr.photos.getSizes&api_key=" + this.options.api_key_flickr + "&photo_id=" + this.media_id + "&format=json&jsoncallback=?";
+
+    // API Call
+    VCO.getJSON(api_url, function(d) {
+      if (d.stat == "ok") {
+        self.createMedia(d);
+      } else {
+        self.loadErrorDisplay("Photo not found or private.");
+      }
+    });
+
+  },
+
+  establishMediaID: function() {
+    var marker = 'flickr.com/photos/';
+    var idx = this.data.url.indexOf(marker);
+    if (idx == -1) { throw "Invalid Flickr URL"; }
+    var pos = idx + marker.length;
+    this.media_id = this.data.url.substr(pos).split("/")[1];
+  },
+
+  createMedia: function(d) {
+    var best_size   = this.sizes(this.options.height),
+      size    = d.sizes.size[d.sizes.size.length - 2].source;
+
+    for(var i = 0; i < d.sizes.size.length; i++) {
+      if (d.sizes.size[i].label == best_size) {
+        size = d.sizes.size[i].source;
+      }
+    }
+
+    // Set Image Source
+    this._el.content_item.src     = size;
+
+    // After Loaded
+    this.onLoaded();
+  },
+
+  sizes: function(s) {
+    var _size = "";
+
+    if (s <= 75) {
+      if (s <= 0) {
+        _size = "Large";
+      } else {
+        _size = "Thumbnail";
+      }
+    } else if (s <= 180) {
+      _size = "Small";
+    } else if (s <= 240) {
+      _size = "Small 320";
+    } else if (s <= 375) {
+      _size = "Medium";
+    } else if (s <= 480) {
+      _size = "Medium 640";
+    } else if (s <= 600) {
+      _size = "Large";
+    } else {
+      _size = "Large";
+    }
+
+    return _size;
+  }
+
+
+
 });
 
 
@@ -5629,61 +5629,61 @@ VCO.Media.Flickr = VCO.Media.extend({
      Begin VCO.Media.Instagram.js
 ********************************************** */
 
-/*	VCO.Media.Instagram
+/*  VCO.Media.Instagram
 
 ================================================== */
 
 VCO.Media.Instagram = VCO.Media.extend({
-	
-	includes: [VCO.Events],
-	
-	/*	Load the media
-	================================================== */
-	_loadMedia: function() {
-		var api_url,
-			self = this;
-		
-		// Loading Message
-		this.message.updateMessage(VCO.Language.messages.loading + " " + this.options.media_name);
-		
-		// Get Media ID
-		this.media_id = this.data.url.split("\/p\/")[1].split("/")[0];
-		
-		// Link
-		this._el.content_link 				= VCO.Dom.create("a", "", this._el.content);
-		this._el.content_link.href 			= this.data.url;
-		this._el.content_link.target 		= "_blank";
-		
-		// Photo
-		this._el.content_item				= VCO.Dom.create("img", "vco-media-item vco-media-image vco-media-instagram vco-media-shadow", this._el.content_link);
-		
-		// Media Loaded Event
-		this._el.content_item.addEventListener('load', function(e) {
-			self.onMediaLoaded();
-		});
-		
-		// Set source
-		this._el.content_item.src			= "http://instagr.am/p/" + this.media_id + "/media/?size=" + this.sizes(this._el.content.offsetWidth);
-		
-		this.onLoaded();
-		
-	},
-	
-	sizes: function(s) {
-		var _size = "";
-		if (s <= 150) {
-			_size = "t";
-		} else if (s <= 306) {
-			_size = "m";
-		} else {
-			_size = "l";
-		}
-		
-		return _size;
-	}
-	
-	
-	
+
+  includes: [VCO.Events],
+
+  /*  Load the media
+  ================================================== */
+  _loadMedia: function() {
+    var api_url,
+      self = this;
+
+    // Loading Message
+    this.message.updateMessage(VCO.Language.messages.loading + " " + this.options.media_name);
+
+    // Get Media ID
+    this.media_id = this.data.url.split("\/p\/")[1].split("/")[0];
+
+    // Link
+    this._el.content_link         = VCO.Dom.create("a", "", this._el.content);
+    this._el.content_link.href      = this.data.url;
+    this._el.content_link.target    = "_blank";
+
+    // Photo
+    this._el.content_item       = VCO.Dom.create("img", "vco-media-item vco-media-image vco-media-instagram vco-media-shadow", this._el.content_link);
+
+    // Media Loaded Event
+    this._el.content_item.addEventListener('load', function(e) {
+      self.onMediaLoaded();
+    });
+
+    // Set source
+    this._el.content_item.src     = "http://instagr.am/p/" + this.media_id + "/media/?size=" + this.sizes(this._el.content.offsetWidth);
+
+    this.onLoaded();
+
+  },
+
+  sizes: function(s) {
+    var _size = "";
+    if (s <= 150) {
+      _size = "t";
+    } else if (s <= 306) {
+      _size = "m";
+    } else {
+      _size = "l";
+    }
+
+    return _size;
+  }
+
+
+
 });
 
 
@@ -5691,83 +5691,83 @@ VCO.Media.Instagram = VCO.Media.extend({
      Begin VCO.Media.Profile.js
 ********************************************** */
 
-/*	VCO.Media.Profile
+/*  VCO.Media.Profile
 
 ================================================== */
 
 VCO.Media.Profile = VCO.Media.extend({
-	
-	includes: [VCO.Events],
-	
-	/*	Load the media
-	================================================== */
-	_loadMedia: function() {
-		// Loading Message
-		this.message.updateMessage(VCO.Language.messages.loading + " " + this.options.media_name);
-		
-		this._el.content_item				= VCO.Dom.create("img", "vco-media-item vco-media-image vco-media-profile vco-media-shadow", this._el.content);
-		this._el.content_item.src			= this.data.url;
-		
-		this.onLoaded();
-	},
-	
-	_updateMediaDisplay: function(layout) {
-		
-		
-		if(VCO.Browser.firefox) {
-			this._el.content_item.style.maxWidth = (this.options.width/2) - 40 + "px";
-		}
-	}
-	
+
+  includes: [VCO.Events],
+
+  /*  Load the media
+  ================================================== */
+  _loadMedia: function() {
+    // Loading Message
+    this.message.updateMessage(VCO.Language.messages.loading + " " + this.options.media_name);
+
+    this._el.content_item       = VCO.Dom.create("img", "vco-media-item vco-media-image vco-media-profile vco-media-shadow", this._el.content);
+    this._el.content_item.src     = this.data.url;
+
+    this.onLoaded();
+  },
+
+  _updateMediaDisplay: function(layout) {
+
+
+    if(VCO.Browser.firefox) {
+      this._el.content_item.style.maxWidth = (this.options.width/2) - 40 + "px";
+    }
+  }
+
 });
 
 /* **********************************************
      Begin VCO.Media.GoogleDoc.js
 ********************************************** */
 
-/*	VCO.Media.GoogleDoc
+/*  VCO.Media.GoogleDoc
 
 ================================================== */
 
 VCO.Media.GoogleDoc = VCO.Media.extend({
-	
-	includes: [VCO.Events],
-	
-	/*	Load the media
-	================================================== */
-	_loadMedia: function() {
-		var api_url,
-			self = this;
-		
-		// Loading Message
-		this.message.updateMessage(VCO.Language.messages.loading + " " + this.options.media_name);
-		
-		// Create Dom element
-		this._el.content_item	= VCO.Dom.create("div", "vco-media-item vco-media-iframe", this._el.content);
-		
-		// Get Media ID
-		this.media_id = this.data.url;
-		
-		// API URL
-		api_url = this.media_id;
-		
-		// API Call
-		if (this.media_id.match(/docs.google.com/i)) {
-			this._el.content_item.innerHTML	=	"<iframe class='doc' frameborder='0' width='100%' height='100%' src='" + this.media_id + "&amp;embedded=true'></iframe>";
-		} else {
-			this._el.content_item.innerHTML	=	"<iframe class='doc' frameborder='0' width='100%' height='100%' src='" + "http://docs.google.com/viewer?url=" + this.media_id + "&amp;embedded=true'></iframe>";
-		}
-		
-		// After Loaded
-		this.onLoaded();
-	},
-	
-	// Update Media Display
-	_updateMediaDisplay: function() {
-		this._el.content_item.style.height = this.options.height + "px";
-	}
 
-	
+  includes: [VCO.Events],
+
+  /*  Load the media
+  ================================================== */
+  _loadMedia: function() {
+    var api_url,
+      self = this;
+
+    // Loading Message
+    this.message.updateMessage(VCO.Language.messages.loading + " " + this.options.media_name);
+
+    // Create Dom element
+    this._el.content_item = VCO.Dom.create("div", "vco-media-item vco-media-iframe", this._el.content);
+
+    // Get Media ID
+    this.media_id = this.data.url;
+
+    // API URL
+    api_url = this.media_id;
+
+    // API Call
+    if (this.media_id.match(/docs.google.com/i)) {
+      this._el.content_item.innerHTML = "<iframe class='doc' frameborder='0' width='100%' height='100%' src='" + this.media_id + "&amp;embedded=true'></iframe>";
+    } else {
+      this._el.content_item.innerHTML = "<iframe class='doc' frameborder='0' width='100%' height='100%' src='" + "http://docs.google.com/viewer?url=" + this.media_id + "&amp;embedded=true'></iframe>";
+    }
+
+    // After Loaded
+    this.onLoaded();
+  },
+
+  // Update Media Display
+  _updateMediaDisplay: function() {
+    this._el.content_item.style.height = this.options.height + "px";
+  }
+
+
 });
 
 
@@ -5775,44 +5775,44 @@ VCO.Media.GoogleDoc = VCO.Media.extend({
      Begin VCO.Media.GooglePlus.js
 ********************************************** */
 
-/*	VCO.Media.GooglePlus
+/*  VCO.Media.GooglePlus
 ================================================== */
 
 VCO.Media.GooglePlus = VCO.Media.extend({
-	
-	includes: [VCO.Events],
-	
-	/*	Load the media
-	================================================== */
-	_loadMedia: function() {
-		var api_url,
-			self = this;
-		
-		// Loading Message
-		this.message.updateMessage(VCO.Language.messages.loading + " " + this.options.media_name);
-		
-		// Create Dom element
-		this._el.content_item	= VCO.Dom.create("div", "vco-media-item vco-media-googleplus", this._el.content);
-		
-		// Get Media ID
-		this.media_id = this.data.url;
-		
-		// API URL
-		api_url = this.media_id;
-		
-		// API Call
-		this._el.content_item.innerHTML = "<iframe frameborder='0' width='100%' height='100%' src='" + api_url + "'></iframe>"		
-		
-		// After Loaded
-		this.onLoaded();
-	},
-	
-	// Update Media Display
-	_updateMediaDisplay: function() {
-		this._el.content_item.style.height = this.options.height + "px";
-	}
 
-	
+  includes: [VCO.Events],
+
+  /*  Load the media
+  ================================================== */
+  _loadMedia: function() {
+    var api_url,
+      self = this;
+
+    // Loading Message
+    this.message.updateMessage(VCO.Language.messages.loading + " " + this.options.media_name);
+
+    // Create Dom element
+    this._el.content_item = VCO.Dom.create("div", "vco-media-item vco-media-googleplus", this._el.content);
+
+    // Get Media ID
+    this.media_id = this.data.url;
+
+    // API URL
+    api_url = this.media_id;
+
+    // API Call
+    this._el.content_item.innerHTML = "<iframe frameborder='0' width='100%' height='100%' src='" + api_url + "'></iframe>"
+
+    // After Loaded
+    this.onLoaded();
+  },
+
+  // Update Media Display
+  _updateMediaDisplay: function() {
+    this._el.content_item.style.height = this.options.height + "px";
+  }
+
+
 });
 
 
@@ -5820,43 +5820,43 @@ VCO.Media.GooglePlus = VCO.Media.extend({
      Begin VCO.Media.IFrame.js
 ********************************************** */
 
-/*	VCO.Media.IFrame
+/*  VCO.Media.IFrame
 ================================================== */
 
 VCO.Media.IFrame = VCO.Media.extend({
-	
-	includes: [VCO.Events],
-	
-	/*	Load the media
-	================================================== */
-	_loadMedia: function() {
-		var api_url,
-			self = this;
-		
-		// Loading Message
-		this.message.updateMessage(VCO.Language.messages.loading + " " + this.options.media_name);
-		
-		// Create Dom element
-		this._el.content_item	= VCO.Dom.create("div", "vco-media-item vco-media-iframe", this._el.content);
-		
-		// Get Media ID
-		this.media_id = this.data.url;
-		
-		// API URL
-		api_url = this.media_id;
-		
-		// API Call
-		this._el.content_item.innerHTML = api_url;
-		
-		// After Loaded
-		this.onLoaded();
-	},
-	
-	// Update Media Display
-	_updateMediaDisplay: function() {
-		this._el.content_item.style.height = this.options.height + "px";
-	}
-	
+
+  includes: [VCO.Events],
+
+  /*  Load the media
+  ================================================== */
+  _loadMedia: function() {
+    var api_url,
+      self = this;
+
+    // Loading Message
+    this.message.updateMessage(VCO.Language.messages.loading + " " + this.options.media_name);
+
+    // Create Dom element
+    this._el.content_item = VCO.Dom.create("div", "vco-media-item vco-media-iframe", this._el.content);
+
+    // Get Media ID
+    this.media_id = this.data.url;
+
+    // API URL
+    api_url = this.media_id;
+
+    // API Call
+    this._el.content_item.innerHTML = api_url;
+
+    // After Loaded
+    this.onLoaded();
+  },
+
+  // Update Media Display
+  _updateMediaDisplay: function() {
+    this._el.content_item.style.height = this.options.height + "px";
+  }
+
 });
 
 
@@ -5864,96 +5864,96 @@ VCO.Media.IFrame = VCO.Media.extend({
      Begin VCO.Media.Image.js
 ********************************************** */
 
-/*	VCO.Media.Image
-	Produces image assets.
-	Takes a data object and populates a dom object
+/*  VCO.Media.Image
+  Produces image assets.
+  Takes a data object and populates a dom object
 ================================================== */
 
 VCO.Media.Image = VCO.Media.extend({
-	
-	includes: [VCO.Events],
-	
-	/*	Load the media
-	================================================== */
-	_loadMedia: function() {
-		var self = this;
-		// Loading Message
-		this.message.updateMessage(VCO.Language.messages.loading + " " + this.options.media_name);
-		
-		// Link
-		if (this.data.link) {
-			this._el.content_link 				= VCO.Dom.create("a", "", this._el.content);
-			this._el.content_link.href 			= this.data.link;
-			this._el.content_link.target 		= "_blank";
-			this._el.content_item				= VCO.Dom.create("img", "vco-media-item vco-media-image vco-media-shadow", this._el.content_link);
-		} else {
-			this._el.content_item				= VCO.Dom.create("img", "vco-media-item vco-media-image vco-media-shadow", this._el.content);
-		}
-		
-		// Media Loaded Event
-		this._el.content_item.addEventListener('load', function(e) {
-			self.onMediaLoaded();
-		});
-		
-		this._el.content_item.src			= this.data.url;
-		
-		this.onLoaded();
-	},
-	
-	_updateMediaDisplay: function(layout) {
-		
-		
-		if(VCO.Browser.firefox) { 
-			//this._el.content_item.style.maxWidth = (this.options.width/2) - 40 + "px";
-			this._el.content_item.style.width = "auto";
-		}
-	}
-	
+
+  includes: [VCO.Events],
+
+  /*  Load the media
+  ================================================== */
+  _loadMedia: function() {
+    var self = this;
+    // Loading Message
+    this.message.updateMessage(VCO.Language.messages.loading + " " + this.options.media_name);
+
+    // Link
+    if (this.data.link) {
+      this._el.content_link         = VCO.Dom.create("a", "", this._el.content);
+      this._el.content_link.href      = this.data.link;
+      this._el.content_link.target    = "_blank";
+      this._el.content_item       = VCO.Dom.create("img", "vco-media-item vco-media-image vco-media-shadow", this._el.content_link);
+    } else {
+      this._el.content_item       = VCO.Dom.create("img", "vco-media-item vco-media-image vco-media-shadow", this._el.content);
+    }
+
+    // Media Loaded Event
+    this._el.content_item.addEventListener('load', function(e) {
+      self.onMediaLoaded();
+    });
+
+    this._el.content_item.src     = this.data.url;
+
+    this.onLoaded();
+  },
+
+  _updateMediaDisplay: function(layout) {
+
+
+    if(VCO.Browser.firefox) {
+      //this._el.content_item.style.maxWidth = (this.options.width/2) - 40 + "px";
+      this._el.content_item.style.width = "auto";
+    }
+  }
+
 });
 
 /* **********************************************
      Begin VCO.Media.SoundCloud.js
 ********************************************** */
 
-/*	VCO.Media.SoundCloud
+/*  VCO.Media.SoundCloud
 ================================================== */
 
 VCO.Media.SoundCloud = VCO.Media.extend({
-	
-	includes: [VCO.Events],
-	
-	/*	Load the media
-	================================================== */
-	_loadMedia: function() {
-		var api_url,
-			self = this;
-		
-		// Loading Message
-		this.message.updateMessage(VCO.Language.messages.loading + " " + this.options.media_name);
-		
-		// Create Dom element
-		this._el.content_item	= VCO.Dom.create("div", "vco-media-item vco-media-iframe vco-media-soundcloud vco-media-shadow", this._el.content);
-		
-		// Get Media ID
-		this.media_id = this.data.url;
-		
-		// API URL
-		api_url = "http://soundcloud.com/oembed?url=" + this.media_id + "&format=js&callback=?"
-		
-		// API Call
-		VCO.getJSON(api_url, function(d) {
-			self.createMedia(d);
-		});
-		
-	},
-	
-	createMedia: function(d) {
-		this._el.content_item.innerHTML = d.html;
-		
-		// After Loaded
-		this.onLoaded();
-	}
-	
+
+  includes: [VCO.Events],
+
+  /*  Load the media
+  ================================================== */
+  _loadMedia: function() {
+    var api_url,
+      self = this;
+
+    // Loading Message
+    this.message.updateMessage(VCO.Language.messages.loading + " " + this.options.media_name);
+
+    // Create Dom element
+    this._el.content_item = VCO.Dom.create("div", "vco-media-item vco-media-iframe vco-media-soundcloud vco-media-shadow", this._el.content);
+
+    // Get Media ID
+    this.media_id = this.data.url;
+
+    // API URL
+    api_url = "http://soundcloud.com/oembed?url=" + this.media_id + "&format=js&callback=?"
+
+    // API Call
+    VCO.getJSON(api_url, function(d) {
+      self.createMedia(d);
+    });
+
+  },
+
+  createMedia: function(d) {
+    this._el.content_item.innerHTML = d.html;
+
+    // After Loaded
+    this.onLoaded();
+  }
+
 });
 
 
@@ -5961,44 +5961,44 @@ VCO.Media.SoundCloud = VCO.Media.extend({
      Begin VCO.Media.Storify.js
 ********************************************** */
 
-/*	VCO.Media.Storify
+/*  VCO.Media.Storify
 ================================================== */
 
 VCO.Media.Storify = VCO.Media.extend({
-	
-	includes: [VCO.Events],
-	
-	/*	Load the media
-	================================================== */
-	_loadMedia: function() {
-		var content;
-		
-		// Loading Message
-		this.message.updateMessage(VCO.Language.messages.loading + " " + this.options.media_name);
-		
-		// Create Dom element
-		this._el.content_item	= VCO.Dom.create("div", "vco-media-item vco-media-iframe vco-media-storify", this._el.content);
-		
-		// Get Media ID
-		this.media_id = this.data.url;
-		
-		// Content
-		content =	"<iframe frameborder='0' width='100%' height='100%' src='" + this.media_id + "/embed'></iframe>";
-		content +=	"<script src='" + this.media_id + ".js'></script>";
-		
-		// API Call
-		this._el.content_item.innerHTML = content;
-		
-		// After Loaded
-		this.onLoaded();
-	},
-	
-	// Update Media Display
-	_updateMediaDisplay: function() {
-		this._el.content_item.style.height = this.options.height + "px";
-	}
-	
-	
+
+  includes: [VCO.Events],
+
+  /*  Load the media
+  ================================================== */
+  _loadMedia: function() {
+    var content;
+
+    // Loading Message
+    this.message.updateMessage(VCO.Language.messages.loading + " " + this.options.media_name);
+
+    // Create Dom element
+    this._el.content_item = VCO.Dom.create("div", "vco-media-item vco-media-iframe vco-media-storify", this._el.content);
+
+    // Get Media ID
+    this.media_id = this.data.url;
+
+    // Content
+    content = "<iframe frameborder='0' width='100%' height='100%' src='" + this.media_id + "/embed'></iframe>";
+    content +=  "<script src='" + this.media_id + ".js'></script>";
+
+    // API Call
+    this._el.content_item.innerHTML = content;
+
+    // After Loaded
+    this.onLoaded();
+  },
+
+  // Update Media Display
+  _updateMediaDisplay: function() {
+    this._el.content_item.style.height = this.options.height + "px";
+  }
+
+
 });
 
 
@@ -6007,252 +6007,252 @@ VCO.Media.Storify = VCO.Media.extend({
 ********************************************** */
 
 VCO.Media.Text = VCO.Class.extend({
-	
-	includes: [VCO.Events],
-	
-	// DOM ELEMENTS
-	_el: {
-		container: {},
-		content_container: {},
-		content: {},
-		headline: {},
-		date: {},
-		start_btn: {}
-	},
-	
-	// Data
-	data: {
-		uniqueid: 			"",
-		headline: 			"headline",
-		text: 				"text"
-	},
-	
-	// Options
-	options: {
-		title: 			false
-	},
-	
-	/*	Constructor
-	================================================== */
-	initialize: function(data, options, add_to_container) {
-		
-		VCO.Util.setData(this, data);
-		
-		// Merge Options
-		VCO.Util.mergeData(this.options, options);
-		
-		this._el.container = VCO.Dom.create("div", "vco-text");
-		this._el.container.id = this.data.uniqueid;
-		
-		this._initLayout();
-		
-		if (add_to_container) {
-			add_to_container.appendChild(this._el.container);
-		};
-		
-	},
-	
-	/*	Adding, Hiding, Showing etc
-	================================================== */
-	show: function() {
-		
-	},
-	
-	hide: function() {
-		
-	},
-	
-	addTo: function(container) {
-		container.appendChild(this._el.container);
-		//this.onAdd();
-	},
-	
-	removeFrom: function(container) {
-		container.removeChild(this._el.container);
-	},
-	
-	headlineHeight: function() {
-		return this._el.headline.offsetHeight + 40;
-	},
-	
-	addDateText: function(str) {
-		this._el.date.innerHTML = str;
-	},
-	
-	/*	Events
-	================================================== */
-	onLoaded: function() {
-		this.fire("loaded", this.data);
-	},
-	
-	onAdd: function() {
-		this.fire("added", this.data);
-	},
 
-	onRemove: function() {
-		this.fire("removed", this.data);
-	},
-	
-	/*	Private Methods
-	================================================== */
-	_initLayout: function () {
-		
-		// Create Layout
-		this._el.content_container			= VCO.Dom.create("div", "vco-text-content-container", this._el.container);
-		
-		// Date
-		this._el.date 				= VCO.Dom.create("h3", "vco-headline-date", this._el.content_container);
-		
-		// Headline
-		if (this.data.headline != "") {
-			var headline_class = "vco-headline";
-			if (this.options.title) {
-				headline_class = "vco-headline vco-headline-title";
-			}
-			this._el.headline				= VCO.Dom.create("h2", headline_class, this._el.content_container);
-			this._el.headline.innerHTML		= this.data.headline;
-		}
-		
-		// Text
-		if (this.data.text != "") {
-			var text_content = "";
-			
-			text_content 					+= VCO.Util.htmlify(this.data.text);
-			
-			// Date
-			if (this.data.date && this.data.date.created_time && this.data.date.created_time != "") {
-				if (this.data.date.created_time.length > 10) {
-					if (typeof(moment) !== 'undefined') {
-						text_content 	+= "<div class='vco-text-date'>" + moment(this.data.date.created_time, 'YYYY-MM-DD h:mm:ss').fromNow() + "</div>";
-					
-					} else {
-						text_content 	+= "<div class='vco-text-date'>" + VCO.Util.convertUnixTime(this.data.date.created_time) + "</div>";
-					}
-				}
-			}
-			
-			
-			this._el.content				= VCO.Dom.create("div", "vco-text-content", this._el.content_container);
-			this._el.content.innerHTML		= text_content;
-			
-		}
-		
-		
-		// Fire event that the slide is loaded
-		this.onLoaded();
-		
-		
-		
-	}
-	
+  includes: [VCO.Events],
+
+  // DOM ELEMENTS
+  _el: {
+    container: {},
+    content_container: {},
+    content: {},
+    headline: {},
+    date: {},
+    start_btn: {}
+  },
+
+  // Data
+  data: {
+    uniqueid:       "",
+    headline:       "headline",
+    text:         "text"
+  },
+
+  // Options
+  options: {
+    title:      false
+  },
+
+  /*  Constructor
+  ================================================== */
+  initialize: function(data, options, add_to_container) {
+
+    VCO.Util.setData(this, data);
+
+    // Merge Options
+    VCO.Util.mergeData(this.options, options);
+
+    this._el.container = VCO.Dom.create("div", "vco-text");
+    this._el.container.id = this.data.uniqueid;
+
+    this._initLayout();
+
+    if (add_to_container) {
+      add_to_container.appendChild(this._el.container);
+    };
+
+  },
+
+  /*  Adding, Hiding, Showing etc
+  ================================================== */
+  show: function() {
+
+  },
+
+  hide: function() {
+
+  },
+
+  addTo: function(container) {
+    container.appendChild(this._el.container);
+    //this.onAdd();
+  },
+
+  removeFrom: function(container) {
+    container.removeChild(this._el.container);
+  },
+
+  headlineHeight: function() {
+    return this._el.headline.offsetHeight + 40;
+  },
+
+  addDateText: function(str) {
+    this._el.date.innerHTML = str;
+  },
+
+  /*  Events
+  ================================================== */
+  onLoaded: function() {
+    this.fire("loaded", this.data);
+  },
+
+  onAdd: function() {
+    this.fire("added", this.data);
+  },
+
+  onRemove: function() {
+    this.fire("removed", this.data);
+  },
+
+  /*  Private Methods
+  ================================================== */
+  _initLayout: function () {
+
+    // Create Layout
+    this._el.content_container      = VCO.Dom.create("div", "vco-text-content-container", this._el.container);
+
+    // Date
+    this._el.date         = VCO.Dom.create("h3", "vco-headline-date", this._el.content_container);
+
+    // Headline
+    if (this.data.headline != "") {
+      var headline_class = "vco-headline";
+      if (this.options.title) {
+        headline_class = "vco-headline vco-headline-title";
+      }
+      this._el.headline       = VCO.Dom.create("h2", headline_class, this._el.content_container);
+      this._el.headline.innerHTML   = this.data.headline;
+    }
+
+    // Text
+    if (this.data.text != "") {
+      var text_content = "";
+
+      text_content          += VCO.Util.htmlify(this.data.text);
+
+      // Date
+      if (this.data.date && this.data.date.created_time && this.data.date.created_time != "") {
+        if (this.data.date.created_time.length > 10) {
+          if (typeof(moment) !== 'undefined') {
+            text_content  += "<div class='vco-text-date'>" + moment(this.data.date.created_time, 'YYYY-MM-DD h:mm:ss').fromNow() + "</div>";
+
+          } else {
+            text_content  += "<div class='vco-text-date'>" + VCO.Util.convertUnixTime(this.data.date.created_time) + "</div>";
+          }
+        }
+      }
+
+
+      this._el.content        = VCO.Dom.create("div", "vco-text-content", this._el.content_container);
+      this._el.content.innerHTML    = text_content;
+
+    }
+
+
+    // Fire event that the slide is loaded
+    this.onLoaded();
+
+
+
+  }
+
 });
 
 /* **********************************************
      Begin VCO.Media.Twitter.js
 ********************************************** */
 
-/*	VCO.Media.Twitter
-	Produces Twitter Display
+/*  VCO.Media.Twitter
+  Produces Twitter Display
 ================================================== */
 
 VCO.Media.Twitter = VCO.Media.extend({
-	
-	includes: [VCO.Events],
-	
-	/*	Load the media
-	================================================== */
-	_loadMedia: function() {
-		var api_url,
-			self = this;
-			
-		// Loading Message
-		this.message.updateMessage(VCO.Language.messages.loading + " " + this.options.media_name);
-		
-		// Create Dom element
-		this._el.content_item = VCO.Dom.create("div", "vco-media-twitter", this._el.content);
-		
-		// Get Media ID
-		if (this.data.url.match("status\/")) {
-			this.media_id = this.data.url.split("status\/")[1];
-		} else if (url.match("statuses\/")) {
-			this.media_id = this.data.url.split("statuses\/")[1];
-		} else {
-			this.media_id = "";
-		}
-		
-		// API URL
-		api_url = "https://api.twitter.com/1/statuses/oembed.json?id=" + this.media_id + "&omit_script=true&include_entities=true&callback=?";
-		
-		// API Call
-		VCO.ajax({
-			type: 'GET',
-			url: api_url,
-			dataType: 'json', //json data type
-			success: function(d){
-				self.createMedia(d);
-			},
-			error:function(xhr, type){
-				var error_text = "";
-				error_text += "Unable to load Tweet. <br/>" + self.media_id + "<br/>" + type;
-				self.loadErrorDisplay(error_text);
-			}
-		});
-		 
-	},
-	
-	createMedia: function(d) {	
-		trace("create_media")	
-		var tweet				= "",
-			tweet_text			= "",
-			tweetuser			= "",
-			tweet_status_temp 	= "",
-			tweet_status_url 	= "",
-			tweet_status_date 	= "";
-			
-		//	TWEET CONTENT
-		tweet_text 			= d.html.split("<\/p>\&mdash;")[0] + "</p></blockquote>";
-		tweetuser			= d.author_url.split("twitter.com\/")[1];
-		tweet_status_temp 	= d.html.split("<\/p>\&mdash;")[1].split("<a href=\"")[1];
-		tweet_status_url 	= tweet_status_temp.split("\"\>")[0];
-		tweet_status_date 	= tweet_status_temp.split("\"\>")[1].split("<\/a>")[0];
-		
-		// Open links in new window
-		tweet_text = tweet_text.replace(/<a href/ig, '<a target="_blank" href');
-		
-		// 	TWEET CONTENT
-		tweet += tweet_text;
-		
-		//	TWEET AUTHOR
-		tweet += "<div class='vcard'>";
-		tweet += "<a href='" + tweet_status_url + "' class='twitter-date' target='_blank'>" + tweet_status_date + "</a>";
-		tweet += "<div class='author'>";
-		tweet += "<a class='screen-name url' href='" + d.author_url + "' target='_blank'>";
-		tweet += "<span class='avatar'></span>";
-		tweet += "<span class='fn'>" + d.author_name + " <span class='vco-icon-twitter'></span></span>";
-		tweet += "<span class='nickname'>@" + tweetuser + "<span class='thumbnail-inline'></span></span>";
-		tweet += "</a>";
-		tweet += "</div>";
-		tweet += "</div>";
-		
-		
-		// Add to DOM
-		this._el.content_item.innerHTML	= tweet;
-		
-		// After Loaded
-		this.onLoaded();
-			
-	},
-	
-	updateMediaDisplay: function() {
-		
-	},
-	
-	_updateMediaDisplay: function() {
-		
-	}
-	
-	
-	
+
+  includes: [VCO.Events],
+
+  /*  Load the media
+  ================================================== */
+  _loadMedia: function() {
+    var api_url,
+      self = this;
+
+    // Loading Message
+    this.message.updateMessage(VCO.Language.messages.loading + " " + this.options.media_name);
+
+    // Create Dom element
+    this._el.content_item = VCO.Dom.create("div", "vco-media-twitter", this._el.content);
+
+    // Get Media ID
+    if (this.data.url.match("status\/")) {
+      this.media_id = this.data.url.split("status\/")[1];
+    } else if (url.match("statuses\/")) {
+      this.media_id = this.data.url.split("statuses\/")[1];
+    } else {
+      this.media_id = "";
+    }
+
+    // API URL
+    api_url = "https://api.twitter.com/1/statuses/oembed.json?id=" + this.media_id + "&omit_script=true&include_entities=true&callback=?";
+
+    // API Call
+    VCO.ajax({
+      type: 'GET',
+      url: api_url,
+      dataType: 'json', //json data type
+      success: function(d){
+        self.createMedia(d);
+      },
+      error:function(xhr, type){
+        var error_text = "";
+        error_text += "Unable to load Tweet. <br/>" + self.media_id + "<br/>" + type;
+        self.loadErrorDisplay(error_text);
+      }
+    });
+
+  },
+
+  createMedia: function(d) {
+    trace("create_media")
+    var tweet       = "",
+      tweet_text      = "",
+      tweetuser     = "",
+      tweet_status_temp   = "",
+      tweet_status_url  = "",
+      tweet_status_date   = "";
+
+    //  TWEET CONTENT
+    tweet_text      = d.html.split("<\/p>\&mdash;")[0] + "</p></blockquote>";
+    tweetuser     = d.author_url.split("twitter.com\/")[1];
+    tweet_status_temp   = d.html.split("<\/p>\&mdash;")[1].split("<a href=\"")[1];
+    tweet_status_url  = tweet_status_temp.split("\"\>")[0];
+    tweet_status_date   = tweet_status_temp.split("\"\>")[1].split("<\/a>")[0];
+
+    // Open links in new window
+    tweet_text = tweet_text.replace(/<a href/ig, '<a target="_blank" href');
+
+    //  TWEET CONTENT
+    tweet += tweet_text;
+
+    //  TWEET AUTHOR
+    tweet += "<div class='vcard'>";
+    tweet += "<a href='" + tweet_status_url + "' class='twitter-date' target='_blank'>" + tweet_status_date + "</a>";
+    tweet += "<div class='author'>";
+    tweet += "<a class='screen-name url' href='" + d.author_url + "' target='_blank'>";
+    tweet += "<span class='avatar'></span>";
+    tweet += "<span class='fn'>" + d.author_name + " <span class='vco-icon-twitter'></span></span>";
+    tweet += "<span class='nickname'>@" + tweetuser + "<span class='thumbnail-inline'></span></span>";
+    tweet += "</a>";
+    tweet += "</div>";
+    tweet += "</div>";
+
+
+    // Add to DOM
+    this._el.content_item.innerHTML = tweet;
+
+    // After Loaded
+    this.onLoaded();
+
+  },
+
+  updateMediaDisplay: function() {
+
+  },
+
+  _updateMediaDisplay: function() {
+
+  }
+
+
+
 });
 
 
@@ -6260,58 +6260,58 @@ VCO.Media.Twitter = VCO.Media.extend({
      Begin VCO.Media.Vimeo.js
 ********************************************** */
 
-/*	VCO.Media.Vimeo
+/*  VCO.Media.Vimeo
 ================================================== */
 
 VCO.Media.Vimeo = VCO.Media.extend({
-	
-	includes: [VCO.Events],
-	
-	/*	Load the media
-	================================================== */
-	_loadMedia: function() {
-		var api_url,
-			self = this;
-		
-		// Loading Message
-		this.message.updateMessage(VCO.Language.messages.loading + " " + this.options.media_name);
-		
-		// Create Dom element
-		this._el.content_item	= VCO.Dom.create("div", "vco-media-item vco-media-iframe vco-media-vimeo vco-media-shadow", this._el.content);
-		
-		// Get Media ID
-		this.media_id = this.data.url.split(/video\/|\/\/vimeo\.com\//)[1].split(/[?&]/)[0];
-		
-		// API URL
-		api_url = "http://player.vimeo.com/video/" + this.media_id + "?api=1&title=0&amp;byline=0&amp;portrait=0&amp;color=ffffff";
-		
-		this.player = VCO.Dom.create("iframe", "", this._el.content_item);
-		this.player.width 		= "100%";
-		this.player.height 		= "100%";
-		this.player.frameBorder = "0";
-		this.player.src 		= api_url;
-		
-		// After Loaded
-		this.onLoaded();
-	},
-	
-	// Update Media Display
-	_updateMediaDisplay: function() {
-		this._el.content_item.style.height = VCO.Util.ratio.r16_9({w:this._el.content_item.offsetWidth}) + "px";
-		
-	},
-	
-	_stopMedia: function() {
-		
-		try {
-			this.player.contentWindow.postMessage(JSON.stringify({method: "pause"}), "http://player.vimeo.com");
-		}
-		catch(err) {
-			trace(err);
-		}
-		
-	}
-	
+
+  includes: [VCO.Events],
+
+  /*  Load the media
+  ================================================== */
+  _loadMedia: function() {
+    var api_url,
+      self = this;
+
+    // Loading Message
+    this.message.updateMessage(VCO.Language.messages.loading + " " + this.options.media_name);
+
+    // Create Dom element
+    this._el.content_item = VCO.Dom.create("div", "vco-media-item vco-media-iframe vco-media-vimeo vco-media-shadow", this._el.content);
+
+    // Get Media ID
+    this.media_id = this.data.url.split(/video\/|\/\/vimeo\.com\//)[1].split(/[?&]/)[0];
+
+    // API URL
+    api_url = "http://player.vimeo.com/video/" + this.media_id + "?api=1&title=0&amp;byline=0&amp;portrait=0&amp;color=ffffff";
+
+    this.player = VCO.Dom.create("iframe", "", this._el.content_item);
+    this.player.width     = "100%";
+    this.player.height    = "100%";
+    this.player.frameBorder = "0";
+    this.player.src     = api_url;
+
+    // After Loaded
+    this.onLoaded();
+  },
+
+  // Update Media Display
+  _updateMediaDisplay: function() {
+    this._el.content_item.style.height = VCO.Util.ratio.r16_9({w:this._el.content_item.offsetWidth}) + "px";
+
+  },
+
+  _stopMedia: function() {
+
+    try {
+      this.player.contentWindow.postMessage(JSON.stringify({method: "pause"}), "http://player.vimeo.com");
+    }
+    catch(err) {
+      trace(err);
+    }
+
+  }
+
 });
 
 
@@ -6319,47 +6319,47 @@ VCO.Media.Vimeo = VCO.Media.extend({
      Begin VCO.Media.DailyMotion.js
 ********************************************** */
 
-/*	VCO.Media.DailyMotion
+/*  VCO.Media.DailyMotion
 ================================================== */
 
 VCO.Media.DailyMotion = VCO.Media.extend({
-	
-	includes: [VCO.Events],
-	
-	/*	Load the media
-	================================================== */
-	_loadMedia: function() {
-		var api_url,
-			self = this;
-		
-		// Loading Message
-		this.message.updateMessage(VCO.Language.messages.loading + " " + this.options.media_name);
-		
-		// Create Dom element
-		this._el.content_item	= VCO.Dom.create("div", "vco-media-item vco-media-iframe vco-media-dailymotion", this._el.content);
-		
-		// Get Media ID
-		if (this.data.url.match("video")) {
-			this.media_id = this.data.url.split("video\/")[1].split(/[?&]/)[0];
-		} else {
-			this.media_id = this.data.url.split("embed\/")[1].split(/[?&]/)[0];
-		}
-		
-		// API URL
-		api_url = "http://www.dailymotion.com/embed/video/" + this.media_id;
-		
-		// API Call
-		this._el.content_item.innerHTML = "<iframe autostart='false' frameborder='0' width='100%' height='100%' src='" + api_url + "'></iframe>"		
-		
-		// After Loaded
-		this.onLoaded();
-	},
-	
-	// Update Media Display
-	_updateMediaDisplay: function() {
-		this._el.content_item.style.height = VCO.Util.ratio.r16_9({w:this._el.content_item.offsetWidth}) + "px";
-	}
-	
+
+  includes: [VCO.Events],
+
+  /*  Load the media
+  ================================================== */
+  _loadMedia: function() {
+    var api_url,
+      self = this;
+
+    // Loading Message
+    this.message.updateMessage(VCO.Language.messages.loading + " " + this.options.media_name);
+
+    // Create Dom element
+    this._el.content_item = VCO.Dom.create("div", "vco-media-item vco-media-iframe vco-media-dailymotion", this._el.content);
+
+    // Get Media ID
+    if (this.data.url.match("video")) {
+      this.media_id = this.data.url.split("video\/")[1].split(/[?&]/)[0];
+    } else {
+      this.media_id = this.data.url.split("embed\/")[1].split(/[?&]/)[0];
+    }
+
+    // API URL
+    api_url = "http://www.dailymotion.com/embed/video/" + this.media_id;
+
+    // API Call
+    this._el.content_item.innerHTML = "<iframe autostart='false' frameborder='0' width='100%' height='100%' src='" + api_url + "'></iframe>"
+
+    // After Loaded
+    this.onLoaded();
+  },
+
+  // Update Media Display
+  _updateMediaDisplay: function() {
+    this._el.content_item.style.height = VCO.Util.ratio.r16_9({w:this._el.content_item.offsetWidth}) + "px";
+  }
+
 });
 
 
@@ -6367,45 +6367,45 @@ VCO.Media.DailyMotion = VCO.Media.extend({
      Begin VCO.Media.Vine.js
 ********************************************** */
 
-/*	VCO.Media.Vine
+/*  VCO.Media.Vine
 
 ================================================== */
 
 VCO.Media.Vine = VCO.Media.extend({
-	
-	includes: [VCO.Events],
-	
-	/*	Load the media
-	================================================== */
-	_loadMedia: function() {
-		var api_url,
-			self = this;
-		
-		// Loading Message
-		this.message.updateMessage(VCO.Language.messages.loading + " " + this.options.media_name);
-		
-		// Create Dom element
-		this._el.content_item	= VCO.Dom.create("div", "vco-media-item vco-media-iframe vco-media-vine vco-media-shadow", this._el.content);
-		
-		// Get Media ID
-		this.media_id = this.data.url.split("vine.co/v/")[1];
-		
-		// API URL
-		api_url = "https://vine.co/v/" + this.media_id + "/embed/simple";
-		
-		// API Call
-		this._el.content_item.innerHTML = "<iframe frameborder='0' width='100%' height='100%' src='" + api_url + "'></iframe><script async src='http://platform.vine.co/static/scripts/embed.js' charset='utf-8'></script>"		
-		
-		// After Loaded
-		this.onLoaded();
-	},
-	
-	// Update Media Display
-	_updateMediaDisplay: function() {
-		var size = VCO.Util.ratio.square({w:this._el.content_item.offsetWidth , h:this.options.height});
-		this._el.content_item.style.height = size.h + "px";
-	}
-	
+
+  includes: [VCO.Events],
+
+  /*  Load the media
+  ================================================== */
+  _loadMedia: function() {
+    var api_url,
+      self = this;
+
+    // Loading Message
+    this.message.updateMessage(VCO.Language.messages.loading + " " + this.options.media_name);
+
+    // Create Dom element
+    this._el.content_item = VCO.Dom.create("div", "vco-media-item vco-media-iframe vco-media-vine vco-media-shadow", this._el.content);
+
+    // Get Media ID
+    this.media_id = this.data.url.split("vine.co/v/")[1];
+
+    // API URL
+    api_url = "https://vine.co/v/" + this.media_id + "/embed/simple";
+
+    // API Call
+    this._el.content_item.innerHTML = "<iframe frameborder='0' width='100%' height='100%' src='" + api_url + "'></iframe><script async src='http://platform.vine.co/static/scripts/embed.js' charset='utf-8'></script>"
+
+    // After Loaded
+    this.onLoaded();
+  },
+
+  // Update Media Display
+  _updateMediaDisplay: function() {
+    var size = VCO.Util.ratio.square({w:this._el.content_item.offsetWidth , h:this.options.height});
+    this._el.content_item.style.height = size.h + "px";
+  }
+
 });
 
 
@@ -6413,30 +6413,30 @@ VCO.Media.Vine = VCO.Media.extend({
      Begin VCO.Media.Website.js
 ********************************************** */
 
-/*	VCO.Media.Website
+/*  VCO.Media.Website
 ================================================== */
 
 VCO.Media.Website = VCO.Media.extend({
-	
-	includes: [VCO.Events],
-	
-	/*	Load the media
-	================================================== */
-	_loadMedia: function() {
-		
-		
-	},
-	
-	createMedia: function(d) {		
 
-		
-		// After Loaded
-		this.onLoaded();
-			
-	}
-	
-	
-	
+  includes: [VCO.Events],
+
+  /*  Load the media
+  ================================================== */
+  _loadMedia: function() {
+
+
+  },
+
+  createMedia: function(d) {
+
+
+    // After Loaded
+    this.onLoaded();
+
+  }
+
+
+
 });
 
 
@@ -6444,109 +6444,109 @@ VCO.Media.Website = VCO.Media.extend({
      Begin VCO.Media.Wikipedia.js
 ********************************************** */
 
-/*	VCO.Media.Wikipedia
+/*  VCO.Media.Wikipedia
 ================================================== */
 
 VCO.Media.Wikipedia = VCO.Media.extend({
-	
-	includes: [VCO.Events],
-	
-	/*	Load the media
-	================================================== */
-	_loadMedia: function() {
-		var api_url,
-			api_language,
-			self = this;
-		
-		// Loading Message
-		this.message.updateMessage(VCO.Language.messages.loading + " " + this.options.media_name);
-		
-		// Create Dom element
-		this._el.content_item	= VCO.Dom.create("div", "vco-media-item vco-media-wikipedia", this._el.content);
-		
-		// Get Media ID
-		this.media_id	 = this.data.url.split("wiki\/")[1].split("#")[0].replace("_", " ");
-		this.media_id	 = this.media_id.replace(" ", "%20");
-		api_language	 = this.data.url.split("//")[1].split(".wikipedia")[0];
-		
-		// API URL
-		api_url = "http://" + api_language + ".wikipedia.org/w/api.php?action=query&prop=extracts&redirects=&titles=" + this.media_id + "&exintro=1&format=json&callback=?";
-		
-		// API Call
-		
-		VCO.ajax({
-			type: 'GET',
-			url: api_url,
-			dataType: 'json', //json data type
-			
-			success: function(d){
-				self.createMedia(d);
-			},
-			error:function(xhr, type){
-				var error_text = "";
-				error_text += "Unable to load Wikipedia entry. <br/>" + self.media_id + "<br/>" + type;
-				self.loadErrorDisplay(error_text);
-			}
-		});
-		
-	},
-	
-	createMedia: function(d) {
-		var wiki = "";
-		
-		if (d.query) {
-			var content,
-				wiki = {
-					entry: {},
-					title: "",
-					text: "",
-					extract: "",
-					paragraphs: 1,
-					text_array: []
-				};
-			
-			wiki.entry		 = VCO.Util.getObjectAttributeByIndex(d.query.pages, 0);
-			wiki.extract	 = wiki.entry.extract;
-			wiki.title		 = wiki.entry.title;
-			
-			if (wiki.extract.match("<p>")) {
-				wiki.text_array = wiki.extract.split("<p>");
-			} else {
-				wiki.text_array.push(wiki.extract);
-			}
-			
-			for(var i = 0; i < wiki.text_array.length; i++) {
-				if (i+1 <= wiki.paragraphs && i+1 < wiki.text_array.length) {
-					wiki.text	+= "<p>" + wiki.text_array[i+1];
-				}
-			}
-			
-			content		=	"<h4><a href='" + this.data.url + "' target='_blank'>" + wiki.title + "</a></h4>";
-			content		+=	"<span class='wiki-source'>" + VCO.Language.messages.wikipedia + "</span>";
-			content		+=	wiki.text;
-			
-			if (wiki.extract.match("REDIRECT")) {
-			
-			} else {
-				// Add to DOM
-				this._el.content_item.innerHTML	= content;
-				// After Loaded
-				this.onLoaded();
-			}
-			
-			
-		}
-			
-	},
-	
-	updateMediaDisplay: function() {
-		
-	},
-	
-	_updateMediaDisplay: function() {
-		
-	}
-	
+
+  includes: [VCO.Events],
+
+  /*  Load the media
+  ================================================== */
+  _loadMedia: function() {
+    var api_url,
+      api_language,
+      self = this;
+
+    // Loading Message
+    this.message.updateMessage(VCO.Language.messages.loading + " " + this.options.media_name);
+
+    // Create Dom element
+    this._el.content_item = VCO.Dom.create("div", "vco-media-item vco-media-wikipedia", this._el.content);
+
+    // Get Media ID
+    this.media_id  = this.data.url.split("wiki\/")[1].split("#")[0].replace("_", " ");
+    this.media_id  = this.media_id.replace(" ", "%20");
+    api_language   = this.data.url.split("//")[1].split(".wikipedia")[0];
+
+    // API URL
+    api_url = "http://" + api_language + ".wikipedia.org/w/api.php?action=query&prop=extracts&redirects=&titles=" + this.media_id + "&exintro=1&format=json&callback=?";
+
+    // API Call
+
+    VCO.ajax({
+      type: 'GET',
+      url: api_url,
+      dataType: 'json', //json data type
+
+      success: function(d){
+        self.createMedia(d);
+      },
+      error:function(xhr, type){
+        var error_text = "";
+        error_text += "Unable to load Wikipedia entry. <br/>" + self.media_id + "<br/>" + type;
+        self.loadErrorDisplay(error_text);
+      }
+    });
+
+  },
+
+  createMedia: function(d) {
+    var wiki = "";
+
+    if (d.query) {
+      var content,
+        wiki = {
+          entry: {},
+          title: "",
+          text: "",
+          extract: "",
+          paragraphs: 1,
+          text_array: []
+        };
+
+      wiki.entry     = VCO.Util.getObjectAttributeByIndex(d.query.pages, 0);
+      wiki.extract   = wiki.entry.extract;
+      wiki.title     = wiki.entry.title;
+
+      if (wiki.extract.match("<p>")) {
+        wiki.text_array = wiki.extract.split("<p>");
+      } else {
+        wiki.text_array.push(wiki.extract);
+      }
+
+      for(var i = 0; i < wiki.text_array.length; i++) {
+        if (i+1 <= wiki.paragraphs && i+1 < wiki.text_array.length) {
+          wiki.text += "<p>" + wiki.text_array[i+1];
+        }
+      }
+
+      content   = "<h4><a href='" + this.data.url + "' target='_blank'>" + wiki.title + "</a></h4>";
+      content   +=  "<span class='wiki-source'>" + VCO.Language.messages.wikipedia + "</span>";
+      content   +=  wiki.text;
+
+      if (wiki.extract.match("REDIRECT")) {
+
+      } else {
+        // Add to DOM
+        this._el.content_item.innerHTML = content;
+        // After Loaded
+        this.onLoaded();
+      }
+
+
+    }
+
+  },
+
+  updateMediaDisplay: function() {
+
+  },
+
+  _updateMediaDisplay: function() {
+
+  }
+
 });
 
 
@@ -6554,158 +6554,158 @@ VCO.Media.Wikipedia = VCO.Media.extend({
      Begin VCO.Media.YouTube.js
 ********************************************** */
 
-/*	VCO.Media.YouTube
+/*  VCO.Media.YouTube
 ================================================== */
 
 VCO.Media.YouTube = VCO.Media.extend({
-	
-	includes: [VCO.Events],
-	
-	/*	Load the media
-	================================================== */
-	_loadMedia: function() {
-		var self = this,
-			url_vars;
-		
-		// Loading Message 
-		this.message.updateMessage(VCO.Language.messages.loading + " " + this.options.media_name);
-		
-		this.youtube_loaded = false;
-		
-		// Create Dom element
-		this._el.content_item	= VCO.Dom.create("div", "vco-media-item vco-media-youtube vco-media-shadow", this._el.content);
-		this._el.content_item.id = VCO.Util.unique_ID(7)
-		
-		// URL Vars
-		url_vars = VCO.Util.getUrlVars(this.data.url);
-		
-		// Get Media ID
-		this.media_id = {};
-		
-		if (this.data.url.match('v=')) {
-			this.media_id.id	= url_vars["v"];
-		} else if (this.data.url.match('\/embed\/')) {
-			this.media_id.id	= this.data.url.split("embed\/")[1].split(/[?&]/)[0];
-		} else if (this.data.url.match(/v\/|v=|youtu\.be\//)){
-			this.media_id.id	= this.data.url.split(/v\/|v=|youtu\.be\//)[1].split(/[?&]/)[0];
-		} else {
-			trace("YOUTUBE IN URL BUT NOT A VALID VIDEO");
-		}
-		
-		this.media_id.start		= url_vars["t"];
-		this.media_id.hd		= url_vars["hd"];
-		
-		
-		// API Call
-		VCO.Load.js('https://www.youtube.com/player_api', function() {
-			self.createMedia();
-		});
-		
-	},
-	
-	// Update Media Display
-	_updateMediaDisplay: function() {
-		this._el.content_item.style.height = VCO.Util.ratio.r16_9({w:this._el.content_item.offsetWidth}) + "px";
-	},
-	
-	_stopMedia: function() {
-		if (this.youtube_loaded) {
-			try {
-				this.player.pauseVideo();
-			}
-			catch(err) {
-				trace(err);
-			}
-			
-		}
-	},
-	
-	createMedia: function() {
-		var self = this;
-		
-		// Determine Start of Media
-		if (typeof(this.media_id.start) != 'undefined') {
-			
-			var vidstart			= this.media_id.start.toString(),
-				vid_start_minutes	= 0,
-				vid_start_seconds	= 0;
-				
-			if (vidstart.match('m')) {
-				vid_start_minutes = parseInt(vidstart.split("m")[0], 10);
-				vid_start_seconds = parseInt(vidstart.split("m")[1].split("s")[0], 10);
-				this.media_id.start = (vid_start_minutes * 60) + vid_start_seconds;
-			} else {
-				this.media_id.start = 0;
-			}
-		} else {
-			this.media_id.start = 0;
-		}
-		
-		// Determine HD
-		if (typeof(this.media_id.hd) != 'undefined') {
-			this.media_id.hd = true;
-		} else {
-			this.media_id.hd = false;
-		}
-		
-		this.createPlayer();
-		
-			
-	},
-	
-	createPlayer: function() {
-		var self = this;
-		
-		clearTimeout(this.timer);
-		
-		if(typeof YT != 'undefined' && typeof YT.Player != 'undefined') {
-			// Create Player
-			this.player = new YT.Player(this._el.content_item.id, {
-				playerVars: {
-					enablejsapi:		1,
-					color: 				'white',
-					autohide: 			1,
-					showinfo:			0,
-					theme:				'light',
-					start:				this.media_id.start,
-					fs: 				0,
-					rel:				0
-				},
-				videoId: this.media_id.id,
-				events: {
-					onReady: 			function() {
-						self.onPlayerReady();
-						// After Loaded
-						//self.onLoaded();
-					},
-					'onStateChange': 	self.onStateChange
-				}
-			});
-		} else {
-			this.timer = setTimeout(function() {
-				self.createPlayer();
-			}, 1000);
-		}
-		
-		this.onLoaded();
-		
-	},
-	
-	/*	Events
-	================================================== */
-	onPlayerReady: function(e) {
-		
-		this.youtube_loaded = true;
-		this._el.content_item = document.getElementById(this._el.content_item.id);
-		this.onMediaLoaded();
-		this.onLoaded();
-	},
-	
-	onStateChange: function(e) {
-		
-	}
 
-	
+  includes: [VCO.Events],
+
+  /*  Load the media
+  ================================================== */
+  _loadMedia: function() {
+    var self = this,
+      url_vars;
+
+    // Loading Message
+    this.message.updateMessage(VCO.Language.messages.loading + " " + this.options.media_name);
+
+    this.youtube_loaded = false;
+
+    // Create Dom element
+    this._el.content_item = VCO.Dom.create("div", "vco-media-item vco-media-youtube vco-media-shadow", this._el.content);
+    this._el.content_item.id = VCO.Util.unique_ID(7)
+
+    // URL Vars
+    url_vars = VCO.Util.getUrlVars(this.data.url);
+
+    // Get Media ID
+    this.media_id = {};
+
+    if (this.data.url.match('v=')) {
+      this.media_id.id  = url_vars["v"];
+    } else if (this.data.url.match('\/embed\/')) {
+      this.media_id.id  = this.data.url.split("embed\/")[1].split(/[?&]/)[0];
+    } else if (this.data.url.match(/v\/|v=|youtu\.be\//)){
+      this.media_id.id  = this.data.url.split(/v\/|v=|youtu\.be\//)[1].split(/[?&]/)[0];
+    } else {
+      trace("YOUTUBE IN URL BUT NOT A VALID VIDEO");
+    }
+
+    this.media_id.start   = url_vars["t"];
+    this.media_id.hd    = url_vars["hd"];
+
+
+    // API Call
+    VCO.Load.js('https://www.youtube.com/player_api', function() {
+      self.createMedia();
+    });
+
+  },
+
+  // Update Media Display
+  _updateMediaDisplay: function() {
+    this._el.content_item.style.height = VCO.Util.ratio.r16_9({w:this._el.content_item.offsetWidth}) + "px";
+  },
+
+  _stopMedia: function() {
+    if (this.youtube_loaded) {
+      try {
+        this.player.pauseVideo();
+      }
+      catch(err) {
+        trace(err);
+      }
+
+    }
+  },
+
+  createMedia: function() {
+    var self = this;
+
+    // Determine Start of Media
+    if (typeof(this.media_id.start) != 'undefined') {
+
+      var vidstart      = this.media_id.start.toString(),
+        vid_start_minutes = 0,
+        vid_start_seconds = 0;
+
+      if (vidstart.match('m')) {
+        vid_start_minutes = parseInt(vidstart.split("m")[0], 10);
+        vid_start_seconds = parseInt(vidstart.split("m")[1].split("s")[0], 10);
+        this.media_id.start = (vid_start_minutes * 60) + vid_start_seconds;
+      } else {
+        this.media_id.start = 0;
+      }
+    } else {
+      this.media_id.start = 0;
+    }
+
+    // Determine HD
+    if (typeof(this.media_id.hd) != 'undefined') {
+      this.media_id.hd = true;
+    } else {
+      this.media_id.hd = false;
+    }
+
+    this.createPlayer();
+
+
+  },
+
+  createPlayer: function() {
+    var self = this;
+
+    clearTimeout(this.timer);
+
+    if(typeof YT != 'undefined' && typeof YT.Player != 'undefined') {
+      // Create Player
+      this.player = new YT.Player(this._el.content_item.id, {
+        playerVars: {
+          enablejsapi:    1,
+          color:        'white',
+          autohide:       1,
+          showinfo:     0,
+          theme:        'light',
+          start:        this.media_id.start,
+          fs:         0,
+          rel:        0
+        },
+        videoId: this.media_id.id,
+        events: {
+          onReady:      function() {
+            self.onPlayerReady();
+            // After Loaded
+            //self.onLoaded();
+          },
+          'onStateChange':  self.onStateChange
+        }
+      });
+    } else {
+      this.timer = setTimeout(function() {
+        self.createPlayer();
+      }, 1000);
+    }
+
+    this.onLoaded();
+
+  },
+
+  /*  Events
+  ================================================== */
+  onPlayerReady: function(e) {
+
+    this.youtube_loaded = true;
+    this._el.content_item = document.getElementById(this._el.content_item.id);
+    this.onMediaLoaded();
+    this.onLoaded();
+  },
+
+  onStateChange: function(e) {
+
+  }
+
+
 });
 
 
@@ -6713,347 +6713,347 @@ VCO.Media.YouTube = VCO.Media.extend({
      Begin VCO.Media.Slider.js
 ********************************************** */
 
-/*	VCO.Media.SLider
-	Produces a Slider
-	Takes a data object and populates a dom object
-	TODO
-	Placeholder
+/*  VCO.Media.SLider
+  Produces a Slider
+  Takes a data object and populates a dom object
+  TODO
+  Placeholder
 ================================================== */
 
 VCO.Media.Slider = VCO.Media.extend({
-	
-	includes: [VCO.Events],
-	
-	/*	Load the media
-	================================================== */
-	_loadMedia: function() {
-		
-		this._el.content_item				= VCO.Dom.create("img", "vco-media-item vco-media-image", this._el.content);
-		this._el.content_item.src			= this.data.url;
-		
-		this.onLoaded();
-	}
-	
+
+  includes: [VCO.Events],
+
+  /*  Load the media
+  ================================================== */
+  _loadMedia: function() {
+
+    this._el.content_item       = VCO.Dom.create("img", "vco-media-item vco-media-image", this._el.content);
+    this._el.content_item.src     = this.data.url;
+
+    this.onLoaded();
+  }
+
 });
 
 /* **********************************************
      Begin VCO.Slide.js
 ********************************************** */
 
-/*	VCO.Slide
-	Creates a slide. Takes a data object and
-	populates the slide with content.
+/*  VCO.Slide
+  Creates a slide. Takes a data object and
+  populates the slide with content.
 ================================================== */
 
 VCO.Slide = VCO.Class.extend({
-	
-	includes: [VCO.Events, VCO.DomMixins],
-	
-	_el: {},
-	
-	/*	Constructor
-	================================================== */
-	initialize: function(data, options, title_slide) {
-		
-		// DOM Elements
-		this._el = {
-			container: {},
-			scroll_container: {},
-			background: {},
-			content_container: {},
-			content: {},
-			call_to_action: null
-		};
-	
-		// Components
-		this._media 		= null;
-		this._mediaclass	= {};
-		this._text			= {};
-	
-		// State
-		this._state = {
-			loaded: 		false
-		};
-		
-		this.has = {
-			headline: 	false,
-			text: 		false,
-			media: 		false,
-			title: 		false,
-			background: {
-				image: false,
-				color: false,
-				color_value :""
-			}
-		}
-		
-		this.has.title = title_slide;
-		
-		this.title = "";
-		
-		// Data
-		this.data = {
-			uniqueid: 				null,
-			background: 			null,
-			date: 					null,
-			location: 				null,
-			text: 					null,
-			media: 					null
-		};
-	
-		// Options
-		this.options = {
-			// animation
-			duration: 			1000,
-			slide_padding_lr: 	40,
-			ease: 				VCO.Ease.easeInSpline,
-			width: 				600,
-			height: 			600,
-			skinny_size: 		650,
-			media_name: 		""
-		};
-		
-		// Actively Displaying
-		this.active = false;
-		
-		// Animation Object
-		this.animator = {};
-		
-		// Merge Data and Options
-		VCO.Util.mergeData(this.options, options);
-		VCO.Util.mergeData(this.data, data);
-		
-		this._initLayout();
-		this._initEvents();
-		
-		
-	},
-	
-	/*	Adding, Hiding, Showing etc
-	================================================== */
-	show: function() {
-		this.animator = VCO.Animate(this._el.slider_container, {
-			left: 		-(this._el.container.offsetWidth * n) + "px",
-			duration: 	this.options.duration,
-			easing: 	this.options.ease
-		});
-	},
-	
-	hide: function() {
-		
-	},
-	
-	setActive: function(is_active) {
-		this.active = is_active;
-		
-		if (this.active) {
-			if (this.data.background) {
-				this.fire("background_change", this.has.background);
-			}
-			this.loadMedia();
-		} else {
-			this.stopMedia();
-		}
-	},
-	
-	addTo: function(container) {
-		container.appendChild(this._el.container);
-		//this.onAdd();
-	},
-	
-	removeFrom: function(container) {
-		container.removeChild(this._el.container);
-	},
-	
-	updateDisplay: function(w, h, l) {
-		this._updateDisplay(w, h, l);
-	},
-	
-	loadMedia: function() {
-		
-		if (this._media && !this._state.loaded) {
-			this._media.loadMedia();
-			this._state.loaded = true;
-		}
-	},
-	
-	stopMedia: function() {
-		if (this._media && this._state.loaded) {
-			this._media.stopMedia();
-		}
-	},
-	
-	getBackground: function() {
-		return this.has.background;
-	},
-	
-	scrollToTop: function() {
-		this._el.container.scrollTop = 0;
-	},
-	
-	addCallToAction: function(str) {
-		this._el.call_to_action = VCO.Dom.create("div", "vco-slide-calltoaction", this._el.content_container);
-		this._el.call_to_action.innerHTML = "<span class='vco-slide-calltoaction-button-text'>" + str + "</span>";
-		VCO.DomEvent.addListener(this._el.call_to_action, 'click', this._onCallToAction, this);
-	},
-	
-	/*	Events
-	================================================== */
-	_onCallToAction: function(e) {
-		this.fire("call_to_action", e);
-	},
-	
-	/*	Private Methods
-	================================================== */
-	_initLayout: function () {
-		
-		// Create Layout
-		this._el.container 				= VCO.Dom.create("div", "vco-slide");
-		if (this.data.uniqueid) {
-			this._el.container.id 		= this.data.uniqueid;
-		}
-		this._el.scroll_container 		= VCO.Dom.create("div", "vco-slide-scrollable-container", this._el.container);
-		this._el.content_container		= VCO.Dom.create("div", "vco-slide-content-container", this._el.scroll_container);
-		this._el.content				= VCO.Dom.create("div", "vco-slide-content", this._el.content_container);
-		this._el.background				= VCO.Dom.create("div", "vco-slide-background", this._el.container);
-		// Style Slide Background
-		if (this.data.background) {
-			if (this.data.background.url) {
-				this.has.background.image 					= true;
-				this._el.container.className 				+= ' vco-full-image-background';
-				//this._el.container.style.backgroundImage="url('" + this.data.background.url + "')";
-				this.has.background.color_value 			= "#000";
-				this._el.background.style.backgroundImage 	= "url('" + this.data.background.url + "')";
-				this._el.background.style.display 			= "block";
-			}
-			if (this.data.background.color) {
-				this.has.background.color 					= true;
-				this._el.container.className 				+= ' vco-full-color-background';
-				this.has.background.color_value 			= this.data.background.color;
-				//this._el.container.style.backgroundColor = this.data.background.color;
-				//this._el.background.style.backgroundColor 	= this.data.background.color;
-				//this._el.background.style.display 			= "block";
-			}
-			if (this.data.background.text_background) {
-				this._el.container.className 				+= ' vco-text-background';
-			}
-			
-		} 
-		
-		
-		
-		// Determine Assets for layout and loading
-		if (this.data.media && this.data.media.url && this.data.media.url != "") {
-			this.has.media = true;
-		}
-		if (this.data.text && this.data.text.text) {
-			this.has.text = true;
-		}
-		if (this.data.text && this.data.text.headline) {
-			this.has.headline = true;
-			this.title = this.data.text.headline;
-		}
-		
-		// Create Media
-		if (this.has.media) {
-			
-			// Determine the media type
-			this.data.media.mediatype 	= VCO.MediaType(this.data.media);
-			this.options.media_name 	= this.data.media.mediatype.name;
-			this.options.media_type 	= this.data.media.mediatype.type;
-			
-			// Create a media object using the matched class name
-			this._media = new this.data.media.mediatype.cls(this.data.media, this.options);
-			
-		}
-		
-		// Create Text
-		if (this.has.text || this.has.headline) {
-			this._text = new VCO.Media.Text(this.data.text, {title:this.has.title});
-		}
-		
-		// Add to DOM
-		if (!this.has.text && !this.has.headline && this.has.media) {
-			this._el.container.className += ' vco-slide-media-only';
-			this._media.addTo(this._el.content);
-		} else if (this.has.headline && this.has.media && !this.has.text) {
-			this._el.container.className += ' vco-slide-media-only';
-			this._text.addTo(this._el.content);
-			this._media.addTo(this._el.content);
-		} else if (this.has.text && this.has.media) {
-			this._media.addTo(this._el.content);
-			this._text.addTo(this._el.content);
-		} else if (this.has.text || this.has.headline) {
-			this._el.container.className += ' vco-slide-text-only';
-			this._text.addTo(this._el.content);
-		}
-		
-		// Fire event that the slide is loaded
-		this.onLoaded();
-		
-	},
-	
-	_initEvents: function() {
-		
-	},
-	
-	// Update Display
-	_updateDisplay: function(width, height, layout) {
-		var pad_left, pad_right, new_width;
-		
-		if (width) {
-			this.options.width 					= width;
-		} else {
-			this.options.width 					= this._el.container.offsetWidth;
-		}
-		
-		if(VCO.Browser.mobile && (this.options.width <= this.options.skinny_size)) {
-			pad_left 	= 0 + "px";
-			pad_right 	= 0 + "px";
-			new_width	= this.options.width - 0 + "px";
-		} else if (layout == "landscape") {
-			pad_left 	= 40 + "px";
-			pad_right	= 75 + "px";
-			new_width	= this.options.width - (75 + 40) + "px";
-		
-		} else if (this.options.width <= this.options.skinny_size) {
-			pad_left 	= this.options.slide_padding_lr + "px";
-			pad_right 	= this.options.slide_padding_lr + "px";
-			new_width	= this.options.width - (this.options.slide_padding_lr * 2) + "px";
-		} else {
-			pad_left	= this.options.slide_padding_lr + "px";
-			pad_right 	= this.options.slide_padding_lr + "px";
-			new_width	= this.options.width - (this.options.slide_padding_lr * 2) + "px";
-		}
-		
-		this._el.content.style.paddingLeft 	= pad_left;
-		this._el.content.style.paddingRight = pad_right;
-		this._el.content.style.width		= new_width;
-		
-		if (this._el.call_to_action) {
-			this._el.call_to_action.style.paddingLeft 	= pad_left;
-			this._el.call_to_action.style.paddingRight = pad_right;
-			this._el.call_to_action.style.width		= new_width;
-		}
-		
-		if (height) {
-			this.options.height = height;
-			//this._el.scroll_container.style.height		= this.options.height + "px";
-			
-		} else {
-			this.options.height = this._el.container.offsetHeight;
-		}
-		
-		if (this._media) {
-			if (!this.has.text && this.has.headline) {
-				this._media.updateDisplay(this.options.width, (this.options.height - this._text.headlineHeight()), layout);
-			} else {
-				this._media.updateDisplay(this.options.width, this.options.height, layout);
-			}
-		}
-		
-	}
-	
+
+  includes: [VCO.Events, VCO.DomMixins],
+
+  _el: {},
+
+  /*  Constructor
+  ================================================== */
+  initialize: function(data, options, title_slide) {
+
+    // DOM Elements
+    this._el = {
+      container: {},
+      scroll_container: {},
+      background: {},
+      content_container: {},
+      content: {},
+      call_to_action: null
+    };
+
+    // Components
+    this._media     = null;
+    this._mediaclass  = {};
+    this._text      = {};
+
+    // State
+    this._state = {
+      loaded:     false
+    };
+
+    this.has = {
+      headline:   false,
+      text:     false,
+      media:    false,
+      title:    false,
+      background: {
+        image: false,
+        color: false,
+        color_value :""
+      }
+    }
+
+    this.has.title = title_slide;
+
+    this.title = "";
+
+    // Data
+    this.data = {
+      uniqueid:         null,
+      background:       null,
+      date:           null,
+      location:         null,
+      text:           null,
+      media:          null
+    };
+
+    // Options
+    this.options = {
+      // animation
+      duration:       1000,
+      slide_padding_lr:   40,
+      ease:         VCO.Ease.easeInSpline,
+      width:        600,
+      height:       600,
+      skinny_size:    650,
+      media_name:     ""
+    };
+
+    // Actively Displaying
+    this.active = false;
+
+    // Animation Object
+    this.animator = {};
+
+    // Merge Data and Options
+    VCO.Util.mergeData(this.options, options);
+    VCO.Util.mergeData(this.data, data);
+
+    this._initLayout();
+    this._initEvents();
+
+
+  },
+
+  /*  Adding, Hiding, Showing etc
+  ================================================== */
+  show: function() {
+    this.animator = VCO.Animate(this._el.slider_container, {
+      left:     -(this._el.container.offsetWidth * n) + "px",
+      duration:   this.options.duration,
+      easing:   this.options.ease
+    });
+  },
+
+  hide: function() {
+
+  },
+
+  setActive: function(is_active) {
+    this.active = is_active;
+
+    if (this.active) {
+      if (this.data.background) {
+        this.fire("background_change", this.has.background);
+      }
+      this.loadMedia();
+    } else {
+      this.stopMedia();
+    }
+  },
+
+  addTo: function(container) {
+    container.appendChild(this._el.container);
+    //this.onAdd();
+  },
+
+  removeFrom: function(container) {
+    container.removeChild(this._el.container);
+  },
+
+  updateDisplay: function(w, h, l) {
+    this._updateDisplay(w, h, l);
+  },
+
+  loadMedia: function() {
+
+    if (this._media && !this._state.loaded) {
+      this._media.loadMedia();
+      this._state.loaded = true;
+    }
+  },
+
+  stopMedia: function() {
+    if (this._media && this._state.loaded) {
+      this._media.stopMedia();
+    }
+  },
+
+  getBackground: function() {
+    return this.has.background;
+  },
+
+  scrollToTop: function() {
+    this._el.container.scrollTop = 0;
+  },
+
+  addCallToAction: function(str) {
+    this._el.call_to_action = VCO.Dom.create("div", "vco-slide-calltoaction", this._el.content_container);
+    this._el.call_to_action.innerHTML = "<span class='vco-slide-calltoaction-button-text'>" + str + "</span>";
+    VCO.DomEvent.addListener(this._el.call_to_action, 'click', this._onCallToAction, this);
+  },
+
+  /*  Events
+  ================================================== */
+  _onCallToAction: function(e) {
+    this.fire("call_to_action", e);
+  },
+
+  /*  Private Methods
+  ================================================== */
+  _initLayout: function () {
+
+    // Create Layout
+    this._el.container        = VCO.Dom.create("div", "vco-slide");
+    if (this.data.uniqueid) {
+      this._el.container.id     = this.data.uniqueid;
+    }
+    this._el.scroll_container     = VCO.Dom.create("div", "vco-slide-scrollable-container", this._el.container);
+    this._el.content_container    = VCO.Dom.create("div", "vco-slide-content-container", this._el.scroll_container);
+    this._el.content        = VCO.Dom.create("div", "vco-slide-content", this._el.content_container);
+    this._el.background       = VCO.Dom.create("div", "vco-slide-background", this._el.container);
+    // Style Slide Background
+    if (this.data.background) {
+      if (this.data.background.url) {
+        this.has.background.image           = true;
+        this._el.container.className        += ' vco-full-image-background';
+        //this._el.container.style.backgroundImage="url('" + this.data.background.url + "')";
+        this.has.background.color_value       = "#000";
+        this._el.background.style.backgroundImage   = "url('" + this.data.background.url + "')";
+        this._el.background.style.display       = "block";
+      }
+      if (this.data.background.color) {
+        this.has.background.color           = true;
+        this._el.container.className        += ' vco-full-color-background';
+        this.has.background.color_value       = this.data.background.color;
+        //this._el.container.style.backgroundColor = this.data.background.color;
+        //this._el.background.style.backgroundColor   = this.data.background.color;
+        //this._el.background.style.display       = "block";
+      }
+      if (this.data.background.text_background) {
+        this._el.container.className        += ' vco-text-background';
+      }
+
+    }
+
+
+
+    // Determine Assets for layout and loading
+    if (this.data.media && this.data.media.url && this.data.media.url != "") {
+      this.has.media = true;
+    }
+    if (this.data.text && this.data.text.text) {
+      this.has.text = true;
+    }
+    if (this.data.text && this.data.text.headline) {
+      this.has.headline = true;
+      this.title = this.data.text.headline;
+    }
+
+    // Create Media
+    if (this.has.media) {
+
+      // Determine the media type
+      this.data.media.mediatype   = VCO.MediaType(this.data.media);
+      this.options.media_name   = this.data.media.mediatype.name;
+      this.options.media_type   = this.data.media.mediatype.type;
+
+      // Create a media object using the matched class name
+      this._media = new this.data.media.mediatype.cls(this.data.media, this.options);
+
+    }
+
+    // Create Text
+    if (this.has.text || this.has.headline) {
+      this._text = new VCO.Media.Text(this.data.text, {title:this.has.title});
+    }
+
+    // Add to DOM
+    if (!this.has.text && !this.has.headline && this.has.media) {
+      this._el.container.className += ' vco-slide-media-only';
+      this._media.addTo(this._el.content);
+    } else if (this.has.headline && this.has.media && !this.has.text) {
+      this._el.container.className += ' vco-slide-media-only';
+      this._text.addTo(this._el.content);
+      this._media.addTo(this._el.content);
+    } else if (this.has.text && this.has.media) {
+      this._media.addTo(this._el.content);
+      this._text.addTo(this._el.content);
+    } else if (this.has.text || this.has.headline) {
+      this._el.container.className += ' vco-slide-text-only';
+      this._text.addTo(this._el.content);
+    }
+
+    // Fire event that the slide is loaded
+    this.onLoaded();
+
+  },
+
+  _initEvents: function() {
+
+  },
+
+  // Update Display
+  _updateDisplay: function(width, height, layout) {
+    var pad_left, pad_right, new_width;
+
+    if (width) {
+      this.options.width          = width;
+    } else {
+      this.options.width          = this._el.container.offsetWidth;
+    }
+
+    if(VCO.Browser.mobile && (this.options.width <= this.options.skinny_size)) {
+      pad_left  = 0 + "px";
+      pad_right   = 0 + "px";
+      new_width = this.options.width - 0 + "px";
+    } else if (layout == "landscape") {
+      pad_left  = 40 + "px";
+      pad_right = 75 + "px";
+      new_width = this.options.width - (75 + 40) + "px";
+
+    } else if (this.options.width <= this.options.skinny_size) {
+      pad_left  = this.options.slide_padding_lr + "px";
+      pad_right   = this.options.slide_padding_lr + "px";
+      new_width = this.options.width - (this.options.slide_padding_lr * 2) + "px";
+    } else {
+      pad_left  = this.options.slide_padding_lr + "px";
+      pad_right   = this.options.slide_padding_lr + "px";
+      new_width = this.options.width - (this.options.slide_padding_lr * 2) + "px";
+    }
+
+    this._el.content.style.paddingLeft  = pad_left;
+    this._el.content.style.paddingRight = pad_right;
+    this._el.content.style.width    = new_width;
+
+    if (this._el.call_to_action) {
+      this._el.call_to_action.style.paddingLeft   = pad_left;
+      this._el.call_to_action.style.paddingRight = pad_right;
+      this._el.call_to_action.style.width   = new_width;
+    }
+
+    if (height) {
+      this.options.height = height;
+      //this._el.scroll_container.style.height    = this.options.height + "px";
+
+    } else {
+      this.options.height = this._el.container.offsetHeight;
+    }
+
+    if (this._media) {
+      if (!this.has.text && this.has.headline) {
+        this._media.updateDisplay(this.options.width, (this.options.height - this._text.headlineHeight()), layout);
+      } else {
+        this._media.updateDisplay(this.options.width, this.options.height, layout);
+      }
+    }
+
+  }
+
 });
 
 
@@ -7061,826 +7061,826 @@ VCO.Slide = VCO.Class.extend({
      Begin VCO.SlideNav.js
 ********************************************** */
 
-/*	VCO.SlideNav
-	Navigation for Slideshows
+/*  VCO.SlideNav
+  Navigation for Slideshows
 ================================================== */
 // TODO null out data
 
 VCO.SlideNav = VCO.Class.extend({
-	
-	includes: [VCO.Events, VCO.DomMixins],
-	
-	_el: {},
-	
-	/*	Constructor
-	================================================== */
-	initialize: function(data, options, add_to_container) {
-		// DOM ELEMENTS
-		this._el = {
-			container: {},
-			content_container: {},
-			icon: {},
-			title: {},
-			description: {}
-		};
-	
-		// Media Type
-		this.mediatype = {};
-		
-		// Data
-		this.data = {
-			title: "Navigation",
-			description: "Description"
-		};
-	
-		//Options
-		this.options = {
-			direction: 			"previous"
-		};
-	
-		this.animator = null;
-		this.animator_position = null;
-		
-		// Merge Data and Options
-		VCO.Util.mergeData(this.options, options);
-		VCO.Util.mergeData(this.data, data);
-		
-		
-		this._el.container = VCO.Dom.create("div", "vco-slidenav-" + this.options.direction);
-		
-		if (VCO.Browser.mobile) {
-			this._el.container.setAttribute("ontouchstart"," ");
-		}
-		
-		this._initLayout();
-		this._initEvents();
-		
-		if (add_to_container) {
-			add_to_container.appendChild(this._el.container);
-		};
-		
-	},
-	
-	/*	Update Content
-	================================================== */
-	update: function(d) {
-		this._update(d);
-	},
-	
-	/*	Color
-	================================================== */
-	setColor: function(inverted) {
-		if (inverted) {
-			this._el.content_container.className = 'vco-slidenav-content-container vco-slidenav-inverted';
-		} else {
-			this._el.content_container.className = 'vco-slidenav-content-container';
-		}
-	},
-	
-	/*	Position
-	================================================== */
-	updatePosition: function(pos, use_percent, duration, ease, start_value, return_to_default) {
-		var self = this,
-			ani = {
-				duration: 	duration,
-				easing: 	ease,
-				complete: function() {
-					self._onUpdatePositionComplete(return_to_default);
-				}
-			};
-		var _start_value = start_value;
-		
-		for (var name in pos) {
-			if (pos.hasOwnProperty(name)) {
-				if (use_percent) {
-					ani[name] = pos[name] + "%";
-				} else {
-					ani[name] = pos[name] + "px";
-				}
-			
-			}
-		}
-		
-		if (this.animator_position) {
-			this.animator_position.stop();
-		}
-		
-		var prop_to_set;
-		if (ani.right) {
-			prop_to_set = "right";
-		} else {
-			prop_to_set = "left";
-		}
-		if (use_percent) {
-			this._el.container.style[prop_to_set] = _start_value + "%";
-		} else {
-			this._el.container.style[prop_to_set] = _start_value + "px";
-		}
-		
-		this.animator_position = VCO.Animate(this._el.container, ani);
 
-	},
-	
-	_onUpdatePositionComplete: function(return_to_default) {
-		if (return_to_default) {
-			this._el.container.style.left = "";
-			this._el.container.style.right = "";
-		}
-	},
-	
-	/*	Events
-	================================================== */
-	_onMouseClick: function() {
-		this.fire("clicked", this.options);
-	},
-	
-	/*	Private Methods
-	================================================== */
-	_update: function(d) {
-		// update data
-		this.data = VCO.Util.mergeData(this.data, d);
-		
-		// Title
-		if (this.data.title != "") {
-			this._el.title.innerHTML		= this.data.title;
-		}
-		
-		// Date
-		if (this.data.date != "") {
-			this._el.description.innerHTML	= this.data.description;
-		}
-	},
-	
-	_initLayout: function () {
-		
-		// Create Layout
-		this._el.content_container			= VCO.Dom.create("div", "vco-slidenav-content-container", this._el.container);
-		this._el.icon						= VCO.Dom.create("div", "vco-slidenav-icon", this._el.content_container);
-		this._el.title						= VCO.Dom.create("div", "vco-slidenav-title", this._el.content_container);
-		this._el.description				= VCO.Dom.create("div", "vco-slidenav-description", this._el.content_container);
-		
-		this._el.icon.innerHTML				= "&nbsp;"
-		
-		this._update();
-	},
-	
-	_initEvents: function () {
-		VCO.DomEvent.addListener(this._el.container, 'click', this._onMouseClick, this);
-	}
-	
-	
+  includes: [VCO.Events, VCO.DomMixins],
+
+  _el: {},
+
+  /*  Constructor
+  ================================================== */
+  initialize: function(data, options, add_to_container) {
+    // DOM ELEMENTS
+    this._el = {
+      container: {},
+      content_container: {},
+      icon: {},
+      title: {},
+      description: {}
+    };
+
+    // Media Type
+    this.mediatype = {};
+
+    // Data
+    this.data = {
+      title: "Navigation",
+      description: "Description"
+    };
+
+    //Options
+    this.options = {
+      direction:      "previous"
+    };
+
+    this.animator = null;
+    this.animator_position = null;
+
+    // Merge Data and Options
+    VCO.Util.mergeData(this.options, options);
+    VCO.Util.mergeData(this.data, data);
+
+
+    this._el.container = VCO.Dom.create("div", "vco-slidenav-" + this.options.direction);
+
+    if (VCO.Browser.mobile) {
+      this._el.container.setAttribute("ontouchstart"," ");
+    }
+
+    this._initLayout();
+    this._initEvents();
+
+    if (add_to_container) {
+      add_to_container.appendChild(this._el.container);
+    };
+
+  },
+
+  /*  Update Content
+  ================================================== */
+  update: function(d) {
+    this._update(d);
+  },
+
+  /*  Color
+  ================================================== */
+  setColor: function(inverted) {
+    if (inverted) {
+      this._el.content_container.className = 'vco-slidenav-content-container vco-slidenav-inverted';
+    } else {
+      this._el.content_container.className = 'vco-slidenav-content-container';
+    }
+  },
+
+  /*  Position
+  ================================================== */
+  updatePosition: function(pos, use_percent, duration, ease, start_value, return_to_default) {
+    var self = this,
+      ani = {
+        duration:   duration,
+        easing:   ease,
+        complete: function() {
+          self._onUpdatePositionComplete(return_to_default);
+        }
+      };
+    var _start_value = start_value;
+
+    for (var name in pos) {
+      if (pos.hasOwnProperty(name)) {
+        if (use_percent) {
+          ani[name] = pos[name] + "%";
+        } else {
+          ani[name] = pos[name] + "px";
+        }
+
+      }
+    }
+
+    if (this.animator_position) {
+      this.animator_position.stop();
+    }
+
+    var prop_to_set;
+    if (ani.right) {
+      prop_to_set = "right";
+    } else {
+      prop_to_set = "left";
+    }
+    if (use_percent) {
+      this._el.container.style[prop_to_set] = _start_value + "%";
+    } else {
+      this._el.container.style[prop_to_set] = _start_value + "px";
+    }
+
+    this.animator_position = VCO.Animate(this._el.container, ani);
+
+  },
+
+  _onUpdatePositionComplete: function(return_to_default) {
+    if (return_to_default) {
+      this._el.container.style.left = "";
+      this._el.container.style.right = "";
+    }
+  },
+
+  /*  Events
+  ================================================== */
+  _onMouseClick: function() {
+    this.fire("clicked", this.options);
+  },
+
+  /*  Private Methods
+  ================================================== */
+  _update: function(d) {
+    // update data
+    this.data = VCO.Util.mergeData(this.data, d);
+
+    // Title
+    if (this.data.title != "") {
+      this._el.title.innerHTML    = this.data.title;
+    }
+
+    // Date
+    if (this.data.date != "") {
+      this._el.description.innerHTML  = this.data.description;
+    }
+  },
+
+  _initLayout: function () {
+
+    // Create Layout
+    this._el.content_container      = VCO.Dom.create("div", "vco-slidenav-content-container", this._el.container);
+    this._el.icon           = VCO.Dom.create("div", "vco-slidenav-icon", this._el.content_container);
+    this._el.title            = VCO.Dom.create("div", "vco-slidenav-title", this._el.content_container);
+    this._el.description        = VCO.Dom.create("div", "vco-slidenav-description", this._el.content_container);
+
+    this._el.icon.innerHTML       = "&nbsp;"
+
+    this._update();
+  },
+
+  _initEvents: function () {
+    VCO.DomEvent.addListener(this._el.container, 'click', this._onMouseClick, this);
+  }
+
+
 });
 
 /* **********************************************
      Begin VCO.StorySlider.js
 ********************************************** */
 
-/*	StorySlider
-	is the central class of the API - it is used to create a StorySlider
+/*  StorySlider
+  is the central class of the API - it is used to create a StorySlider
 
-	Events:
-	nav_next
-	nav_previous
-	slideDisplayUpdate
-	loaded
-	slideAdded
-	slideLoaded
-	slideRemoved
+  Events:
+  nav_next
+  nav_previous
+  slideDisplayUpdate
+  loaded
+  slideAdded
+  slideLoaded
+  slideRemoved
 
-	
+
 ================================================== */
 
 VCO.StorySlider = VCO.Class.extend({
-	
-	includes: VCO.Events,
-	
-	/*	Private Methods
-	================================================== */
-	initialize: function (elem, data, options, init) {
-		
-		// DOM ELEMENTS
-		this._el = {
-			container: {},
-			background: {},
-			slider_container_mask: {},
-			slider_container: {},
-			slider_item_container: {}
-		};
-		
-		this._nav = {};
-		this._nav.previous = {};
-		this._nav.next = {};
-		
-		// Slide Spacing
-		this.slide_spacing = 0;
-		
-		// Slides Array
-		this._slides = [];
-		
-		// Swipe Object
-		this._swipable;
-		
-		// Preload Timer
-		this.preloadTimer;
-		
-		// Message
-		this._message;
-		
-		// Current Slide
-		this.current_slide = 0;
-		
-		// Current Background Color
-		this.current_bg_color = null;
-		
-		// Data Object
-		this.data = {};
-		
-		this.options = {
-			id: 					"",
-			layout: 				"portrait",
-			width: 					600,
-			height: 				600,
-			default_bg_color: 		{r:256, g:256, b:256},
-			slide_padding_lr: 		40, 			// padding on slide of slide
-			start_at_slide: 		1,
-			slide_default_fade: 	"0%", 			// landscape fade
-			// animation
-			duration: 				1000,
-			ease: 					VCO.Ease.easeInOutQuint,
-			// interaction
-			dragging: 				true,
-			trackResize: 			true
-		};
-		
-		// Main element ID
-		if (typeof elem === 'object') {
-			this._el.container = elem;
-			this.options.id = VCO.Util.unique_ID(6, "vco");
-		} else {
-			this.options.id = elem;
-			this._el.container = VCO.Dom.get(elem);
-		}
 
-		if (!this._el.container.id) {
-			this._el.container.id = this.options.id;
-		}
-		
-		// Animation Object
-		this.animator = null;
-		this.animator_background = null;
-		
-		// Merge Data and Options
-		VCO.Util.mergeData(this.options, options);
-		VCO.Util.mergeData(this.data, data);
-		
-		if (init) {
-			this.init();
-		}
-	},
-	
-	init: function() {
-		this._initLayout();
-		this._initEvents();
-		this._initData();
-		this._updateDisplay();
-		
-		// Go to initial slide
-		this.goTo(this.options.start_at_slide);
-		
-		this._onLoaded();
-		this._introInterface();
-	},
-	
-	/*	Public
-	================================================== */
-	updateDisplay: function(w, h, a, l) {
-		this._updateDisplay(w, h, a, l);
-	},
-	
-	// Create a slide
-	createSlide: function(d) {
-		this._createSlide(d);
-	},
-	
-	// Create Many Slides from an array
-	createSlides: function(array) {
-		this._createSlides(array);
-	},
-	
-	/*	Create Slides
-	================================================== */
-	_createSlides: function(array) {
-		for (var i = 0; i < array.length; i++) {
-			if (array[i].uniqueid == "") {
-				array[i].uniqueid = VCO.Util.unique_ID(6, "vco-slide");
-			}
-			if (i == 0) {
-				this._createSlide(array[i], true);
-			} else {
-				this._createSlide(array[i], false);
-			}
-			
-		};
-	},
-	
-	_createSlide: function(d, title_slide) {
-		var slide = new VCO.Slide(d, this.options, title_slide);
-		this._addSlide(slide);
-		this._slides.push(slide);
-	},
-	
-	_destroySlide: function(slide) {
-		this._removeSlide(slide);
-		for (var i = 0; i < this._slides.length; i++) {
-			if (this._slides[i] == slide) {
-				this._slides.splice(i, 1);
-			}
-		}
-	},
-	
-	_addSlide:function(slide) {
-		slide.addTo(this._el.slider_item_container);
-		slide.on('added', this._onSlideAdded, this);
-		slide.on('background_change', this._onBackgroundChange, this);
-	},
-	
-	_removeSlide: function(slide) {
-		slide.removeFrom(this._el.slider_item_container);
-		slide.off('added', this._onSlideAdded, this);
-		slide.off('background_change', this._onBackgroundChange);
-	},
-	
-	/*	Message
-	================================================== */
-	
-	/*	Navigation
-	================================================== */
-	goToId: function(n, fast, displayupdate) {
-		if (typeof n == 'string' || n instanceof String) {
-			_n = VCO.Util.findArrayNumberByUniqueID(n, this._slides, "uniqueid");
-		} else {
-			_n = n;
-		}
-		this.goTo(_n, fast, displayupdate);
-		
-	},
-	
-	goTo: function(n, fast, displayupdate) {
-		var self = this;
-		
-		this.changeBackground({color_value:"", image:false});
-		
-		// Clear Preloader Timer
-		if (this.preloadTimer) {
-			clearTimeout(this.preloadTimer);
-		}
-		
-		// Set Slide Active State
-		for (var i = 0; i < this._slides.length; i++) {
-			this._slides[i].setActive(false);
-		}
-		
-		if (n < this._slides.length && n >= 0) {
-			
-			
-			this.current_slide = n;
-			
-			// Stop animation
-			if (this.animator) {
-				this.animator.stop();
-			}
-			if (this._swipable) {
-				this._swipable.stopMomentum();
-			}
-			
-			if (fast) {
-				this._el.slider_container.style.left = -(this.slide_spacing * n) + "px";
-				this._onSlideChange(displayupdate);
-			} else {
-				this.animator = VCO.Animate(this._el.slider_container, {
-					left: 		-(this.slide_spacing * n) + "px",
-					duration: 	this.options.duration,
-					easing: 	this.options.ease,
-					complete: 	this._onSlideChange(displayupdate)
-				});
-				
-			}
-			
-			// Set Slide Active State
-			this._slides[this.current_slide].setActive(true);
-			
-			// Update Navigation and Info
-			if (this._slides[this.current_slide + 1]) {
-				this.showNav(this._nav.next, true);
-				this._nav.next.update(this.getNavInfo(this._slides[this.current_slide + 1]));
-			} else {
-				this.showNav(this._nav.next, false);
-			}
-			if (this._slides[this.current_slide - 1]) {
-				this.showNav(this._nav.previous, true);
-				this._nav.previous.update(this.getNavInfo(this._slides[this.current_slide - 1]));
-			} else {
-				this.showNav(this._nav.previous, false);
-			}
-			
-			
-			// Preload Slides
-			this.preloadTimer = setTimeout(function() {
-				self.preloadSlides();
-			}, this.options.duration);
-			
-		}
-	},
-	
-	preloadSlides: function() {
-		if (this._slides[this.current_slide + 1]) {
-			this._slides[this.current_slide + 1].loadMedia();
-			this._slides[this.current_slide + 1].scrollToTop();
-		}
-		if (this._slides[this.current_slide + 2]) {
-			this._slides[this.current_slide + 2].loadMedia();
-			this._slides[this.current_slide + 2].scrollToTop();
-		}
-		if (this._slides[this.current_slide - 1]) {
-			this._slides[this.current_slide - 1].loadMedia();
-			this._slides[this.current_slide - 1].scrollToTop();
-		}
-		if (this._slides[this.current_slide - 2]) {
-			this._slides[this.current_slide - 2].loadMedia();
-			this._slides[this.current_slide - 2].scrollToTop();
-		}
-	},
-	
-	
-	getNavInfo: function(slide) {
-		var n = {
-			title: "",
-			description: ""
-		};
-		
-		if (slide.data.text) {
-			if (slide.data.text.headline) {
-				n.title = slide.data.text.headline;
-			}
-			/*
-			// Disabling location in description for now.
-			if (slide.data.location) {
-				if (slide.data.location.name) {
-					n.description = slide.data.location.name;
-				}
-			}
-			*/
-		}
-		
-		return n;
-		
-	},
-	
-	next: function() {
-		if ((this.current_slide +1) < (this._slides.length)) {
-			this.goTo(this.current_slide +1);
-		} else {
-			this.goTo(this.current_slide);
-		}
-	},
-	
-	previous: function() {
-		if (this.current_slide -1 >= 0) {
-			this.goTo(this.current_slide -1);
-		} else {
-			this.goTo(this.current_slide);
-		}
-	},
-	
-	showNav: function(nav_obj, show) {
-		
-		if (this.options.width <= 500 && VCO.Browser.mobile) {
-			
-		} else {
-			if (show) {
-				nav_obj.show();
-			} else {
-				nav_obj.hide();
-			}
-			
-		}
-	},
-	
-	changeBackground: function(bg) {
-		var self = this,
-			do_animation = false;
-		
-		var bg_color = {r:256, g:256, b:256},
-			bg_color_rgb,
-			bg_percent_start 	= this.options.slide_default_fade,
-			bg_percent_end 		= "15%",
-			bg_alpha_end 		= "0.87",
-			bg_css 				= "",
-			bg_old 				= this._el.background.getAttribute('style');
-		
-		if (bg.color_value) {
-			bg_color = VCO.Util.hexToRgb(bg.color_value);
-		} else {
-			bg_color = this.options.default_bg_color;
-		}
-		
-		
-		// Stop animation
-		if (this.animator_background) {
-			this.animator_background.stop();
-		}
-		
-		bg_color_rgb 	= bg_color.r + "," + bg_color.g + "," + bg_color.b;
-		
-		if (!this.current_bg_color || this.current_bg_color != bg_color_rgb) {
-			this.current_bg_color = bg_color_rgb;
-			do_animation = true;
-		} 
-		
-		
-		
-		if (do_animation) {
+  includes: VCO.Events,
 
-			// Figure out CSS
-			if (this.options.layout == "landscape") {
-			
-				this._nav.next.setColor(false);
-				this._nav.previous.setColor(false);
-			
-				// If background is not white, less fade is better
-				if (bg_color.r < 255 && bg_color.g < 255 && bg_color.b < 255) {
-					bg_percent_start = "15%";
-				}
-			
-				if (bg.image) {
-					bg_percent_start = "0%";
-				
-				} 
-				bg_css 	+= "opacity:0;"
-				bg_css 	+= "background-image: -webkit-linear-gradient(left, color-stop(rgba(" + bg_color_rgb + ",0.0001 ) " + bg_percent_start + "), color-stop(rgba(" + bg_color_rgb + "," + bg_alpha_end + ") " + bg_percent_end + "));";
-				bg_css 	+= "background-image: linear-gradient(to right, rgba(" + bg_color_rgb + ",0.0001 ) "+ bg_percent_start + ", rgba(" + bg_color_rgb + "," + bg_alpha_end + ") " + bg_percent_end + ");";
-				bg_css 	+= "background-repeat: repeat-x;";
-				bg_css 	+= "filter: e(%('progid:DXImageTransform.Microsoft.gradient(startColorstr='%d', endColorstr='%d', GradientType=1)',argb(" + bg_color_rgb + ", 0.0001),argb(" + bg_color_rgb + ",0.80)));";
-			
-			
-			} else {
-				if (bg.color_value) {
-					bg_css 	+= 'background-color:' + bg.color_value + ";";
-				} else {
-					bg_css 	+= "background-color:#FFF;";
-				}
-			
-				if (bg_color.r < 255 && bg_color.g < 255 && bg_color.b < 255 || bg.image) {
-					this._nav.next.setColor(true);
-					this._nav.previous.setColor(true);
-				} else {
-					this._nav.next.setColor(false);
-					this._nav.previous.setColor(false);
-				}
-			}
-		
-			// FADE OUT IN
-			this.animator_background = VCO.Animate(this._el.background, {
-				opacity: 	0,
-				duration: 	this.options.duration/2,
-				easing: 	this.options.ease,
-				complete: 	function() {
-					self.fadeInBackground(bg_css);
-				}
-			});
-		}
-		
-		
-	},
-	
-	fadeInBackground: function(bg_css) {
-		if (this.animator_background) {
-			this.animator_background.stop();
-		}
-		
-		if (bg_css) {
-			this._el.background.setAttribute("style", bg_css);
-		}
-		
-		this.animator_background = VCO.Animate(this._el.background, {
-			opacity: 	1,
-			duration: 	this.options.duration/2,
-			easing: 	this.options.ease
-		});
-		
-	},
-	
-	/*	Private Methods
-	================================================== */
-	
-	// Update Display
-	_updateDisplay: function(width, height, animate, layout) {
-		var nav_pos, _layout;
-		
-		if(typeof layout === 'undefined'){
-			_layout = this.options.layout;
-		} else {
-			_layout = layout;
-		}
-		
-		this.options.layout = _layout;
-		
-		this.slide_spacing = this.options.width*2;
-		
-		if (width) {
-			this.options.width = width;
-		} else {
-			this.options.width = this._el.container.offsetWidth;
+  /*  Private Methods
+  ================================================== */
+  initialize: function (elem, data, options, init) {
+
+    // DOM ELEMENTS
+    this._el = {
+      container: {},
+      background: {},
+      slider_container_mask: {},
+      slider_container: {},
+      slider_item_container: {}
+    };
+
+    this._nav = {};
+    this._nav.previous = {};
+    this._nav.next = {};
+
+    // Slide Spacing
+    this.slide_spacing = 0;
+
+    // Slides Array
+    this._slides = [];
+
+    // Swipe Object
+    this._swipable;
+
+    // Preload Timer
+    this.preloadTimer;
+
+    // Message
+    this._message;
+
+    // Current Slide
+    this.current_slide = 0;
+
+    // Current Background Color
+    this.current_bg_color = null;
+
+    // Data Object
+    this.data = {};
+
+    this.options = {
+      id:           "",
+      layout:         "portrait",
+      width:          600,
+      height:         600,
+      default_bg_color:     {r:256, g:256, b:256},
+      slide_padding_lr:     40,       // padding on slide of slide
+      start_at_slide:     1,
+      slide_default_fade:   "0%",       // landscape fade
+      // animation
+      duration:         1000,
+      ease:           VCO.Ease.easeInOutQuint,
+      // interaction
+      dragging:         true,
+      trackResize:      true
+    };
+
+    // Main element ID
+    if (typeof elem === 'object') {
+      this._el.container = elem;
+      this.options.id = VCO.Util.unique_ID(6, "vco");
+    } else {
+      this.options.id = elem;
+      this._el.container = VCO.Dom.get(elem);
+    }
+
+    if (!this._el.container.id) {
+      this._el.container.id = this.options.id;
+    }
+
+    // Animation Object
+    this.animator = null;
+    this.animator_background = null;
+
+    // Merge Data and Options
+    VCO.Util.mergeData(this.options, options);
+    VCO.Util.mergeData(this.data, data);
+
+    if (init) {
+      this.init();
+    }
+  },
+
+  init: function() {
+    this._initLayout();
+    this._initEvents();
+    this._initData();
+    this._updateDisplay();
+
+    // Go to initial slide
+    this.goTo(this.options.start_at_slide);
+
+    this._onLoaded();
+    this._introInterface();
+  },
+
+  /*  Public
+  ================================================== */
+  updateDisplay: function(w, h, a, l) {
+    this._updateDisplay(w, h, a, l);
+  },
+
+  // Create a slide
+  createSlide: function(d) {
+    this._createSlide(d);
+  },
+
+  // Create Many Slides from an array
+  createSlides: function(array) {
+    this._createSlides(array);
+  },
+
+  /*  Create Slides
+  ================================================== */
+  _createSlides: function(array) {
+    for (var i = 0; i < array.length; i++) {
+      if (array[i].uniqueid == "") {
+        array[i].uniqueid = VCO.Util.unique_ID(6, "vco-slide");
+      }
+      if (i == 0) {
+        this._createSlide(array[i], true);
+      } else {
+        this._createSlide(array[i], false);
+      }
+
+    };
+  },
+
+  _createSlide: function(d, title_slide) {
+    var slide = new VCO.Slide(d, this.options, title_slide);
+    this._addSlide(slide);
+    this._slides.push(slide);
+  },
+
+  _destroySlide: function(slide) {
+    this._removeSlide(slide);
+    for (var i = 0; i < this._slides.length; i++) {
+      if (this._slides[i] == slide) {
+        this._slides.splice(i, 1);
+      }
+    }
+  },
+
+  _addSlide:function(slide) {
+    slide.addTo(this._el.slider_item_container);
+    slide.on('added', this._onSlideAdded, this);
+    slide.on('background_change', this._onBackgroundChange, this);
+  },
+
+  _removeSlide: function(slide) {
+    slide.removeFrom(this._el.slider_item_container);
+    slide.off('added', this._onSlideAdded, this);
+    slide.off('background_change', this._onBackgroundChange);
+  },
+
+  /*  Message
+  ================================================== */
+
+  /*  Navigation
+  ================================================== */
+  goToId: function(n, fast, displayupdate) {
+    if (typeof n == 'string' || n instanceof String) {
+      _n = VCO.Util.findArrayNumberByUniqueID(n, this._slides, "uniqueid");
+    } else {
+      _n = n;
+    }
+    this.goTo(_n, fast, displayupdate);
+
+  },
+
+  goTo: function(n, fast, displayupdate) {
+    var self = this;
+
+    this.changeBackground({color_value:"", image:false});
+
+    // Clear Preloader Timer
+    if (this.preloadTimer) {
+      clearTimeout(this.preloadTimer);
+    }
+
+    // Set Slide Active State
+    for (var i = 0; i < this._slides.length; i++) {
+      this._slides[i].setActive(false);
+    }
+
+    if (n < this._slides.length && n >= 0) {
+
+
+      this.current_slide = n;
+
+      // Stop animation
+      if (this.animator) {
+        this.animator.stop();
+      }
+      if (this._swipable) {
+        this._swipable.stopMomentum();
+      }
+
+      if (fast) {
+        this._el.slider_container.style.left = -(this.slide_spacing * n) + "px";
+        this._onSlideChange(displayupdate);
+      } else {
+        this.animator = VCO.Animate(this._el.slider_container, {
+          left:     -(this.slide_spacing * n) + "px",
+          duration:   this.options.duration,
+          easing:   this.options.ease,
+          complete:   this._onSlideChange(displayupdate)
+        });
+
+      }
+
+      // Set Slide Active State
+      this._slides[this.current_slide].setActive(true);
+
+      // Update Navigation and Info
+      if (this._slides[this.current_slide + 1]) {
+        this.showNav(this._nav.next, true);
+        this._nav.next.update(this.getNavInfo(this._slides[this.current_slide + 1]));
+      } else {
+        this.showNav(this._nav.next, false);
+      }
+      if (this._slides[this.current_slide - 1]) {
+        this.showNav(this._nav.previous, true);
+        this._nav.previous.update(this.getNavInfo(this._slides[this.current_slide - 1]));
+      } else {
+        this.showNav(this._nav.previous, false);
+      }
+
+
+      // Preload Slides
+      this.preloadTimer = setTimeout(function() {
+        self.preloadSlides();
+      }, this.options.duration);
+
+    }
+  },
+
+  preloadSlides: function() {
+    if (this._slides[this.current_slide + 1]) {
+      this._slides[this.current_slide + 1].loadMedia();
+      this._slides[this.current_slide + 1].scrollToTop();
+    }
+    if (this._slides[this.current_slide + 2]) {
+      this._slides[this.current_slide + 2].loadMedia();
+      this._slides[this.current_slide + 2].scrollToTop();
+    }
+    if (this._slides[this.current_slide - 1]) {
+      this._slides[this.current_slide - 1].loadMedia();
+      this._slides[this.current_slide - 1].scrollToTop();
+    }
+    if (this._slides[this.current_slide - 2]) {
+      this._slides[this.current_slide - 2].loadMedia();
+      this._slides[this.current_slide - 2].scrollToTop();
+    }
+  },
+
+
+  getNavInfo: function(slide) {
+    var n = {
+      title: "",
+      description: ""
+    };
+
+    if (slide.data.text) {
+      if (slide.data.text.headline) {
+        n.title = slide.data.text.headline;
+      }
+      /*
+      // Disabling location in description for now.
+      if (slide.data.location) {
+        if (slide.data.location.name) {
+          n.description = slide.data.location.name;
+        }
+      }
+      */
+    }
+
+    return n;
+
+  },
+
+  next: function() {
+    if ((this.current_slide +1) < (this._slides.length)) {
+      this.goTo(this.current_slide +1);
+    } else {
+      this.goTo(this.current_slide);
+    }
+  },
+
+  previous: function() {
+    if (this.current_slide -1 >= 0) {
+      this.goTo(this.current_slide -1);
+    } else {
+      this.goTo(this.current_slide);
+    }
+  },
+
+  showNav: function(nav_obj, show) {
+
+    if (this.options.width <= 500 && VCO.Browser.mobile) {
+
+    } else {
+      if (show) {
+        nav_obj.show();
+      } else {
+        nav_obj.hide();
+      }
+
+    }
+  },
+
+  changeBackground: function(bg) {
+    var self = this,
+      do_animation = false;
+
+    var bg_color = {r:256, g:256, b:256},
+      bg_color_rgb,
+      bg_percent_start  = this.options.slide_default_fade,
+      bg_percent_end    = "15%",
+      bg_alpha_end    = "0.87",
+      bg_css        = "",
+      bg_old        = this._el.background.getAttribute('style');
+
+    if (bg.color_value) {
+      bg_color = VCO.Util.hexToRgb(bg.color_value);
+    } else {
+      bg_color = this.options.default_bg_color;
+    }
+
+
+    // Stop animation
+    if (this.animator_background) {
+      this.animator_background.stop();
+    }
+
+    bg_color_rgb  = bg_color.r + "," + bg_color.g + "," + bg_color.b;
+
+    if (!this.current_bg_color || this.current_bg_color != bg_color_rgb) {
+      this.current_bg_color = bg_color_rgb;
+      do_animation = true;
+    }
+
+
+
+    if (do_animation) {
+
+      // Figure out CSS
+      if (this.options.layout == "landscape") {
+
+        this._nav.next.setColor(false);
+        this._nav.previous.setColor(false);
+
+        // If background is not white, less fade is better
+        if (bg_color.r < 255 && bg_color.g < 255 && bg_color.b < 255) {
+          bg_percent_start = "15%";
+        }
+
+        if (bg.image) {
+          bg_percent_start = "0%";
+
+        }
+        bg_css  += "opacity:0;"
+        bg_css  += "background-image: -webkit-linear-gradient(left, color-stop(rgba(" + bg_color_rgb + ",0.0001 ) " + bg_percent_start + "), color-stop(rgba(" + bg_color_rgb + "," + bg_alpha_end + ") " + bg_percent_end + "));";
+        bg_css  += "background-image: linear-gradient(to right, rgba(" + bg_color_rgb + ",0.0001 ) "+ bg_percent_start + ", rgba(" + bg_color_rgb + "," + bg_alpha_end + ") " + bg_percent_end + ");";
+        bg_css  += "background-repeat: repeat-x;";
+        bg_css  += "filter: e(%('progid:DXImageTransform.Microsoft.gradient(startColorstr='%d', endColorstr='%d', GradientType=1)',argb(" + bg_color_rgb + ", 0.0001),argb(" + bg_color_rgb + ",0.80)));";
+
+
+      } else {
+        if (bg.color_value) {
+          bg_css  += 'background-color:' + bg.color_value + ";";
+        } else {
+          bg_css  += "background-color:#FFF;";
+        }
+
+        if (bg_color.r < 255 && bg_color.g < 255 && bg_color.b < 255 || bg.image) {
+          this._nav.next.setColor(true);
+          this._nav.previous.setColor(true);
+        } else {
+          this._nav.next.setColor(false);
+          this._nav.previous.setColor(false);
+        }
+      }
+
+      // FADE OUT IN
+      this.animator_background = VCO.Animate(this._el.background, {
+        opacity:  0,
+        duration:   this.options.duration/2,
+        easing:   this.options.ease,
+        complete:   function() {
+          self.fadeInBackground(bg_css);
+        }
+      });
+    }
+
+
+  },
+
+  fadeInBackground: function(bg_css) {
+    if (this.animator_background) {
+      this.animator_background.stop();
+    }
+
+    if (bg_css) {
+      this._el.background.setAttribute("style", bg_css);
+    }
+
+    this.animator_background = VCO.Animate(this._el.background, {
+      opacity:  1,
+      duration:   this.options.duration/2,
+      easing:   this.options.ease
+    });
+
+  },
+
+  /*  Private Methods
+  ================================================== */
+
+  // Update Display
+  _updateDisplay: function(width, height, animate, layout) {
+    var nav_pos, _layout;
+
+    if(typeof layout === 'undefined'){
+      _layout = this.options.layout;
+    } else {
+      _layout = layout;
+    }
+
+    this.options.layout = _layout;
+
+    this.slide_spacing = this.options.width*2;
+
+    if (width) {
+      this.options.width = width;
+    } else {
+      this.options.width = this._el.container.offsetWidth;
       console.log("line 457: ", this.options.width);
-		}
-		
-		if (height) {
-			this.options.height = height;
-		} else {
-			this.options.height = this._el.container.offsetHeight;
-		}
-		
-		//this._el.container.style.height = this.options.height;
-		
-		// position navigation
-		nav_pos = (this.options.height/2);
-		this._nav.next.setPosition({top:nav_pos});
-		this._nav.previous.setPosition({top:nav_pos});
-		
-		
-		// Position slides
-		for (var i = 0; i < this._slides.length; i++) {
-			this._slides[i].updateDisplay(this.options.width, this.options.height, _layout);
-			this._slides[i].setPosition({left:(this.slide_spacing * i), top:0});
-		};
-		
-		// Go to the current slide
-		this.goTo(this.current_slide, true, true);
-	},
-	
-	_introInterface: function() {
-		
-		if (this.options.call_to_action) {
-			var _str = VCO.Language.messages.start;
-			if (this.options.call_to_action_text != "") {
-				_str = this.options.call_to_action_text;
-			}
-			this._slides[0].addCallToAction(_str);
-			this._slides[0].on('call_to_action', this.next, this);
-		}
-		
-		if (this.options.width <= this.options.skinny_size) {
-			
-		} else {
-			this._nav.next.updatePosition({right:"130"}, false, this.options.duration*3, this.options.ease, -100, true);
-			this._nav.previous.updatePosition({left:"-100"}, true, this.options.duration*3, this.options.ease, -200, true);
-		}
-	},
-	
-	/*	Init
-	================================================== */
-	_initLayout: function () {
-		
-		this._el.container.className += ' vco-storyslider';
-		
-		// Create Layout
-		this._el.slider_container_mask		= VCO.Dom.create('div', 'vco-slider-container-mask', this._el.container);
-		this._el.background 				= VCO.Dom.create('div', 'vco-slider-background', this._el.container); 
-		this._el.slider_container			= VCO.Dom.create('div', 'vco-slider-container vcoanimate', this._el.slider_container_mask);
-		this._el.slider_item_container		= VCO.Dom.create('div', 'vco-slider-item-container', this._el.slider_container);
-		
-		
-		// Update Size
-		this.options.width = this._el.container.offsetWidth;
-		this.options.height = this._el.container.offsetHeight;
-		
-		// Create Navigation
-		this._nav.previous = new VCO.SlideNav({title: "Previous", description: "description"}, {direction:"previous"});
-		this._nav.next = new VCO.SlideNav({title: "Next",description: "description"}, {direction:"next"});
-		
-		// add the navigation to the dom
-		this._nav.next.addTo(this._el.container);
-		this._nav.previous.addTo(this._el.container);
-		
-		
-				
-		this._el.slider_container.style.left="0px";
-		
-		if (VCO.Browser.touch) {
-			//this._el.slider_touch_mask = VCO.Dom.create('div', 'vco-slider-touch-mask', this._el.slider_container_mask);
-			this._swipable = new VCO.Swipable(this._el.slider_container_mask, this._el.slider_container, {
-				enable: {x:true, y:false},
-				snap: 	true
-			});
-			this._swipable.enable();
-			
-			// Message
-			this._message = new VCO.Message({}, {
-				message_class: 		"vco-message-full",
-				message_icon_class: "vco-icon-swipe-left"
-			});
-			this._message.updateMessage("Swipe to Navigate<br><span class='vco-button'>OK</span>");
-			this._message.addTo(this._el.container);
-		}
-	},
-	
-	_initEvents: function () {
-		this._nav.next.on('clicked', this._onNavigation, this);
-		this._nav.previous.on('clicked', this._onNavigation, this);
-		
-		if (this._message) {
-			this._message.on('clicked', this._onMessageClick, this);
-		}
-		
-		if (this._swipable) {
-			this._swipable.on('swipe_left', this._onNavigation, this);
-			this._swipable.on('swipe_right', this._onNavigation, this);
-			this._swipable.on('swipe_nodirection', this._onSwipeNoDirection, this);
-		}
-		
-		
-	},
-	
-	_initData: function() {
-		// Create Slides and then add them
-		this._createSlides(this.data.slides);
-	},
-	
-	/*	Events
-	================================================== */
-	_onBackgroundChange: function(e) {
-		var slide_background = this._slides[this.current_slide].getBackground();
-		this.changeBackground(e);
-		this.fire("colorchange", slide_background);
-	},
-	
-	_onMessageClick: function(e) {
-		this._message.hide();
-	},
-	
-	_onSwipeNoDirection: function(e) {
-		this.goTo(this.current_slide);
-	},
-	
-	_onNavigation: function(e) {
-		
-		if (e.direction == "next" || e.direction == "left") {
-			this.next();
-		} else if (e.direction == "previous" || e.direction == "right") {
-			this.previous();
-		} 
-		this.fire("nav_" + e.direction, this.data);
-	},
-	
-	_onSlideAdded: function(e) {
-		trace("slideadded")
-		this.fire("slideAdded", this.data);
-	},
-	
-	_onSlideRemoved: function(e) {
-		this.fire("slideAdded", this.data);
-	},
-	
-	_onSlideChange: function(displayupdate) {
-		
-		if (!displayupdate) {
-			this.fire("change", {current_slide:this.current_slide, uniqueid:this._slides[this.current_slide].data.uniqueid});
-		}
-	},
-	
-	_onMouseClick: function(e) {
-		
-	},
-	
-	_fireMouseEvent: function (e) {
-		if (!this._loaded) {
-			return;
-		}
+    }
 
-		var type = e.type;
-		type = (type === 'mouseenter' ? 'mouseover' : (type === 'mouseleave' ? 'mouseout' : type));
+    if (height) {
+      this.options.height = height;
+    } else {
+      this.options.height = this._el.container.offsetHeight;
+    }
 
-		if (!this.hasEventListeners(type)) {
-			return;
-		}
+    //this._el.container.style.height = this.options.height;
 
-		if (type === 'contextmenu') {
-			VCO.DomEvent.preventDefault(e);
-		}
-		
-		this.fire(type, {
-			latlng: "something", //this.mouseEventToLatLng(e),
-			layerPoint: "something else" //this.mouseEventToLayerPoint(e)
-		});
-	},
-	
-	_onLoaded: function() {
-		this.fire("loaded", this.data);
-		this.fire("title", {title:this._slides[0].title});
-		
-	}
-	
-	
+    // position navigation
+    nav_pos = (this.options.height/2);
+    this._nav.next.setPosition({top:nav_pos});
+    this._nav.previous.setPosition({top:nav_pos});
+
+
+    // Position slides
+    for (var i = 0; i < this._slides.length; i++) {
+      this._slides[i].updateDisplay(this.options.width, this.options.height, _layout);
+      this._slides[i].setPosition({left:(this.slide_spacing * i), top:0});
+    };
+
+    // Go to the current slide
+    this.goTo(this.current_slide, true, true);
+  },
+
+  _introInterface: function() {
+
+    if (this.options.call_to_action) {
+      var _str = VCO.Language.messages.start;
+      if (this.options.call_to_action_text != "") {
+        _str = this.options.call_to_action_text;
+      }
+      this._slides[0].addCallToAction(_str);
+      this._slides[0].on('call_to_action', this.next, this);
+    }
+
+    if (this.options.width <= this.options.skinny_size) {
+
+    } else {
+      this._nav.next.updatePosition({right:"130"}, false, this.options.duration*3, this.options.ease, -100, true);
+      this._nav.previous.updatePosition({left:"-100"}, true, this.options.duration*3, this.options.ease, -200, true);
+    }
+  },
+
+  /*  Init
+  ================================================== */
+  _initLayout: function () {
+
+    this._el.container.className += ' vco-storyslider';
+
+    // Create Layout
+    this._el.slider_container_mask    = VCO.Dom.create('div', 'vco-slider-container-mask', this._el.container);
+    this._el.background         = VCO.Dom.create('div', 'vco-slider-background', this._el.container);
+    this._el.slider_container     = VCO.Dom.create('div', 'vco-slider-container vcoanimate', this._el.slider_container_mask);
+    this._el.slider_item_container    = VCO.Dom.create('div', 'vco-slider-item-container', this._el.slider_container);
+
+
+    // Update Size
+    this.options.width = this._el.container.offsetWidth;
+    this.options.height = this._el.container.offsetHeight;
+
+    // Create Navigation
+    this._nav.previous = new VCO.SlideNav({title: "Previous", description: "description"}, {direction:"previous"});
+    this._nav.next = new VCO.SlideNav({title: "Next",description: "description"}, {direction:"next"});
+
+    // add the navigation to the dom
+    this._nav.next.addTo(this._el.container);
+    this._nav.previous.addTo(this._el.container);
+
+
+
+    this._el.slider_container.style.left="0px";
+
+    if (VCO.Browser.touch) {
+      //this._el.slider_touch_mask = VCO.Dom.create('div', 'vco-slider-touch-mask', this._el.slider_container_mask);
+      this._swipable = new VCO.Swipable(this._el.slider_container_mask, this._el.slider_container, {
+        enable: {x:true, y:false},
+        snap:   true
+      });
+      this._swipable.enable();
+
+      // Message
+      this._message = new VCO.Message({}, {
+        message_class:    "vco-message-full",
+        message_icon_class: "vco-icon-swipe-left"
+      });
+      this._message.updateMessage("Swipe to Navigate<br><span class='vco-button'>OK</span>");
+      this._message.addTo(this._el.container);
+    }
+  },
+
+  _initEvents: function () {
+    this._nav.next.on('clicked', this._onNavigation, this);
+    this._nav.previous.on('clicked', this._onNavigation, this);
+
+    if (this._message) {
+      this._message.on('clicked', this._onMessageClick, this);
+    }
+
+    if (this._swipable) {
+      this._swipable.on('swipe_left', this._onNavigation, this);
+      this._swipable.on('swipe_right', this._onNavigation, this);
+      this._swipable.on('swipe_nodirection', this._onSwipeNoDirection, this);
+    }
+
+
+  },
+
+  _initData: function() {
+    // Create Slides and then add them
+    this._createSlides(this.data.slides);
+  },
+
+  /*  Events
+  ================================================== */
+  _onBackgroundChange: function(e) {
+    var slide_background = this._slides[this.current_slide].getBackground();
+    this.changeBackground(e);
+    this.fire("colorchange", slide_background);
+  },
+
+  _onMessageClick: function(e) {
+    this._message.hide();
+  },
+
+  _onSwipeNoDirection: function(e) {
+    this.goTo(this.current_slide);
+  },
+
+  _onNavigation: function(e) {
+
+    if (e.direction == "next" || e.direction == "left") {
+      this.next();
+    } else if (e.direction == "previous" || e.direction == "right") {
+      this.previous();
+    }
+    this.fire("nav_" + e.direction, this.data);
+  },
+
+  _onSlideAdded: function(e) {
+    trace("slideadded")
+    this.fire("slideAdded", this.data);
+  },
+
+  _onSlideRemoved: function(e) {
+    this.fire("slideAdded", this.data);
+  },
+
+  _onSlideChange: function(displayupdate) {
+
+    if (!displayupdate) {
+      this.fire("change", {current_slide:this.current_slide, uniqueid:this._slides[this.current_slide].data.uniqueid});
+    }
+  },
+
+  _onMouseClick: function(e) {
+
+  },
+
+  _fireMouseEvent: function (e) {
+    if (!this._loaded) {
+      return;
+    }
+
+    var type = e.type;
+    type = (type === 'mouseenter' ? 'mouseover' : (type === 'mouseleave' ? 'mouseout' : type));
+
+    if (!this.hasEventListeners(type)) {
+      return;
+    }
+
+    if (type === 'contextmenu') {
+      VCO.DomEvent.preventDefault(e);
+    }
+
+    this.fire(type, {
+      latlng: "something", //this.mouseEventToLatLng(e),
+      layerPoint: "something else" //this.mouseEventToLayerPoint(e)
+    });
+  },
+
+  _onLoaded: function() {
+    this.fire("loaded", this.data);
+    this.fire("title", {title:this._slides[0].title});
+
+  }
+
+
 });
 
 
@@ -7897,18 +7897,18 @@ L.version = '0.7.2';
 
 // define Leaflet for Node module pattern loaders, including Browserify
 if (typeof module === 'object' && typeof module.exports === 'object') {
-	module.exports = L;
+  module.exports = L;
 
 // define Leaflet as an AMD module
 } else if (typeof define === 'function' && define.amd) {
-	define(L);
+  define(L);
 }
 
 // define Leaflet as a global L variable, saving the original L to restore later if needed
 
 L.noConflict = function () {
-	window.L = oldL;
-	return this;
+  window.L = oldL;
+  return this;
 };
 
 window.L = L;
@@ -7923,175 +7923,175 @@ window.L = L;
  */
 
 L.Util = {
-	extend: function (dest) { // (Object[, Object, ...]) ->
-		var sources = Array.prototype.slice.call(arguments, 1),
-		    i, j, len, src;
+  extend: function (dest) { // (Object[, Object, ...]) ->
+    var sources = Array.prototype.slice.call(arguments, 1),
+        i, j, len, src;
 
-		for (j = 0, len = sources.length; j < len; j++) {
-			src = sources[j] || {};
-			for (i in src) {
-				if (src.hasOwnProperty(i)) {
-					dest[i] = src[i];
-				}
-			}
-		}
-		return dest;
-	},
+    for (j = 0, len = sources.length; j < len; j++) {
+      src = sources[j] || {};
+      for (i in src) {
+        if (src.hasOwnProperty(i)) {
+          dest[i] = src[i];
+        }
+      }
+    }
+    return dest;
+  },
 
-	bind: function (fn, obj) { // (Function, Object) -> Function
-		var args = arguments.length > 2 ? Array.prototype.slice.call(arguments, 2) : null;
-		return function () {
-			return fn.apply(obj, args || arguments);
-		};
-	},
+  bind: function (fn, obj) { // (Function, Object) -> Function
+    var args = arguments.length > 2 ? Array.prototype.slice.call(arguments, 2) : null;
+    return function () {
+      return fn.apply(obj, args || arguments);
+    };
+  },
 
-	stamp: (function () {
-		var lastId = 0,
-		    key = '_leaflet_id';
-		return function (obj) {
-			obj[key] = obj[key] || ++lastId;
-			return obj[key];
-		};
-	}()),
+  stamp: (function () {
+    var lastId = 0,
+        key = '_leaflet_id';
+    return function (obj) {
+      obj[key] = obj[key] || ++lastId;
+      return obj[key];
+    };
+  }()),
 
-	invokeEach: function (obj, method, context) {
-		var i, args;
+  invokeEach: function (obj, method, context) {
+    var i, args;
 
-		if (typeof obj === 'object') {
-			args = Array.prototype.slice.call(arguments, 3);
+    if (typeof obj === 'object') {
+      args = Array.prototype.slice.call(arguments, 3);
 
-			for (i in obj) {
-				method.apply(context, [i, obj[i]].concat(args));
-			}
-			return true;
-		}
+      for (i in obj) {
+        method.apply(context, [i, obj[i]].concat(args));
+      }
+      return true;
+    }
 
-		return false;
-	},
+    return false;
+  },
 
-	limitExecByInterval: function (fn, time, context) {
-		var lock, execOnUnlock;
+  limitExecByInterval: function (fn, time, context) {
+    var lock, execOnUnlock;
 
-		return function wrapperFn() {
-			var args = arguments;
+    return function wrapperFn() {
+      var args = arguments;
 
-			if (lock) {
-				execOnUnlock = true;
-				return;
-			}
+      if (lock) {
+        execOnUnlock = true;
+        return;
+      }
 
-			lock = true;
+      lock = true;
 
-			setTimeout(function () {
-				lock = false;
+      setTimeout(function () {
+        lock = false;
 
-				if (execOnUnlock) {
-					wrapperFn.apply(context, args);
-					execOnUnlock = false;
-				}
-			}, time);
+        if (execOnUnlock) {
+          wrapperFn.apply(context, args);
+          execOnUnlock = false;
+        }
+      }, time);
 
-			fn.apply(context, args);
-		};
-	},
+      fn.apply(context, args);
+    };
+  },
 
-	falseFn: function () {
-		return false;
-	},
+  falseFn: function () {
+    return false;
+  },
 
-	formatNum: function (num, digits) {
-		var pow = Math.pow(10, digits || 5);
-		return Math.round(num * pow) / pow;
-	},
+  formatNum: function (num, digits) {
+    var pow = Math.pow(10, digits || 5);
+    return Math.round(num * pow) / pow;
+  },
 
-	trim: function (str) {
-		return str.trim ? str.trim() : str.replace(/^\s+|\s+$/g, '');
-	},
+  trim: function (str) {
+    return str.trim ? str.trim() : str.replace(/^\s+|\s+$/g, '');
+  },
 
-	splitWords: function (str) {
-		return L.Util.trim(str).split(/\s+/);
-	},
+  splitWords: function (str) {
+    return L.Util.trim(str).split(/\s+/);
+  },
 
-	setOptions: function (obj, options) {
-		obj.options = L.extend({}, obj.options, options);
-		return obj.options;
-	},
+  setOptions: function (obj, options) {
+    obj.options = L.extend({}, obj.options, options);
+    return obj.options;
+  },
 
-	getParamString: function (obj, existingUrl, uppercase) {
-		var params = [];
-		for (var i in obj) {
-			params.push(encodeURIComponent(uppercase ? i.toUpperCase() : i) + '=' + encodeURIComponent(obj[i]));
-		}
-		return ((!existingUrl || existingUrl.indexOf('?') === -1) ? '?' : '&') + params.join('&');
-	},
-	template: function (str, data) {
-		return str.replace(/\{ *([\w_]+) *\}/g, function (str, key) {
-			var value = data[key];
-			if (value === undefined) {
-				throw new Error('No value provided for variable ' + str);
-			} else if (typeof value === 'function') {
-				value = value(data);
-			}
-			return value;
-		});
-	},
+  getParamString: function (obj, existingUrl, uppercase) {
+    var params = [];
+    for (var i in obj) {
+      params.push(encodeURIComponent(uppercase ? i.toUpperCase() : i) + '=' + encodeURIComponent(obj[i]));
+    }
+    return ((!existingUrl || existingUrl.indexOf('?') === -1) ? '?' : '&') + params.join('&');
+  },
+  template: function (str, data) {
+    return str.replace(/\{ *([\w_]+) *\}/g, function (str, key) {
+      var value = data[key];
+      if (value === undefined) {
+        throw new Error('No value provided for variable ' + str);
+      } else if (typeof value === 'function') {
+        value = value(data);
+      }
+      return value;
+    });
+  },
 
-	isArray: Array.isArray || function (obj) {
-		return (Object.prototype.toString.call(obj) === '[object Array]');
-	},
+  isArray: Array.isArray || function (obj) {
+    return (Object.prototype.toString.call(obj) === '[object Array]');
+  },
 
-	emptyImageUrl: 'data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs='
+  emptyImageUrl: 'data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs='
 };
 
 (function () {
 
-	// inspired by http://paulirish.com/2011/requestanimationframe-for-smart-animating/
+  // inspired by http://paulirish.com/2011/requestanimationframe-for-smart-animating/
 
-	function getPrefixed(name) {
-		var i, fn,
-		    prefixes = ['webkit', 'moz', 'o', 'ms'];
+  function getPrefixed(name) {
+    var i, fn,
+        prefixes = ['webkit', 'moz', 'o', 'ms'];
 
-		for (i = 0; i < prefixes.length && !fn; i++) {
-			fn = window[prefixes[i] + name];
-		}
+    for (i = 0; i < prefixes.length && !fn; i++) {
+      fn = window[prefixes[i] + name];
+    }
 
-		return fn;
-	}
+    return fn;
+  }
 
-	var lastTime = 0;
+  var lastTime = 0;
 
-	function timeoutDefer(fn) {
-		var time = +new Date(),
-		    timeToCall = Math.max(0, 16 - (time - lastTime));
+  function timeoutDefer(fn) {
+    var time = +new Date(),
+        timeToCall = Math.max(0, 16 - (time - lastTime));
 
-		lastTime = time + timeToCall;
-		return window.setTimeout(fn, timeToCall);
-	}
+    lastTime = time + timeToCall;
+    return window.setTimeout(fn, timeToCall);
+  }
 
-	var requestFn = window.requestAnimationFrame ||
-	        getPrefixed('RequestAnimationFrame') || timeoutDefer;
+  var requestFn = window.requestAnimationFrame ||
+          getPrefixed('RequestAnimationFrame') || timeoutDefer;
 
-	var cancelFn = window.cancelAnimationFrame ||
-	        getPrefixed('CancelAnimationFrame') ||
-	        getPrefixed('CancelRequestAnimationFrame') ||
-	        function (id) { window.clearTimeout(id); };
+  var cancelFn = window.cancelAnimationFrame ||
+          getPrefixed('CancelAnimationFrame') ||
+          getPrefixed('CancelRequestAnimationFrame') ||
+          function (id) { window.clearTimeout(id); };
 
 
-	L.Util.requestAnimFrame = function (fn, context, immediate, element) {
-		fn = L.bind(fn, context);
+  L.Util.requestAnimFrame = function (fn, context, immediate, element) {
+    fn = L.bind(fn, context);
 
-		if (immediate && requestFn === timeoutDefer) {
-			fn();
-		} else {
-			return requestFn.call(window, fn, element);
-		}
-	};
+    if (immediate && requestFn === timeoutDefer) {
+      fn();
+    } else {
+      return requestFn.call(window, fn, element);
+    }
+  };
 
-	L.Util.cancelAnimFrame = function (id) {
-		if (id) {
-			cancelFn.call(window, id);
-		}
-	};
+  L.Util.cancelAnimFrame = function (id) {
+    if (id) {
+      cancelFn.call(window, id);
+    }
+  };
 
 }());
 
@@ -8115,102 +8115,102 @@ L.Class = function () {};
 
 L.Class.extend = function (props) {
 
-	// extended class with the new prototype
-	var NewClass = function () {
+  // extended class with the new prototype
+  var NewClass = function () {
 
-		// call the constructor
-		if (this.initialize) {
-			this.initialize.apply(this, arguments);
-		}
+    // call the constructor
+    if (this.initialize) {
+      this.initialize.apply(this, arguments);
+    }
 
-		// call all constructor hooks
-		if (this._initHooks) {
-			this.callInitHooks();
-		}
-	};
+    // call all constructor hooks
+    if (this._initHooks) {
+      this.callInitHooks();
+    }
+  };
 
-	// instantiate class without calling constructor
-	var F = function () {};
-	F.prototype = this.prototype;
+  // instantiate class without calling constructor
+  var F = function () {};
+  F.prototype = this.prototype;
 
-	var proto = new F();
-	proto.constructor = NewClass;
+  var proto = new F();
+  proto.constructor = NewClass;
 
-	NewClass.prototype = proto;
+  NewClass.prototype = proto;
 
-	//inherit parent's statics
-	for (var i in this) {
-		if (this.hasOwnProperty(i) && i !== 'prototype') {
-			NewClass[i] = this[i];
-		}
-	}
+  //inherit parent's statics
+  for (var i in this) {
+    if (this.hasOwnProperty(i) && i !== 'prototype') {
+      NewClass[i] = this[i];
+    }
+  }
 
-	// mix static properties into the class
-	if (props.statics) {
-		L.extend(NewClass, props.statics);
-		delete props.statics;
-	}
+  // mix static properties into the class
+  if (props.statics) {
+    L.extend(NewClass, props.statics);
+    delete props.statics;
+  }
 
-	// mix includes into the prototype
-	if (props.includes) {
-		L.Util.extend.apply(null, [proto].concat(props.includes));
-		delete props.includes;
-	}
+  // mix includes into the prototype
+  if (props.includes) {
+    L.Util.extend.apply(null, [proto].concat(props.includes));
+    delete props.includes;
+  }
 
-	// merge options
-	if (props.options && proto.options) {
-		props.options = L.extend({}, proto.options, props.options);
-	}
+  // merge options
+  if (props.options && proto.options) {
+    props.options = L.extend({}, proto.options, props.options);
+  }
 
-	// mix given properties into the prototype
-	L.extend(proto, props);
+  // mix given properties into the prototype
+  L.extend(proto, props);
 
-	proto._initHooks = [];
+  proto._initHooks = [];
 
-	var parent = this;
-	// jshint camelcase: false
-	NewClass.__super__ = parent.prototype;
+  var parent = this;
+  // jshint camelcase: false
+  NewClass.__super__ = parent.prototype;
 
-	// add method for calling all hooks
-	proto.callInitHooks = function () {
+  // add method for calling all hooks
+  proto.callInitHooks = function () {
 
-		if (this._initHooksCalled) { return; }
+    if (this._initHooksCalled) { return; }
 
-		if (parent.prototype.callInitHooks) {
-			parent.prototype.callInitHooks.call(this);
-		}
+    if (parent.prototype.callInitHooks) {
+      parent.prototype.callInitHooks.call(this);
+    }
 
-		this._initHooksCalled = true;
+    this._initHooksCalled = true;
 
-		for (var i = 0, len = proto._initHooks.length; i < len; i++) {
-			proto._initHooks[i].call(this);
-		}
-	};
+    for (var i = 0, len = proto._initHooks.length; i < len; i++) {
+      proto._initHooks[i].call(this);
+    }
+  };
 
-	return NewClass;
+  return NewClass;
 };
 
 
 // method for adding properties to prototype
 L.Class.include = function (props) {
-	L.extend(this.prototype, props);
+  L.extend(this.prototype, props);
 };
 
 // merge new default options to the Class
 L.Class.mergeOptions = function (options) {
-	L.extend(this.prototype.options, options);
+  L.extend(this.prototype.options, options);
 };
 
 // add a constructor hook
 L.Class.addInitHook = function (fn) { // (Function) || (String, args...)
-	var args = Array.prototype.slice.call(arguments, 1);
+  var args = Array.prototype.slice.call(arguments, 1);
 
-	var init = typeof fn === 'function' ? fn : function () {
-		this[fn].apply(this, args);
-	};
+  var init = typeof fn === 'function' ? fn : function () {
+    this[fn].apply(this, args);
+  };
 
-	this.prototype._initHooks = this.prototype._initHooks || [];
-	this.prototype._initHooks.push(init);
+  this.prototype._initHooks = this.prototype._initHooks || [];
+  this.prototype._initHooks.push(init);
 };
 
 
@@ -8228,168 +8228,168 @@ L.Mixin = {};
 
 L.Mixin.Events = {
 
-	addEventListener: function (types, fn, context) { // (String, Function[, Object]) or (Object[, Object])
+  addEventListener: function (types, fn, context) { // (String, Function[, Object]) or (Object[, Object])
 
-		// types can be a map of types/handlers
-		if (L.Util.invokeEach(types, this.addEventListener, this, fn, context)) { return this; }
+    // types can be a map of types/handlers
+    if (L.Util.invokeEach(types, this.addEventListener, this, fn, context)) { return this; }
 
-		var events = this[eventsKey] = this[eventsKey] || {},
-		    contextId = context && context !== this && L.stamp(context),
-		    i, len, event, type, indexKey, indexLenKey, typeIndex;
+    var events = this[eventsKey] = this[eventsKey] || {},
+        contextId = context && context !== this && L.stamp(context),
+        i, len, event, type, indexKey, indexLenKey, typeIndex;
 
-		// types can be a string of space-separated words
-		types = L.Util.splitWords(types);
+    // types can be a string of space-separated words
+    types = L.Util.splitWords(types);
 
-		for (i = 0, len = types.length; i < len; i++) {
-			event = {
-				action: fn,
-				context: context || this
-			};
-			type = types[i];
+    for (i = 0, len = types.length; i < len; i++) {
+      event = {
+        action: fn,
+        context: context || this
+      };
+      type = types[i];
 
-			if (contextId) {
-				// store listeners of a particular context in a separate hash (if it has an id)
-				// gives a major performance boost when removing thousands of map layers
+      if (contextId) {
+        // store listeners of a particular context in a separate hash (if it has an id)
+        // gives a major performance boost when removing thousands of map layers
 
-				indexKey = type + '_idx';
-				indexLenKey = indexKey + '_len';
+        indexKey = type + '_idx';
+        indexLenKey = indexKey + '_len';
 
-				typeIndex = events[indexKey] = events[indexKey] || {};
+        typeIndex = events[indexKey] = events[indexKey] || {};
 
-				if (!typeIndex[contextId]) {
-					typeIndex[contextId] = [];
+        if (!typeIndex[contextId]) {
+          typeIndex[contextId] = [];
 
-					// keep track of the number of keys in the index to quickly check if it's empty
-					events[indexLenKey] = (events[indexLenKey] || 0) + 1;
-				}
+          // keep track of the number of keys in the index to quickly check if it's empty
+          events[indexLenKey] = (events[indexLenKey] || 0) + 1;
+        }
 
-				typeIndex[contextId].push(event);
+        typeIndex[contextId].push(event);
 
 
-			} else {
-				events[type] = events[type] || [];
-				events[type].push(event);
-			}
-		}
+      } else {
+        events[type] = events[type] || [];
+        events[type].push(event);
+      }
+    }
 
-		return this;
-	},
+    return this;
+  },
 
-	hasEventListeners: function (type) { // (String) -> Boolean
-		var events = this[eventsKey];
-		return !!events && ((type in events && events[type].length > 0) ||
-		                    (type + '_idx' in events && events[type + '_idx_len'] > 0));
-	},
+  hasEventListeners: function (type) { // (String) -> Boolean
+    var events = this[eventsKey];
+    return !!events && ((type in events && events[type].length > 0) ||
+                        (type + '_idx' in events && events[type + '_idx_len'] > 0));
+  },
 
-	removeEventListener: function (types, fn, context) { // ([String, Function, Object]) or (Object[, Object])
+  removeEventListener: function (types, fn, context) { // ([String, Function, Object]) or (Object[, Object])
 
-		if (!this[eventsKey]) {
-			return this;
-		}
+    if (!this[eventsKey]) {
+      return this;
+    }
 
-		if (!types) {
-			return this.clearAllEventListeners();
-		}
+    if (!types) {
+      return this.clearAllEventListeners();
+    }
 
-		if (L.Util.invokeEach(types, this.removeEventListener, this, fn, context)) { return this; }
+    if (L.Util.invokeEach(types, this.removeEventListener, this, fn, context)) { return this; }
 
-		var events = this[eventsKey],
-		    contextId = context && context !== this && L.stamp(context),
-		    i, len, type, listeners, j, indexKey, indexLenKey, typeIndex, removed;
+    var events = this[eventsKey],
+        contextId = context && context !== this && L.stamp(context),
+        i, len, type, listeners, j, indexKey, indexLenKey, typeIndex, removed;
 
-		types = L.Util.splitWords(types);
+    types = L.Util.splitWords(types);
 
-		for (i = 0, len = types.length; i < len; i++) {
-			type = types[i];
-			indexKey = type + '_idx';
-			indexLenKey = indexKey + '_len';
+    for (i = 0, len = types.length; i < len; i++) {
+      type = types[i];
+      indexKey = type + '_idx';
+      indexLenKey = indexKey + '_len';
 
-			typeIndex = events[indexKey];
+      typeIndex = events[indexKey];
 
-			if (!fn) {
-				// clear all listeners for a type if function isn't specified
-				delete events[type];
-				delete events[indexKey];
-				delete events[indexLenKey];
+      if (!fn) {
+        // clear all listeners for a type if function isn't specified
+        delete events[type];
+        delete events[indexKey];
+        delete events[indexLenKey];
 
-			} else {
-				listeners = contextId && typeIndex ? typeIndex[contextId] : events[type];
+      } else {
+        listeners = contextId && typeIndex ? typeIndex[contextId] : events[type];
 
-				if (listeners) {
-					for (j = listeners.length - 1; j >= 0; j--) {
-						if ((listeners[j].action === fn) && (!context || (listeners[j].context === context))) {
-							removed = listeners.splice(j, 1);
-							// set the old action to a no-op, because it is possible
-							// that the listener is being iterated over as part of a dispatch
-							removed[0].action = L.Util.falseFn;
-						}
-					}
+        if (listeners) {
+          for (j = listeners.length - 1; j >= 0; j--) {
+            if ((listeners[j].action === fn) && (!context || (listeners[j].context === context))) {
+              removed = listeners.splice(j, 1);
+              // set the old action to a no-op, because it is possible
+              // that the listener is being iterated over as part of a dispatch
+              removed[0].action = L.Util.falseFn;
+            }
+          }
 
-					if (context && typeIndex && (listeners.length === 0)) {
-						delete typeIndex[contextId];
-						events[indexLenKey]--;
-					}
-				}
-			}
-		}
+          if (context && typeIndex && (listeners.length === 0)) {
+            delete typeIndex[contextId];
+            events[indexLenKey]--;
+          }
+        }
+      }
+    }
 
-		return this;
-	},
+    return this;
+  },
 
-	clearAllEventListeners: function () {
-		delete this[eventsKey];
-		return this;
-	},
+  clearAllEventListeners: function () {
+    delete this[eventsKey];
+    return this;
+  },
 
-	fireEvent: function (type, data) { // (String[, Object])
-		if (!this.hasEventListeners(type)) {
-			return this;
-		}
+  fireEvent: function (type, data) { // (String[, Object])
+    if (!this.hasEventListeners(type)) {
+      return this;
+    }
 
-		var event = L.Util.extend({}, data, { type: type, target: this });
+    var event = L.Util.extend({}, data, { type: type, target: this });
 
-		var events = this[eventsKey],
-		    listeners, i, len, typeIndex, contextId;
+    var events = this[eventsKey],
+        listeners, i, len, typeIndex, contextId;
 
-		if (events[type]) {
-			// make sure adding/removing listeners inside other listeners won't cause infinite loop
-			listeners = events[type].slice();
+    if (events[type]) {
+      // make sure adding/removing listeners inside other listeners won't cause infinite loop
+      listeners = events[type].slice();
 
-			for (i = 0, len = listeners.length; i < len; i++) {
-				listeners[i].action.call(listeners[i].context, event);
-			}
-		}
+      for (i = 0, len = listeners.length; i < len; i++) {
+        listeners[i].action.call(listeners[i].context, event);
+      }
+    }
 
-		// fire event for the context-indexed listeners as well
-		typeIndex = events[type + '_idx'];
+    // fire event for the context-indexed listeners as well
+    typeIndex = events[type + '_idx'];
 
-		for (contextId in typeIndex) {
-			listeners = typeIndex[contextId].slice();
+    for (contextId in typeIndex) {
+      listeners = typeIndex[contextId].slice();
 
-			if (listeners) {
-				for (i = 0, len = listeners.length; i < len; i++) {
-					listeners[i].action.call(listeners[i].context, event);
-				}
-			}
-		}
+      if (listeners) {
+        for (i = 0, len = listeners.length; i < len; i++) {
+          listeners[i].action.call(listeners[i].context, event);
+        }
+      }
+    }
 
-		return this;
-	},
+    return this;
+  },
 
-	addOneTimeEventListener: function (types, fn, context) {
+  addOneTimeEventListener: function (types, fn, context) {
 
-		if (L.Util.invokeEach(types, this.addOneTimeEventListener, this, fn, context)) { return this; }
+    if (L.Util.invokeEach(types, this.addOneTimeEventListener, this, fn, context)) { return this; }
 
-		var handler = L.bind(function () {
-			this
-			    .removeEventListener(types, fn, context)
-			    .removeEventListener(types, handler, context);
-		}, this);
+    var handler = L.bind(function () {
+      this
+          .removeEventListener(types, fn, context)
+          .removeEventListener(types, handler, context);
+    }, this);
 
-		return this
-		    .addEventListener(types, fn, context)
-		    .addEventListener(types, handler, context);
-	}
+    return this
+        .addEventListener(types, fn, context)
+        .addEventListener(types, handler, context);
+  }
 };
 
 L.Mixin.Events.on = L.Mixin.Events.addEventListener;
@@ -8408,95 +8408,95 @@ L.Mixin.Events.fire = L.Mixin.Events.fireEvent;
 
 (function () {
 
-	var ie = 'ActiveXObject' in window,
-		ielt9 = ie && !document.addEventListener,
+  var ie = 'ActiveXObject' in window,
+    ielt9 = ie && !document.addEventListener,
 
-	    // terrible browser detection to work around Safari / iOS / Android browser bugs
-	    ua = navigator.userAgent.toLowerCase(),
-	    webkit = ua.indexOf('webkit') !== -1,
-	    chrome = ua.indexOf('chrome') !== -1,
-	    phantomjs = ua.indexOf('phantom') !== -1,
-	    android = ua.indexOf('android') !== -1,
-	    android23 = ua.search('android [23]') !== -1,
-		gecko = ua.indexOf('gecko') !== -1,
+      // terrible browser detection to work around Safari / iOS / Android browser bugs
+      ua = navigator.userAgent.toLowerCase(),
+      webkit = ua.indexOf('webkit') !== -1,
+      chrome = ua.indexOf('chrome') !== -1,
+      phantomjs = ua.indexOf('phantom') !== -1,
+      android = ua.indexOf('android') !== -1,
+      android23 = ua.search('android [23]') !== -1,
+    gecko = ua.indexOf('gecko') !== -1,
 
-	    mobile = typeof orientation !== undefined + '',
-	    msPointer = window.navigator && window.navigator.msPointerEnabled &&
-	              window.navigator.msMaxTouchPoints && !window.PointerEvent,
-		pointer = (window.PointerEvent && window.navigator.pointerEnabled && window.navigator.maxTouchPoints) ||
-				  msPointer,
-	    retina = ('devicePixelRatio' in window && window.devicePixelRatio > 1) ||
-	             ('matchMedia' in window && window.matchMedia('(min-resolution:144dpi)') &&
-	              window.matchMedia('(min-resolution:144dpi)').matches),
+      mobile = typeof orientation !== undefined + '',
+      msPointer = window.navigator && window.navigator.msPointerEnabled &&
+                window.navigator.msMaxTouchPoints && !window.PointerEvent,
+    pointer = (window.PointerEvent && window.navigator.pointerEnabled && window.navigator.maxTouchPoints) ||
+          msPointer,
+      retina = ('devicePixelRatio' in window && window.devicePixelRatio > 1) ||
+               ('matchMedia' in window && window.matchMedia('(min-resolution:144dpi)') &&
+                window.matchMedia('(min-resolution:144dpi)').matches),
 
-	    doc = document.documentElement,
-	    ie3d = ie && ('transition' in doc.style),
-	    webkit3d = ('WebKitCSSMatrix' in window) && ('m11' in new window.WebKitCSSMatrix()) && !android23,
-	    gecko3d = 'MozPerspective' in doc.style,
-	    opera3d = 'OTransition' in doc.style,
-	    any3d = !window.L_DISABLE_3D && (ie3d || webkit3d || gecko3d || opera3d) && !phantomjs;
-
-
-	// PhantomJS has 'ontouchstart' in document.documentElement, but doesn't actually support touch.
-	// https://github.com/Leaflet/Leaflet/pull/1434#issuecomment-13843151
-
-	var touch = !window.L_NO_TOUCH && !phantomjs && (function () {
-
-		var startName = 'ontouchstart';
-
-		// IE10+ (We simulate these into touch* events in L.DomEvent and L.DomEvent.Pointer) or WebKit, etc.
-		if (pointer || (startName in doc)) {
-			return true;
-		}
-
-		// Firefox/Gecko
-		var div = document.createElement('div'),
-		    supported = false;
-
-		if (!div.setAttribute) {
-			return false;
-		}
-		div.setAttribute(startName, 'return;');
-
-		if (typeof div[startName] === 'function') {
-			supported = true;
-		}
-
-		div.removeAttribute(startName);
-		div = null;
-
-		return supported;
-	}());
+      doc = document.documentElement,
+      ie3d = ie && ('transition' in doc.style),
+      webkit3d = ('WebKitCSSMatrix' in window) && ('m11' in new window.WebKitCSSMatrix()) && !android23,
+      gecko3d = 'MozPerspective' in doc.style,
+      opera3d = 'OTransition' in doc.style,
+      any3d = !window.L_DISABLE_3D && (ie3d || webkit3d || gecko3d || opera3d) && !phantomjs;
 
 
-	L.Browser = {
-		ie: ie,
-		ielt9: ielt9,
-		webkit: webkit,
-		gecko: gecko && !webkit && !window.opera && !ie,
+  // PhantomJS has 'ontouchstart' in document.documentElement, but doesn't actually support touch.
+  // https://github.com/Leaflet/Leaflet/pull/1434#issuecomment-13843151
 
-		android: android,
-		android23: android23,
+  var touch = !window.L_NO_TOUCH && !phantomjs && (function () {
 
-		chrome: chrome,
+    var startName = 'ontouchstart';
 
-		ie3d: ie3d,
-		webkit3d: webkit3d,
-		gecko3d: gecko3d,
-		opera3d: opera3d,
-		any3d: any3d,
+    // IE10+ (We simulate these into touch* events in L.DomEvent and L.DomEvent.Pointer) or WebKit, etc.
+    if (pointer || (startName in doc)) {
+      return true;
+    }
 
-		mobile: mobile,
-		mobileWebkit: mobile && webkit,
-		mobileWebkit3d: mobile && webkit3d,
-		mobileOpera: mobile && window.opera,
+    // Firefox/Gecko
+    var div = document.createElement('div'),
+        supported = false;
 
-		touch: touch,
-		msPointer: msPointer,
-		pointer: pointer,
+    if (!div.setAttribute) {
+      return false;
+    }
+    div.setAttribute(startName, 'return;');
 
-		retina: retina
-	};
+    if (typeof div[startName] === 'function') {
+      supported = true;
+    }
+
+    div.removeAttribute(startName);
+    div = null;
+
+    return supported;
+  }());
+
+
+  L.Browser = {
+    ie: ie,
+    ielt9: ielt9,
+    webkit: webkit,
+    gecko: gecko && !webkit && !window.opera && !ie,
+
+    android: android,
+    android23: android23,
+
+    chrome: chrome,
+
+    ie3d: ie3d,
+    webkit3d: webkit3d,
+    gecko3d: gecko3d,
+    opera3d: opera3d,
+    any3d: any3d,
+
+    mobile: mobile,
+    mobileWebkit: mobile && webkit,
+    mobileWebkit3d: mobile && webkit3d,
+    mobileOpera: mobile && window.opera,
+
+    touch: touch,
+    msPointer: msPointer,
+    pointer: pointer,
+
+    retina: retina
+  };
 
 }());
 
@@ -8510,119 +8510,119 @@ L.Mixin.Events.fire = L.Mixin.Events.fireEvent;
  */
 
 L.Point = function (/*Number*/ x, /*Number*/ y, /*Boolean*/ round) {
-	this.x = (round ? Math.round(x) : x);
-	this.y = (round ? Math.round(y) : y);
+  this.x = (round ? Math.round(x) : x);
+  this.y = (round ? Math.round(y) : y);
 };
 
 L.Point.prototype = {
 
-	clone: function () {
-		return new L.Point(this.x, this.y);
-	},
+  clone: function () {
+    return new L.Point(this.x, this.y);
+  },
 
-	// non-destructive, returns a new point
-	add: function (point) {
-		return this.clone()._add(L.point(point));
-	},
+  // non-destructive, returns a new point
+  add: function (point) {
+    return this.clone()._add(L.point(point));
+  },
 
-	// destructive, used directly for performance in situations where it's safe to modify existing point
-	_add: function (point) {
-		this.x += point.x;
-		this.y += point.y;
-		return this;
-	},
+  // destructive, used directly for performance in situations where it's safe to modify existing point
+  _add: function (point) {
+    this.x += point.x;
+    this.y += point.y;
+    return this;
+  },
 
-	subtract: function (point) {
-		return this.clone()._subtract(L.point(point));
-	},
+  subtract: function (point) {
+    return this.clone()._subtract(L.point(point));
+  },
 
-	_subtract: function (point) {
-		this.x -= point.x;
-		this.y -= point.y;
-		return this;
-	},
+  _subtract: function (point) {
+    this.x -= point.x;
+    this.y -= point.y;
+    return this;
+  },
 
-	divideBy: function (num) {
-		return this.clone()._divideBy(num);
-	},
+  divideBy: function (num) {
+    return this.clone()._divideBy(num);
+  },
 
-	_divideBy: function (num) {
-		this.x /= num;
-		this.y /= num;
-		return this;
-	},
+  _divideBy: function (num) {
+    this.x /= num;
+    this.y /= num;
+    return this;
+  },
 
-	multiplyBy: function (num) {
-		return this.clone()._multiplyBy(num);
-	},
+  multiplyBy: function (num) {
+    return this.clone()._multiplyBy(num);
+  },
 
-	_multiplyBy: function (num) {
-		this.x *= num;
-		this.y *= num;
-		return this;
-	},
+  _multiplyBy: function (num) {
+    this.x *= num;
+    this.y *= num;
+    return this;
+  },
 
-	round: function () {
-		return this.clone()._round();
-	},
+  round: function () {
+    return this.clone()._round();
+  },
 
-	_round: function () {
-		this.x = Math.round(this.x);
-		this.y = Math.round(this.y);
-		return this;
-	},
+  _round: function () {
+    this.x = Math.round(this.x);
+    this.y = Math.round(this.y);
+    return this;
+  },
 
-	floor: function () {
-		return this.clone()._floor();
-	},
+  floor: function () {
+    return this.clone()._floor();
+  },
 
-	_floor: function () {
-		this.x = Math.floor(this.x);
-		this.y = Math.floor(this.y);
-		return this;
-	},
+  _floor: function () {
+    this.x = Math.floor(this.x);
+    this.y = Math.floor(this.y);
+    return this;
+  },
 
-	distanceTo: function (point) {
-		point = L.point(point);
+  distanceTo: function (point) {
+    point = L.point(point);
 
-		var x = point.x - this.x,
-		    y = point.y - this.y;
+    var x = point.x - this.x,
+        y = point.y - this.y;
 
-		return Math.sqrt(x * x + y * y);
-	},
+    return Math.sqrt(x * x + y * y);
+  },
 
-	equals: function (point) {
-		point = L.point(point);
+  equals: function (point) {
+    point = L.point(point);
 
-		return point.x === this.x &&
-		       point.y === this.y;
-	},
+    return point.x === this.x &&
+           point.y === this.y;
+  },
 
-	contains: function (point) {
-		point = L.point(point);
+  contains: function (point) {
+    point = L.point(point);
 
-		return Math.abs(point.x) <= Math.abs(this.x) &&
-		       Math.abs(point.y) <= Math.abs(this.y);
-	},
+    return Math.abs(point.x) <= Math.abs(this.x) &&
+           Math.abs(point.y) <= Math.abs(this.y);
+  },
 
-	toString: function () {
-		return 'Point(' +
-		        L.Util.formatNum(this.x) + ', ' +
-		        L.Util.formatNum(this.y) + ')';
-	}
+  toString: function () {
+    return 'Point(' +
+            L.Util.formatNum(this.x) + ', ' +
+            L.Util.formatNum(this.y) + ')';
+  }
 };
 
 L.point = function (x, y, round) {
-	if (x instanceof L.Point) {
-		return x;
-	}
-	if (L.Util.isArray(x)) {
-		return new L.Point(x[0], x[1]);
-	}
-	if (x === undefined || x === null) {
-		return x;
-	}
-	return new L.Point(x, y, round);
+  if (x instanceof L.Point) {
+    return x;
+  }
+  if (L.Util.isArray(x)) {
+    return new L.Point(x[0], x[1]);
+  }
+  if (x === undefined || x === null) {
+    return x;
+  }
+  return new L.Point(x, y, round);
 };
 
 
@@ -8635,95 +8635,95 @@ L.point = function (x, y, round) {
  */
 
 L.Bounds = function (a, b) { //(Point, Point) or Point[]
-	if (!a) { return; }
+  if (!a) { return; }
 
-	var points = b ? [a, b] : a;
+  var points = b ? [a, b] : a;
 
-	for (var i = 0, len = points.length; i < len; i++) {
-		this.extend(points[i]);
-	}
+  for (var i = 0, len = points.length; i < len; i++) {
+    this.extend(points[i]);
+  }
 };
 
 L.Bounds.prototype = {
-	// extend the bounds to contain the given point
-	extend: function (point) { // (Point)
-		point = L.point(point);
+  // extend the bounds to contain the given point
+  extend: function (point) { // (Point)
+    point = L.point(point);
 
-		if (!this.min && !this.max) {
-			this.min = point.clone();
-			this.max = point.clone();
-		} else {
-			this.min.x = Math.min(point.x, this.min.x);
-			this.max.x = Math.max(point.x, this.max.x);
-			this.min.y = Math.min(point.y, this.min.y);
-			this.max.y = Math.max(point.y, this.max.y);
-		}
-		return this;
-	},
+    if (!this.min && !this.max) {
+      this.min = point.clone();
+      this.max = point.clone();
+    } else {
+      this.min.x = Math.min(point.x, this.min.x);
+      this.max.x = Math.max(point.x, this.max.x);
+      this.min.y = Math.min(point.y, this.min.y);
+      this.max.y = Math.max(point.y, this.max.y);
+    }
+    return this;
+  },
 
-	getCenter: function (round) { // (Boolean) -> Point
-		return new L.Point(
-		        (this.min.x + this.max.x) / 2,
-		        (this.min.y + this.max.y) / 2, round);
-	},
+  getCenter: function (round) { // (Boolean) -> Point
+    return new L.Point(
+            (this.min.x + this.max.x) / 2,
+            (this.min.y + this.max.y) / 2, round);
+  },
 
-	getBottomLeft: function () { // -> Point
-		return new L.Point(this.min.x, this.max.y);
-	},
+  getBottomLeft: function () { // -> Point
+    return new L.Point(this.min.x, this.max.y);
+  },
 
-	getTopRight: function () { // -> Point
-		return new L.Point(this.max.x, this.min.y);
-	},
+  getTopRight: function () { // -> Point
+    return new L.Point(this.max.x, this.min.y);
+  },
 
-	getSize: function () {
-		return this.max.subtract(this.min);
-	},
+  getSize: function () {
+    return this.max.subtract(this.min);
+  },
 
-	contains: function (obj) { // (Bounds) or (Point) -> Boolean
-		var min, max;
+  contains: function (obj) { // (Bounds) or (Point) -> Boolean
+    var min, max;
 
-		if (typeof obj[0] === 'number' || obj instanceof L.Point) {
-			obj = L.point(obj);
-		} else {
-			obj = L.bounds(obj);
-		}
+    if (typeof obj[0] === 'number' || obj instanceof L.Point) {
+      obj = L.point(obj);
+    } else {
+      obj = L.bounds(obj);
+    }
 
-		if (obj instanceof L.Bounds) {
-			min = obj.min;
-			max = obj.max;
-		} else {
-			min = max = obj;
-		}
+    if (obj instanceof L.Bounds) {
+      min = obj.min;
+      max = obj.max;
+    } else {
+      min = max = obj;
+    }
 
-		return (min.x >= this.min.x) &&
-		       (max.x <= this.max.x) &&
-		       (min.y >= this.min.y) &&
-		       (max.y <= this.max.y);
-	},
+    return (min.x >= this.min.x) &&
+           (max.x <= this.max.x) &&
+           (min.y >= this.min.y) &&
+           (max.y <= this.max.y);
+  },
 
-	intersects: function (bounds) { // (Bounds) -> Boolean
-		bounds = L.bounds(bounds);
+  intersects: function (bounds) { // (Bounds) -> Boolean
+    bounds = L.bounds(bounds);
 
-		var min = this.min,
-		    max = this.max,
-		    min2 = bounds.min,
-		    max2 = bounds.max,
-		    xIntersects = (max2.x >= min.x) && (min2.x <= max.x),
-		    yIntersects = (max2.y >= min.y) && (min2.y <= max.y);
+    var min = this.min,
+        max = this.max,
+        min2 = bounds.min,
+        max2 = bounds.max,
+        xIntersects = (max2.x >= min.x) && (min2.x <= max.x),
+        yIntersects = (max2.y >= min.y) && (min2.y <= max.y);
 
-		return xIntersects && yIntersects;
-	},
+    return xIntersects && yIntersects;
+  },
 
-	isValid: function () {
-		return !!(this.min && this.max);
-	}
+  isValid: function () {
+    return !!(this.min && this.max);
+  }
 };
 
 L.bounds = function (a, b) { // (Bounds) or (Point, Point) or (Point[])
-	if (!a || a instanceof L.Bounds) {
-		return a;
-	}
-	return new L.Bounds(a, b);
+  if (!a || a instanceof L.Bounds) {
+    return a;
+  }
+  return new L.Bounds(a, b);
 };
 
 
@@ -8736,31 +8736,31 @@ L.bounds = function (a, b) { // (Bounds) or (Point, Point) or (Point[])
  */
 
 L.Transformation = function (a, b, c, d) {
-	this._a = a;
-	this._b = b;
-	this._c = c;
-	this._d = d;
+  this._a = a;
+  this._b = b;
+  this._c = c;
+  this._d = d;
 };
 
 L.Transformation.prototype = {
-	transform: function (point, scale) { // (Point, Number) -> Point
-		return this._transform(point.clone(), scale);
-	},
+  transform: function (point, scale) { // (Point, Number) -> Point
+    return this._transform(point.clone(), scale);
+  },
 
-	// destructive transform (faster)
-	_transform: function (point, scale) {
-		scale = scale || 1;
-		point.x = scale * (this._a * point.x + this._b);
-		point.y = scale * (this._c * point.y + this._d);
-		return point;
-	},
+  // destructive transform (faster)
+  _transform: function (point, scale) {
+    scale = scale || 1;
+    point.x = scale * (this._a * point.x + this._b);
+    point.y = scale * (this._c * point.y + this._d);
+    return point;
+  },
 
-	untransform: function (point, scale) {
-		scale = scale || 1;
-		return new L.Point(
-		        (point.x / scale - this._b) / this._a,
-		        (point.y / scale - this._d) / this._c);
-	}
+  untransform: function (point, scale) {
+    scale = scale || 1;
+    return new L.Point(
+            (point.x / scale - this._b) / this._a,
+            (point.y / scale - this._d) / this._c);
+  }
 };
 
 
@@ -8773,229 +8773,229 @@ L.Transformation.prototype = {
  */
 
 L.DomUtil = {
-	get: function (id) {
-		return (typeof id === 'string' ? document.getElementById(id) : id);
-	},
+  get: function (id) {
+    return (typeof id === 'string' ? document.getElementById(id) : id);
+  },
 
-	getStyle: function (el, style) {
+  getStyle: function (el, style) {
 
-		var value = el.style[style];
+    var value = el.style[style];
 
-		if (!value && el.currentStyle) {
-			value = el.currentStyle[style];
-		}
+    if (!value && el.currentStyle) {
+      value = el.currentStyle[style];
+    }
 
-		if ((!value || value === 'auto') && document.defaultView) {
-			var css = document.defaultView.getComputedStyle(el, null);
-			value = css ? css[style] : null;
-		}
+    if ((!value || value === 'auto') && document.defaultView) {
+      var css = document.defaultView.getComputedStyle(el, null);
+      value = css ? css[style] : null;
+    }
 
-		return value === 'auto' ? null : value;
-	},
+    return value === 'auto' ? null : value;
+  },
 
-	getViewportOffset: function (element) {
+  getViewportOffset: function (element) {
 
-		var top = 0,
-		    left = 0,
-		    el = element,
-		    docBody = document.body,
-		    docEl = document.documentElement,
-		    pos;
+    var top = 0,
+        left = 0,
+        el = element,
+        docBody = document.body,
+        docEl = document.documentElement,
+        pos;
 
-		do {
-			top  += el.offsetTop  || 0;
-			left += el.offsetLeft || 0;
+    do {
+      top  += el.offsetTop  || 0;
+      left += el.offsetLeft || 0;
 
-			//add borders
-			top += parseInt(L.DomUtil.getStyle(el, 'borderTopWidth'), 10) || 0;
-			left += parseInt(L.DomUtil.getStyle(el, 'borderLeftWidth'), 10) || 0;
+      //add borders
+      top += parseInt(L.DomUtil.getStyle(el, 'borderTopWidth'), 10) || 0;
+      left += parseInt(L.DomUtil.getStyle(el, 'borderLeftWidth'), 10) || 0;
 
-			pos = L.DomUtil.getStyle(el, 'position');
+      pos = L.DomUtil.getStyle(el, 'position');
 
-			if (el.offsetParent === docBody && pos === 'absolute') { break; }
+      if (el.offsetParent === docBody && pos === 'absolute') { break; }
 
-			if (pos === 'fixed') {
-				top  += docBody.scrollTop  || docEl.scrollTop  || 0;
-				left += docBody.scrollLeft || docEl.scrollLeft || 0;
-				break;
-			}
+      if (pos === 'fixed') {
+        top  += docBody.scrollTop  || docEl.scrollTop  || 0;
+        left += docBody.scrollLeft || docEl.scrollLeft || 0;
+        break;
+      }
 
-			if (pos === 'relative' && !el.offsetLeft) {
-				var width = L.DomUtil.getStyle(el, 'width'),
-				    maxWidth = L.DomUtil.getStyle(el, 'max-width'),
-				    r = el.getBoundingClientRect();
+      if (pos === 'relative' && !el.offsetLeft) {
+        var width = L.DomUtil.getStyle(el, 'width'),
+            maxWidth = L.DomUtil.getStyle(el, 'max-width'),
+            r = el.getBoundingClientRect();
 
-				if (width !== 'none' || maxWidth !== 'none') {
-					left += r.left + el.clientLeft;
-				}
+        if (width !== 'none' || maxWidth !== 'none') {
+          left += r.left + el.clientLeft;
+        }
 
-				//calculate full y offset since we're breaking out of the loop
-				top += r.top + (docBody.scrollTop  || docEl.scrollTop  || 0);
+        //calculate full y offset since we're breaking out of the loop
+        top += r.top + (docBody.scrollTop  || docEl.scrollTop  || 0);
 
-				break;
-			}
+        break;
+      }
 
-			el = el.offsetParent;
+      el = el.offsetParent;
 
-		} while (el);
+    } while (el);
 
-		el = element;
+    el = element;
 
-		do {
-			if (el === docBody) { break; }
+    do {
+      if (el === docBody) { break; }
 
-			top  -= el.scrollTop  || 0;
-			left -= el.scrollLeft || 0;
+      top  -= el.scrollTop  || 0;
+      left -= el.scrollLeft || 0;
 
-			el = el.parentNode;
-		} while (el);
+      el = el.parentNode;
+    } while (el);
 
-		return new L.Point(left, top);
-	},
+    return new L.Point(left, top);
+  },
 
-	documentIsLtr: function () {
-		if (!L.DomUtil._docIsLtrCached) {
-			L.DomUtil._docIsLtrCached = true;
-			L.DomUtil._docIsLtr = L.DomUtil.getStyle(document.body, 'direction') === 'ltr';
-		}
-		return L.DomUtil._docIsLtr;
-	},
+  documentIsLtr: function () {
+    if (!L.DomUtil._docIsLtrCached) {
+      L.DomUtil._docIsLtrCached = true;
+      L.DomUtil._docIsLtr = L.DomUtil.getStyle(document.body, 'direction') === 'ltr';
+    }
+    return L.DomUtil._docIsLtr;
+  },
 
-	create: function (tagName, className, container) {
+  create: function (tagName, className, container) {
 
-		var el = document.createElement(tagName);
-		el.className = className;
+    var el = document.createElement(tagName);
+    el.className = className;
 
-		if (container) {
-			container.appendChild(el);
-		}
+    if (container) {
+      container.appendChild(el);
+    }
 
-		return el;
-	},
+    return el;
+  },
 
-	hasClass: function (el, name) {
-		if (el.classList !== undefined) {
-			return el.classList.contains(name);
-		}
-		var className = L.DomUtil._getClass(el);
-		return className.length > 0 && new RegExp('(^|\\s)' + name + '(\\s|$)').test(className);
-	},
+  hasClass: function (el, name) {
+    if (el.classList !== undefined) {
+      return el.classList.contains(name);
+    }
+    var className = L.DomUtil._getClass(el);
+    return className.length > 0 && new RegExp('(^|\\s)' + name + '(\\s|$)').test(className);
+  },
 
-	addClass: function (el, name) {
-		if (el.classList !== undefined) {
-			var classes = L.Util.splitWords(name);
-			for (var i = 0, len = classes.length; i < len; i++) {
-				el.classList.add(classes[i]);
-			}
-		} else if (!L.DomUtil.hasClass(el, name)) {
-			var className = L.DomUtil._getClass(el);
-			L.DomUtil._setClass(el, (className ? className + ' ' : '') + name);
-		}
-	},
+  addClass: function (el, name) {
+    if (el.classList !== undefined) {
+      var classes = L.Util.splitWords(name);
+      for (var i = 0, len = classes.length; i < len; i++) {
+        el.classList.add(classes[i]);
+      }
+    } else if (!L.DomUtil.hasClass(el, name)) {
+      var className = L.DomUtil._getClass(el);
+      L.DomUtil._setClass(el, (className ? className + ' ' : '') + name);
+    }
+  },
 
-	removeClass: function (el, name) {
-		if (el.classList !== undefined) {
-			el.classList.remove(name);
-		} else {
-			L.DomUtil._setClass(el, L.Util.trim((' ' + L.DomUtil._getClass(el) + ' ').replace(' ' + name + ' ', ' ')));
-		}
-	},
+  removeClass: function (el, name) {
+    if (el.classList !== undefined) {
+      el.classList.remove(name);
+    } else {
+      L.DomUtil._setClass(el, L.Util.trim((' ' + L.DomUtil._getClass(el) + ' ').replace(' ' + name + ' ', ' ')));
+    }
+  },
 
-	_setClass: function (el, name) {
-		if (el.className.baseVal === undefined) {
-			el.className = name;
-		} else {
-			// in case of SVG element
-			el.className.baseVal = name;
-		}
-	},
+  _setClass: function (el, name) {
+    if (el.className.baseVal === undefined) {
+      el.className = name;
+    } else {
+      // in case of SVG element
+      el.className.baseVal = name;
+    }
+  },
 
-	_getClass: function (el) {
-		return el.className.baseVal === undefined ? el.className : el.className.baseVal;
-	},
+  _getClass: function (el) {
+    return el.className.baseVal === undefined ? el.className : el.className.baseVal;
+  },
 
-	setOpacity: function (el, value) {
+  setOpacity: function (el, value) {
 
-		if ('opacity' in el.style) {
-			el.style.opacity = value;
+    if ('opacity' in el.style) {
+      el.style.opacity = value;
 
-		} else if ('filter' in el.style) {
+    } else if ('filter' in el.style) {
 
-			var filter = false,
-			    filterName = 'DXImageTransform.Microsoft.Alpha';
+      var filter = false,
+          filterName = 'DXImageTransform.Microsoft.Alpha';
 
-			// filters collection throws an error if we try to retrieve a filter that doesn't exist
-			try {
-				filter = el.filters.item(filterName);
-			} catch (e) {
-				// don't set opacity to 1 if we haven't already set an opacity,
-				// it isn't needed and breaks transparent pngs.
-				if (value === 1) { return; }
-			}
+      // filters collection throws an error if we try to retrieve a filter that doesn't exist
+      try {
+        filter = el.filters.item(filterName);
+      } catch (e) {
+        // don't set opacity to 1 if we haven't already set an opacity,
+        // it isn't needed and breaks transparent pngs.
+        if (value === 1) { return; }
+      }
 
-			value = Math.round(value * 100);
+      value = Math.round(value * 100);
 
-			if (filter) {
-				filter.Enabled = (value !== 100);
-				filter.Opacity = value;
-			} else {
-				el.style.filter += ' progid:' + filterName + '(opacity=' + value + ')';
-			}
-		}
-	},
+      if (filter) {
+        filter.Enabled = (value !== 100);
+        filter.Opacity = value;
+      } else {
+        el.style.filter += ' progid:' + filterName + '(opacity=' + value + ')';
+      }
+    }
+  },
 
-	testProp: function (props) {
+  testProp: function (props) {
 
-		var style = document.documentElement.style;
+    var style = document.documentElement.style;
 
-		for (var i = 0; i < props.length; i++) {
-			if (props[i] in style) {
-				return props[i];
-			}
-		}
-		return false;
-	},
+    for (var i = 0; i < props.length; i++) {
+      if (props[i] in style) {
+        return props[i];
+      }
+    }
+    return false;
+  },
 
-	getTranslateString: function (point) {
-		// on WebKit browsers (Chrome/Safari/iOS Safari/Android) using translate3d instead of translate
-		// makes animation smoother as it ensures HW accel is used. Firefox 13 doesn't care
-		// (same speed either way), Opera 12 doesn't support translate3d
+  getTranslateString: function (point) {
+    // on WebKit browsers (Chrome/Safari/iOS Safari/Android) using translate3d instead of translate
+    // makes animation smoother as it ensures HW accel is used. Firefox 13 doesn't care
+    // (same speed either way), Opera 12 doesn't support translate3d
 
-		var is3d = L.Browser.webkit3d,
-		    open = 'translate' + (is3d ? '3d' : '') + '(',
-		    close = (is3d ? ',0' : '') + ')';
+    var is3d = L.Browser.webkit3d,
+        open = 'translate' + (is3d ? '3d' : '') + '(',
+        close = (is3d ? ',0' : '') + ')';
 
-		return open + point.x + 'px,' + point.y + 'px' + close;
-	},
+    return open + point.x + 'px,' + point.y + 'px' + close;
+  },
 
-	getScaleString: function (scale, origin) {
+  getScaleString: function (scale, origin) {
 
-		var preTranslateStr = L.DomUtil.getTranslateString(origin.add(origin.multiplyBy(-1 * scale))),
-		    scaleStr = ' scale(' + scale + ') ';
+    var preTranslateStr = L.DomUtil.getTranslateString(origin.add(origin.multiplyBy(-1 * scale))),
+        scaleStr = ' scale(' + scale + ') ';
 
-		return preTranslateStr + scaleStr;
-	},
+    return preTranslateStr + scaleStr;
+  },
 
-	setPosition: function (el, point, disable3D) { // (HTMLElement, Point[, Boolean])
+  setPosition: function (el, point, disable3D) { // (HTMLElement, Point[, Boolean])
 
-		// jshint camelcase: false
-		el._leaflet_pos = point;
+    // jshint camelcase: false
+    el._leaflet_pos = point;
 
-		if (!disable3D && L.Browser.any3d) {
-			el.style[L.DomUtil.TRANSFORM] =  L.DomUtil.getTranslateString(point);
-		} else {
-			el.style.left = point.x + 'px';
-			el.style.top = point.y + 'px';
-		}
-	},
+    if (!disable3D && L.Browser.any3d) {
+      el.style[L.DomUtil.TRANSFORM] =  L.DomUtil.getTranslateString(point);
+    } else {
+      el.style.left = point.x + 'px';
+      el.style.top = point.y + 'px';
+    }
+  },
 
-	getPosition: function (el) {
-		// this method is only used for elements previously positioned using setPosition,
-		// so it's safe to cache the position for performance
+  getPosition: function (el) {
+    // this method is only used for elements previously positioned using setPosition,
+    // so it's safe to cache the position for performance
 
-		// jshint camelcase: false
-		return el._leaflet_pos;
-	}
+    // jshint camelcase: false
+    return el._leaflet_pos;
+  }
 };
 
 
@@ -9047,15 +9047,15 @@ L.DomUtil.TRANSITION_END =
         });
     }
 
-	L.extend(L.DomUtil, {
-		disableImageDrag: function () {
-			L.DomEvent.on(window, 'dragstart', L.DomEvent.preventDefault);
-		},
+  L.extend(L.DomUtil, {
+    disableImageDrag: function () {
+      L.DomEvent.on(window, 'dragstart', L.DomEvent.preventDefault);
+    },
 
-		enableImageDrag: function () {
-			L.DomEvent.off(window, 'dragstart', L.DomEvent.preventDefault);
-		}
-	});
+    enableImageDrag: function () {
+      L.DomEvent.off(window, 'dragstart', L.DomEvent.preventDefault);
+    }
+  });
 })();
 
 
@@ -9068,98 +9068,98 @@ L.DomUtil.TRANSITION_END =
  */
 
 L.LatLng = function (lat, lng, alt) { // (Number, Number, Number)
-	lat = parseFloat(lat);
-	lng = parseFloat(lng);
+  lat = parseFloat(lat);
+  lng = parseFloat(lng);
 
-	if (isNaN(lat) || isNaN(lng)) {
-		throw new Error('Invalid LatLng object: (' + lat + ', ' + lng + ')');
-	}
+  if (isNaN(lat) || isNaN(lng)) {
+    throw new Error('Invalid LatLng object: (' + lat + ', ' + lng + ')');
+  }
 
-	this.lat = lat;
-	this.lng = lng;
+  this.lat = lat;
+  this.lng = lng;
 
-	if (alt !== undefined) {
-		this.alt = parseFloat(alt);
-	}
+  if (alt !== undefined) {
+    this.alt = parseFloat(alt);
+  }
 };
 
 L.extend(L.LatLng, {
-	DEG_TO_RAD: Math.PI / 180,
-	RAD_TO_DEG: 180 / Math.PI,
-	MAX_MARGIN: 1.0E-9 // max margin of error for the "equals" check
+  DEG_TO_RAD: Math.PI / 180,
+  RAD_TO_DEG: 180 / Math.PI,
+  MAX_MARGIN: 1.0E-9 // max margin of error for the "equals" check
 });
 
 L.LatLng.prototype = {
-	equals: function (obj) { // (LatLng) -> Boolean
-		if (!obj) { return false; }
+  equals: function (obj) { // (LatLng) -> Boolean
+    if (!obj) { return false; }
 
-		obj = L.latLng(obj);
+    obj = L.latLng(obj);
 
-		var margin = Math.max(
-		        Math.abs(this.lat - obj.lat),
-		        Math.abs(this.lng - obj.lng));
+    var margin = Math.max(
+            Math.abs(this.lat - obj.lat),
+            Math.abs(this.lng - obj.lng));
 
-		return margin <= L.LatLng.MAX_MARGIN;
-	},
+    return margin <= L.LatLng.MAX_MARGIN;
+  },
 
-	toString: function (precision) { // (Number) -> String
-		return 'LatLng(' +
-		        L.Util.formatNum(this.lat, precision) + ', ' +
-		        L.Util.formatNum(this.lng, precision) + ')';
-	},
+  toString: function (precision) { // (Number) -> String
+    return 'LatLng(' +
+            L.Util.formatNum(this.lat, precision) + ', ' +
+            L.Util.formatNum(this.lng, precision) + ')';
+  },
 
-	// Haversine distance formula, see http://en.wikipedia.org/wiki/Haversine_formula
-	// TODO move to projection code, LatLng shouldn't know about Earth
-	distanceTo: function (other) { // (LatLng) -> Number
-		other = L.latLng(other);
+  // Haversine distance formula, see http://en.wikipedia.org/wiki/Haversine_formula
+  // TODO move to projection code, LatLng shouldn't know about Earth
+  distanceTo: function (other) { // (LatLng) -> Number
+    other = L.latLng(other);
 
-		var R = 6378137, // earth radius in meters
-		    d2r = L.LatLng.DEG_TO_RAD,
-		    dLat = (other.lat - this.lat) * d2r,
-		    dLon = (other.lng - this.lng) * d2r,
-		    lat1 = this.lat * d2r,
-		    lat2 = other.lat * d2r,
-		    sin1 = Math.sin(dLat / 2),
-		    sin2 = Math.sin(dLon / 2);
+    var R = 6378137, // earth radius in meters
+        d2r = L.LatLng.DEG_TO_RAD,
+        dLat = (other.lat - this.lat) * d2r,
+        dLon = (other.lng - this.lng) * d2r,
+        lat1 = this.lat * d2r,
+        lat2 = other.lat * d2r,
+        sin1 = Math.sin(dLat / 2),
+        sin2 = Math.sin(dLon / 2);
 
-		var a = sin1 * sin1 + sin2 * sin2 * Math.cos(lat1) * Math.cos(lat2);
+    var a = sin1 * sin1 + sin2 * sin2 * Math.cos(lat1) * Math.cos(lat2);
 
-		return R * 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
-	},
+    return R * 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+  },
 
-	wrap: function (a, b) { // (Number, Number) -> LatLng
-		var lng = this.lng;
+  wrap: function (a, b) { // (Number, Number) -> LatLng
+    var lng = this.lng;
 
-		a = a || -180;
-		b = b ||  180;
+    a = a || -180;
+    b = b ||  180;
 
-		lng = (lng + b) % (b - a) + (lng < a || lng === b ? b : a);
+    lng = (lng + b) % (b - a) + (lng < a || lng === b ? b : a);
 
-		return new L.LatLng(this.lat, lng);
-	}
+    return new L.LatLng(this.lat, lng);
+  }
 };
 
 L.latLng = function (a, b) { // (LatLng) or ([Number, Number]) or (Number, Number)
-	if (a instanceof L.LatLng) {
-		return a;
-	}
-	if (L.Util.isArray(a)) {
-		if (typeof a[0] === 'number' || typeof a[0] === 'string') {
-			return new L.LatLng(a[0], a[1], a[2]);
-		} else {
-			return null;
-		}
-	}
-	if (a === undefined || a === null) {
-		return a;
-	}
-	if (typeof a === 'object' && 'lat' in a) {
-		return new L.LatLng(a.lat, 'lng' in a ? a.lng : a.lon);
-	}
-	if (b === undefined) {
-		return null;
-	}
-	return new L.LatLng(a, b);
+  if (a instanceof L.LatLng) {
+    return a;
+  }
+  if (L.Util.isArray(a)) {
+    if (typeof a[0] === 'number' || typeof a[0] === 'string') {
+      return new L.LatLng(a[0], a[1], a[2]);
+    } else {
+      return null;
+    }
+  }
+  if (a === undefined || a === null) {
+    return a;
+  }
+  if (typeof a === 'object' && 'lat' in a) {
+    return new L.LatLng(a.lat, 'lng' in a ? a.lng : a.lon);
+  }
+  if (b === undefined) {
+    return null;
+  }
+  return new L.LatLng(a, b);
 };
 
 
@@ -9173,156 +9173,156 @@ L.latLng = function (a, b) { // (LatLng) or ([Number, Number]) or (Number, Numbe
  */
 
 L.LatLngBounds = function (southWest, northEast) { // (LatLng, LatLng) or (LatLng[])
-	if (!southWest) { return; }
+  if (!southWest) { return; }
 
-	var latlngs = northEast ? [southWest, northEast] : southWest;
+  var latlngs = northEast ? [southWest, northEast] : southWest;
 
-	for (var i = 0, len = latlngs.length; i < len; i++) {
-		this.extend(latlngs[i]);
-	}
+  for (var i = 0, len = latlngs.length; i < len; i++) {
+    this.extend(latlngs[i]);
+  }
 };
 
 L.LatLngBounds.prototype = {
-	// extend the bounds to contain the given point or bounds
-	extend: function (obj) { // (LatLng) or (LatLngBounds)
-		if (!obj) { return this; }
+  // extend the bounds to contain the given point or bounds
+  extend: function (obj) { // (LatLng) or (LatLngBounds)
+    if (!obj) { return this; }
 
-		var latLng = L.latLng(obj);
-		if (latLng !== null) {
-			obj = latLng;
-		} else {
-			obj = L.latLngBounds(obj);
-		}
+    var latLng = L.latLng(obj);
+    if (latLng !== null) {
+      obj = latLng;
+    } else {
+      obj = L.latLngBounds(obj);
+    }
 
-		if (obj instanceof L.LatLng) {
-			if (!this._southWest && !this._northEast) {
-				this._southWest = new L.LatLng(obj.lat, obj.lng);
-				this._northEast = new L.LatLng(obj.lat, obj.lng);
-			} else {
-				this._southWest.lat = Math.min(obj.lat, this._southWest.lat);
-				this._southWest.lng = Math.min(obj.lng, this._southWest.lng);
+    if (obj instanceof L.LatLng) {
+      if (!this._southWest && !this._northEast) {
+        this._southWest = new L.LatLng(obj.lat, obj.lng);
+        this._northEast = new L.LatLng(obj.lat, obj.lng);
+      } else {
+        this._southWest.lat = Math.min(obj.lat, this._southWest.lat);
+        this._southWest.lng = Math.min(obj.lng, this._southWest.lng);
 
-				this._northEast.lat = Math.max(obj.lat, this._northEast.lat);
-				this._northEast.lng = Math.max(obj.lng, this._northEast.lng);
-			}
-		} else if (obj instanceof L.LatLngBounds) {
-			this.extend(obj._southWest);
-			this.extend(obj._northEast);
-		}
-		return this;
-	},
+        this._northEast.lat = Math.max(obj.lat, this._northEast.lat);
+        this._northEast.lng = Math.max(obj.lng, this._northEast.lng);
+      }
+    } else if (obj instanceof L.LatLngBounds) {
+      this.extend(obj._southWest);
+      this.extend(obj._northEast);
+    }
+    return this;
+  },
 
-	// extend the bounds by a percentage
-	pad: function (bufferRatio) { // (Number) -> LatLngBounds
-		var sw = this._southWest,
-		    ne = this._northEast,
-		    heightBuffer = Math.abs(sw.lat - ne.lat) * bufferRatio,
-		    widthBuffer = Math.abs(sw.lng - ne.lng) * bufferRatio;
+  // extend the bounds by a percentage
+  pad: function (bufferRatio) { // (Number) -> LatLngBounds
+    var sw = this._southWest,
+        ne = this._northEast,
+        heightBuffer = Math.abs(sw.lat - ne.lat) * bufferRatio,
+        widthBuffer = Math.abs(sw.lng - ne.lng) * bufferRatio;
 
-		return new L.LatLngBounds(
-		        new L.LatLng(sw.lat - heightBuffer, sw.lng - widthBuffer),
-		        new L.LatLng(ne.lat + heightBuffer, ne.lng + widthBuffer));
-	},
+    return new L.LatLngBounds(
+            new L.LatLng(sw.lat - heightBuffer, sw.lng - widthBuffer),
+            new L.LatLng(ne.lat + heightBuffer, ne.lng + widthBuffer));
+  },
 
-	getCenter: function () { // -> LatLng
-		return new L.LatLng(
-		        (this._southWest.lat + this._northEast.lat) / 2,
-		        (this._southWest.lng + this._northEast.lng) / 2);
-	},
+  getCenter: function () { // -> LatLng
+    return new L.LatLng(
+            (this._southWest.lat + this._northEast.lat) / 2,
+            (this._southWest.lng + this._northEast.lng) / 2);
+  },
 
-	getSouthWest: function () {
-		return this._southWest;
-	},
+  getSouthWest: function () {
+    return this._southWest;
+  },
 
-	getNorthEast: function () {
-		return this._northEast;
-	},
+  getNorthEast: function () {
+    return this._northEast;
+  },
 
-	getNorthWest: function () {
-		return new L.LatLng(this.getNorth(), this.getWest());
-	},
+  getNorthWest: function () {
+    return new L.LatLng(this.getNorth(), this.getWest());
+  },
 
-	getSouthEast: function () {
-		return new L.LatLng(this.getSouth(), this.getEast());
-	},
+  getSouthEast: function () {
+    return new L.LatLng(this.getSouth(), this.getEast());
+  },
 
-	getWest: function () {
-		return this._southWest.lng;
-	},
+  getWest: function () {
+    return this._southWest.lng;
+  },
 
-	getSouth: function () {
-		return this._southWest.lat;
-	},
+  getSouth: function () {
+    return this._southWest.lat;
+  },
 
-	getEast: function () {
-		return this._northEast.lng;
-	},
+  getEast: function () {
+    return this._northEast.lng;
+  },
 
-	getNorth: function () {
-		return this._northEast.lat;
-	},
+  getNorth: function () {
+    return this._northEast.lat;
+  },
 
-	contains: function (obj) { // (LatLngBounds) or (LatLng) -> Boolean
-		if (typeof obj[0] === 'number' || obj instanceof L.LatLng) {
-			obj = L.latLng(obj);
-		} else {
-			obj = L.latLngBounds(obj);
-		}
+  contains: function (obj) { // (LatLngBounds) or (LatLng) -> Boolean
+    if (typeof obj[0] === 'number' || obj instanceof L.LatLng) {
+      obj = L.latLng(obj);
+    } else {
+      obj = L.latLngBounds(obj);
+    }
 
-		var sw = this._southWest,
-		    ne = this._northEast,
-		    sw2, ne2;
+    var sw = this._southWest,
+        ne = this._northEast,
+        sw2, ne2;
 
-		if (obj instanceof L.LatLngBounds) {
-			sw2 = obj.getSouthWest();
-			ne2 = obj.getNorthEast();
-		} else {
-			sw2 = ne2 = obj;
-		}
+    if (obj instanceof L.LatLngBounds) {
+      sw2 = obj.getSouthWest();
+      ne2 = obj.getNorthEast();
+    } else {
+      sw2 = ne2 = obj;
+    }
 
-		return (sw2.lat >= sw.lat) && (ne2.lat <= ne.lat) &&
-		       (sw2.lng >= sw.lng) && (ne2.lng <= ne.lng);
-	},
+    return (sw2.lat >= sw.lat) && (ne2.lat <= ne.lat) &&
+           (sw2.lng >= sw.lng) && (ne2.lng <= ne.lng);
+  },
 
-	intersects: function (bounds) { // (LatLngBounds)
-		bounds = L.latLngBounds(bounds);
+  intersects: function (bounds) { // (LatLngBounds)
+    bounds = L.latLngBounds(bounds);
 
-		var sw = this._southWest,
-		    ne = this._northEast,
-		    sw2 = bounds.getSouthWest(),
-		    ne2 = bounds.getNorthEast(),
+    var sw = this._southWest,
+        ne = this._northEast,
+        sw2 = bounds.getSouthWest(),
+        ne2 = bounds.getNorthEast(),
 
-		    latIntersects = (ne2.lat >= sw.lat) && (sw2.lat <= ne.lat),
-		    lngIntersects = (ne2.lng >= sw.lng) && (sw2.lng <= ne.lng);
+        latIntersects = (ne2.lat >= sw.lat) && (sw2.lat <= ne.lat),
+        lngIntersects = (ne2.lng >= sw.lng) && (sw2.lng <= ne.lng);
 
-		return latIntersects && lngIntersects;
-	},
+    return latIntersects && lngIntersects;
+  },
 
-	toBBoxString: function () {
-		return [this.getWest(), this.getSouth(), this.getEast(), this.getNorth()].join(',');
-	},
+  toBBoxString: function () {
+    return [this.getWest(), this.getSouth(), this.getEast(), this.getNorth()].join(',');
+  },
 
-	equals: function (bounds) { // (LatLngBounds)
-		if (!bounds) { return false; }
+  equals: function (bounds) { // (LatLngBounds)
+    if (!bounds) { return false; }
 
-		bounds = L.latLngBounds(bounds);
+    bounds = L.latLngBounds(bounds);
 
-		return this._southWest.equals(bounds.getSouthWest()) &&
-		       this._northEast.equals(bounds.getNorthEast());
-	},
+    return this._southWest.equals(bounds.getSouthWest()) &&
+           this._northEast.equals(bounds.getNorthEast());
+  },
 
-	isValid: function () {
-		return !!(this._southWest && this._northEast);
-	}
+  isValid: function () {
+    return !!(this._southWest && this._northEast);
+  }
 };
 
 //TODO International date line?
 
 L.latLngBounds = function (a, b) { // (LatLngBounds) or (LatLng, LatLng)
-	if (!a || a instanceof L.LatLngBounds) {
-		return a;
-	}
-	return new L.LatLngBounds(a, b);
+  if (!a || a instanceof L.LatLngBounds) {
+    return a;
+  }
+  return new L.LatLngBounds(a, b);
 };
 
 
@@ -9346,27 +9346,27 @@ L.Projection = {};
  */
 
 L.Projection.SphericalMercator = {
-	MAX_LATITUDE: 85.0511287798,
+  MAX_LATITUDE: 85.0511287798,
 
-	project: function (latlng) { // (LatLng) -> Point
-		var d = L.LatLng.DEG_TO_RAD,
-		    max = this.MAX_LATITUDE,
-		    lat = Math.max(Math.min(max, latlng.lat), -max),
-		    x = latlng.lng * d,
-		    y = lat * d;
+  project: function (latlng) { // (LatLng) -> Point
+    var d = L.LatLng.DEG_TO_RAD,
+        max = this.MAX_LATITUDE,
+        lat = Math.max(Math.min(max, latlng.lat), -max),
+        x = latlng.lng * d,
+        y = lat * d;
 
-		y = Math.log(Math.tan((Math.PI / 4) + (y / 2)));
+    y = Math.log(Math.tan((Math.PI / 4) + (y / 2)));
 
-		return new L.Point(x, y);
-	},
+    return new L.Point(x, y);
+  },
 
-	unproject: function (point) { // (Point, Boolean) -> LatLng
-		var d = L.LatLng.RAD_TO_DEG,
-		    lng = point.x * d,
-		    lat = (2 * Math.atan(Math.exp(point.y)) - (Math.PI / 2)) * d;
+  unproject: function (point) { // (Point, Boolean) -> LatLng
+    var d = L.LatLng.RAD_TO_DEG,
+        lng = point.x * d,
+        lat = (2 * Math.atan(Math.exp(point.y)) - (Math.PI / 2)) * d;
 
-		return new L.LatLng(lat, lng);
-	}
+    return new L.LatLng(lat, lng);
+  }
 };
 
 
@@ -9379,13 +9379,13 @@ L.Projection.SphericalMercator = {
  */
 
 L.Projection.LonLat = {
-	project: function (latlng) {
-		return new L.Point(latlng.lng, latlng.lat);
-	},
+  project: function (latlng) {
+    return new L.Point(latlng.lng, latlng.lat);
+  },
 
-	unproject: function (point) {
-		return new L.LatLng(point.y, point.x);
-	}
+  unproject: function (point) {
+    return new L.LatLng(point.y, point.x);
+  }
 };
 
 
@@ -9398,32 +9398,32 @@ L.Projection.LonLat = {
  */
 
 L.CRS = {
-	latLngToPoint: function (latlng, zoom) { // (LatLng, Number) -> Point
-		var projectedPoint = this.projection.project(latlng),
-		    scale = this.scale(zoom);
+  latLngToPoint: function (latlng, zoom) { // (LatLng, Number) -> Point
+    var projectedPoint = this.projection.project(latlng),
+        scale = this.scale(zoom);
 
-		return this.transformation._transform(projectedPoint, scale);
-	},
+    return this.transformation._transform(projectedPoint, scale);
+  },
 
-	pointToLatLng: function (point, zoom) { // (Point, Number[, Boolean]) -> LatLng
-		var scale = this.scale(zoom),
-		    untransformedPoint = this.transformation.untransform(point, scale);
+  pointToLatLng: function (point, zoom) { // (Point, Number[, Boolean]) -> LatLng
+    var scale = this.scale(zoom),
+        untransformedPoint = this.transformation.untransform(point, scale);
 
-		return this.projection.unproject(untransformedPoint);
-	},
+    return this.projection.unproject(untransformedPoint);
+  },
 
-	project: function (latlng) {
-		return this.projection.project(latlng);
-	},
+  project: function (latlng) {
+    return this.projection.project(latlng);
+  },
 
-	scale: function (zoom) {
-		return 256 * Math.pow(2, zoom);
-	},
+  scale: function (zoom) {
+    return 256 * Math.pow(2, zoom);
+  },
 
-	getSize: function (zoom) {
-		var s = this.scale(zoom);
-		return L.point(s, s);
-	}
+  getSize: function (zoom) {
+    var s = this.scale(zoom);
+    return L.point(s, s);
+  }
 };
 
 
@@ -9436,12 +9436,12 @@ L.CRS = {
  */
 
 L.CRS.Simple = L.extend({}, L.CRS, {
-	projection: L.Projection.LonLat,
-	transformation: new L.Transformation(1, 0, -1, 0),
+  projection: L.Projection.LonLat,
+  transformation: new L.Transformation(1, 0, -1, 0),
 
-	scale: function (zoom) {
-		return Math.pow(2, zoom);
-	}
+  scale: function (zoom) {
+    return Math.pow(2, zoom);
+  }
 });
 
 
@@ -9455,20 +9455,20 @@ L.CRS.Simple = L.extend({}, L.CRS, {
  */
 
 L.CRS.EPSG3857 = L.extend({}, L.CRS, {
-	code: 'EPSG:3857',
+  code: 'EPSG:3857',
 
-	projection: L.Projection.SphericalMercator,
-	transformation: new L.Transformation(0.5 / Math.PI, 0.5, -0.5 / Math.PI, 0.5),
+  projection: L.Projection.SphericalMercator,
+  transformation: new L.Transformation(0.5 / Math.PI, 0.5, -0.5 / Math.PI, 0.5),
 
-	project: function (latlng) { // (LatLng) -> Point
-		var projectedPoint = this.projection.project(latlng),
-		    earthRadius = 6378137;
-		return projectedPoint.multiplyBy(earthRadius);
-	}
+  project: function (latlng) { // (LatLng) -> Point
+    var projectedPoint = this.projection.project(latlng),
+        earthRadius = 6378137;
+    return projectedPoint.multiplyBy(earthRadius);
+  }
 });
 
 L.CRS.EPSG900913 = L.extend({}, L.CRS.EPSG3857, {
-	code: 'EPSG:900913'
+  code: 'EPSG:900913'
 });
 
 
@@ -9481,10 +9481,10 @@ L.CRS.EPSG900913 = L.extend({}, L.CRS.EPSG3857, {
  */
 
 L.CRS.EPSG4326 = L.extend({}, L.CRS, {
-	code: 'EPSG:4326',
+  code: 'EPSG:4326',
 
-	projection: L.Projection.LonLat,
-	transformation: new L.Transformation(1 / 360, 0.5, -1 / 360, 0.5)
+  projection: L.Projection.LonLat,
+  transformation: new L.Transformation(1 / 360, 0.5, -1 / 360, 0.5)
 });
 
 
@@ -9498,809 +9498,809 @@ L.CRS.EPSG4326 = L.extend({}, L.CRS, {
 
 L.Map = L.Class.extend({
 
-	includes: L.Mixin.Events,
+  includes: L.Mixin.Events,
 
-	options: {
-		crs: L.CRS.EPSG3857,
+  options: {
+    crs: L.CRS.EPSG3857,
 
-		/*
-		center: LatLng,
-		zoom: Number,
-		layers: Array,
-		*/
+    /*
+    center: LatLng,
+    zoom: Number,
+    layers: Array,
+    */
 
-		fadeAnimation: L.DomUtil.TRANSITION && !L.Browser.android23,
-		trackResize: true,
-		markerZoomAnimation: L.DomUtil.TRANSITION && L.Browser.any3d
-	},
+    fadeAnimation: L.DomUtil.TRANSITION && !L.Browser.android23,
+    trackResize: true,
+    markerZoomAnimation: L.DomUtil.TRANSITION && L.Browser.any3d
+  },
 
-	initialize: function (id, options) { // (HTMLElement or String, Object)
-		options = L.setOptions(this, options);
+  initialize: function (id, options) { // (HTMLElement or String, Object)
+    options = L.setOptions(this, options);
 
 
-		this._initContainer(id);
-		this._initLayout();
+    this._initContainer(id);
+    this._initLayout();
 
-		// hack for https://github.com/Leaflet/Leaflet/issues/1980
-		this._onResize = L.bind(this._onResize, this);
+    // hack for https://github.com/Leaflet/Leaflet/issues/1980
+    this._onResize = L.bind(this._onResize, this);
 
-		this._initEvents();
+    this._initEvents();
 
-		if (options.maxBounds) {
-			this.setMaxBounds(options.maxBounds);
-		}
+    if (options.maxBounds) {
+      this.setMaxBounds(options.maxBounds);
+    }
 
-		if (options.center && options.zoom !== undefined) {
-			this.setView(L.latLng(options.center), options.zoom, {reset: true});
-		}
+    if (options.center && options.zoom !== undefined) {
+      this.setView(L.latLng(options.center), options.zoom, {reset: true});
+    }
 
-		this._handlers = [];
+    this._handlers = [];
 
-		this._layers = {};
-		this._zoomBoundLayers = {};
-		this._tileLayersNum = 0;
+    this._layers = {};
+    this._zoomBoundLayers = {};
+    this._tileLayersNum = 0;
 
-		this.callInitHooks();
+    this.callInitHooks();
 
-		this._addLayers(options.layers);
-	},
+    this._addLayers(options.layers);
+  },
 
 
-	// public methods that modify map state
+  // public methods that modify map state
 
-	// replaced by animation-powered implementation in Map.PanAnimation.js
-	setView: function (center, zoom) {
-		zoom = zoom === undefined ? this.getZoom() : zoom;
-		this._resetView(L.latLng(center), this._limitZoom(zoom));
-		return this;
-	},
+  // replaced by animation-powered implementation in Map.PanAnimation.js
+  setView: function (center, zoom) {
+    zoom = zoom === undefined ? this.getZoom() : zoom;
+    this._resetView(L.latLng(center), this._limitZoom(zoom));
+    return this;
+  },
 
-	setZoom: function (zoom, options) {
-		if (!this._loaded) {
-			this._zoom = this._limitZoom(zoom);
-			return this;
-		}
-		return this.setView(this.getCenter(), zoom, {zoom: options});
-	},
+  setZoom: function (zoom, options) {
+    if (!this._loaded) {
+      this._zoom = this._limitZoom(zoom);
+      return this;
+    }
+    return this.setView(this.getCenter(), zoom, {zoom: options});
+  },
 
-	zoomIn: function (delta, options) {
-		return this.setZoom(this._zoom + (delta || 1), options);
-	},
+  zoomIn: function (delta, options) {
+    return this.setZoom(this._zoom + (delta || 1), options);
+  },
 
-	zoomOut: function (delta, options) {
-		return this.setZoom(this._zoom - (delta || 1), options);
-	},
+  zoomOut: function (delta, options) {
+    return this.setZoom(this._zoom - (delta || 1), options);
+  },
 
-	setZoomAround: function (latlng, zoom, options) {
-		var scale = this.getZoomScale(zoom),
-		    viewHalf = this.getSize().divideBy(2),
-		    containerPoint = latlng instanceof L.Point ? latlng : this.latLngToContainerPoint(latlng),
+  setZoomAround: function (latlng, zoom, options) {
+    var scale = this.getZoomScale(zoom),
+        viewHalf = this.getSize().divideBy(2),
+        containerPoint = latlng instanceof L.Point ? latlng : this.latLngToContainerPoint(latlng),
 
-		    centerOffset = containerPoint.subtract(viewHalf).multiplyBy(1 - 1 / scale),
-		    newCenter = this.containerPointToLatLng(viewHalf.add(centerOffset));
+        centerOffset = containerPoint.subtract(viewHalf).multiplyBy(1 - 1 / scale),
+        newCenter = this.containerPointToLatLng(viewHalf.add(centerOffset));
 
-		return this.setView(newCenter, zoom, {zoom: options});
-	},
+    return this.setView(newCenter, zoom, {zoom: options});
+  },
 
-	fitBounds: function (bounds, options) {
+  fitBounds: function (bounds, options) {
 
-		options = options || {};
-		bounds = bounds.getBounds ? bounds.getBounds() : L.latLngBounds(bounds);
+    options = options || {};
+    bounds = bounds.getBounds ? bounds.getBounds() : L.latLngBounds(bounds);
 
-		var paddingTL = L.point(options.paddingTopLeft || options.padding || [0, 0]),
-		    paddingBR = L.point(options.paddingBottomRight || options.padding || [0, 0]),
+    var paddingTL = L.point(options.paddingTopLeft || options.padding || [0, 0]),
+        paddingBR = L.point(options.paddingBottomRight || options.padding || [0, 0]),
 
-		    zoom = this.getBoundsZoom(bounds, false, paddingTL.add(paddingBR)),
-		    paddingOffset = paddingBR.subtract(paddingTL).divideBy(2),
+        zoom = this.getBoundsZoom(bounds, false, paddingTL.add(paddingBR)),
+        paddingOffset = paddingBR.subtract(paddingTL).divideBy(2),
 
-		    swPoint = this.project(bounds.getSouthWest(), zoom),
-		    nePoint = this.project(bounds.getNorthEast(), zoom),
-		    center = this.unproject(swPoint.add(nePoint).divideBy(2).add(paddingOffset), zoom);
+        swPoint = this.project(bounds.getSouthWest(), zoom),
+        nePoint = this.project(bounds.getNorthEast(), zoom),
+        center = this.unproject(swPoint.add(nePoint).divideBy(2).add(paddingOffset), zoom);
 
-		zoom = options && options.maxZoom ? Math.min(options.maxZoom, zoom) : zoom;
+    zoom = options && options.maxZoom ? Math.min(options.maxZoom, zoom) : zoom;
 
-		return this.setView(center, zoom, options);
-	},
+    return this.setView(center, zoom, options);
+  },
 
-	fitWorld: function (options) {
-		return this.fitBounds([[-90, -180], [90, 180]], options);
-	},
+  fitWorld: function (options) {
+    return this.fitBounds([[-90, -180], [90, 180]], options);
+  },
 
-	panTo: function (center, options) { // (LatLng)
-		return this.setView(center, this._zoom, {pan: options});
-	},
+  panTo: function (center, options) { // (LatLng)
+    return this.setView(center, this._zoom, {pan: options});
+  },
 
-	panBy: function (offset) { // (Point)
-		// replaced with animated panBy in Map.PanAnimation.js
-		this.fire('movestart');
+  panBy: function (offset) { // (Point)
+    // replaced with animated panBy in Map.PanAnimation.js
+    this.fire('movestart');
 
-		this._rawPanBy(L.point(offset));
+    this._rawPanBy(L.point(offset));
 
-		this.fire('move');
-		return this.fire('moveend');
-	},
+    this.fire('move');
+    return this.fire('moveend');
+  },
 
-	setMaxBounds: function (bounds) {
-		bounds = L.latLngBounds(bounds);
+  setMaxBounds: function (bounds) {
+    bounds = L.latLngBounds(bounds);
 
-		this.options.maxBounds = bounds;
+    this.options.maxBounds = bounds;
 
-		if (!bounds) {
-			return this.off('moveend', this._panInsideMaxBounds, this);
-		}
+    if (!bounds) {
+      return this.off('moveend', this._panInsideMaxBounds, this);
+    }
 
-		if (this._loaded) {
-			this._panInsideMaxBounds();
-		}
+    if (this._loaded) {
+      this._panInsideMaxBounds();
+    }
 
-		return this.on('moveend', this._panInsideMaxBounds, this);
-	},
+    return this.on('moveend', this._panInsideMaxBounds, this);
+  },
 
-	panInsideBounds: function (bounds, options) {
-		var center = this.getCenter(),
-			newCenter = this._limitCenter(center, this._zoom, bounds);
+  panInsideBounds: function (bounds, options) {
+    var center = this.getCenter(),
+      newCenter = this._limitCenter(center, this._zoom, bounds);
 
-		if (center.equals(newCenter)) { return this; }
+    if (center.equals(newCenter)) { return this; }
 
-		return this.panTo(newCenter, options);
-	},
+    return this.panTo(newCenter, options);
+  },
 
-	addLayer: function (layer) {
-		// TODO method is too big, refactor
+  addLayer: function (layer) {
+    // TODO method is too big, refactor
 
-		var id = L.stamp(layer);
+    var id = L.stamp(layer);
 
-		if (this._layers[id]) { return this; }
+    if (this._layers[id]) { return this; }
 
-		this._layers[id] = layer;
+    this._layers[id] = layer;
 
-		// TODO getMaxZoom, getMinZoom in ILayer (instead of options)
-		if (layer.options && (!isNaN(layer.options.maxZoom) || !isNaN(layer.options.minZoom))) {
-			this._zoomBoundLayers[id] = layer;
-			this._updateZoomLevels();
-		}
+    // TODO getMaxZoom, getMinZoom in ILayer (instead of options)
+    if (layer.options && (!isNaN(layer.options.maxZoom) || !isNaN(layer.options.minZoom))) {
+      this._zoomBoundLayers[id] = layer;
+      this._updateZoomLevels();
+    }
 
-		// TODO looks ugly, refactor!!!
-		if (this.options.zoomAnimation && L.TileLayer && (layer instanceof L.TileLayer)) {
-			this._tileLayersNum++;
-			this._tileLayersToLoad++;
-			layer.on('load', this._onTileLayerLoad, this);
-		}
+    // TODO looks ugly, refactor!!!
+    if (this.options.zoomAnimation && L.TileLayer && (layer instanceof L.TileLayer)) {
+      this._tileLayersNum++;
+      this._tileLayersToLoad++;
+      layer.on('load', this._onTileLayerLoad, this);
+    }
 
-		if (this._loaded) {
-			this._layerAdd(layer);
-		}
+    if (this._loaded) {
+      this._layerAdd(layer);
+    }
 
-		return this;
-	},
+    return this;
+  },
 
-	removeLayer: function (layer) {
-		var id = L.stamp(layer);
+  removeLayer: function (layer) {
+    var id = L.stamp(layer);
 
-		if (!this._layers[id]) { return this; }
+    if (!this._layers[id]) { return this; }
 
-		if (this._loaded) {
-			layer.onRemove(this);
-		}
+    if (this._loaded) {
+      layer.onRemove(this);
+    }
 
-		delete this._layers[id];
+    delete this._layers[id];
 
-		if (this._loaded) {
-			this.fire('layerremove', {layer: layer});
-		}
+    if (this._loaded) {
+      this.fire('layerremove', {layer: layer});
+    }
 
-		if (this._zoomBoundLayers[id]) {
-			delete this._zoomBoundLayers[id];
-			this._updateZoomLevels();
-		}
+    if (this._zoomBoundLayers[id]) {
+      delete this._zoomBoundLayers[id];
+      this._updateZoomLevels();
+    }
 
-		// TODO looks ugly, refactor
-		if (this.options.zoomAnimation && L.TileLayer && (layer instanceof L.TileLayer)) {
-			this._tileLayersNum--;
-			this._tileLayersToLoad--;
-			layer.off('load', this._onTileLayerLoad, this);
-		}
+    // TODO looks ugly, refactor
+    if (this.options.zoomAnimation && L.TileLayer && (layer instanceof L.TileLayer)) {
+      this._tileLayersNum--;
+      this._tileLayersToLoad--;
+      layer.off('load', this._onTileLayerLoad, this);
+    }
 
-		return this;
-	},
+    return this;
+  },
 
-	hasLayer: function (layer) {
-		if (!layer) { return false; }
+  hasLayer: function (layer) {
+    if (!layer) { return false; }
 
-		return (L.stamp(layer) in this._layers);
-	},
+    return (L.stamp(layer) in this._layers);
+  },
 
-	eachLayer: function (method, context) {
-		for (var i in this._layers) {
-			method.call(context, this._layers[i]);
-		}
-		return this;
-	},
+  eachLayer: function (method, context) {
+    for (var i in this._layers) {
+      method.call(context, this._layers[i]);
+    }
+    return this;
+  },
 
-	invalidateSize: function (options) {
-		if (!this._loaded) { return this; }
+  invalidateSize: function (options) {
+    if (!this._loaded) { return this; }
 
-		options = L.extend({
-			animate: false,
-			pan: true
-		}, options === true ? {animate: true} : options);
+    options = L.extend({
+      animate: false,
+      pan: true
+    }, options === true ? {animate: true} : options);
 
-		var oldSize = this.getSize();
-		this._sizeChanged = true;
-		this._initialCenter = null;
+    var oldSize = this.getSize();
+    this._sizeChanged = true;
+    this._initialCenter = null;
 
-		var newSize = this.getSize(),
-		    oldCenter = oldSize.divideBy(2).round(),
-		    newCenter = newSize.divideBy(2).round(),
-		    offset = oldCenter.subtract(newCenter);
+    var newSize = this.getSize(),
+        oldCenter = oldSize.divideBy(2).round(),
+        newCenter = newSize.divideBy(2).round(),
+        offset = oldCenter.subtract(newCenter);
 
-		if (!offset.x && !offset.y) { return this; }
+    if (!offset.x && !offset.y) { return this; }
 
-		if (options.animate && options.pan) {
-			this.panBy(offset);
+    if (options.animate && options.pan) {
+      this.panBy(offset);
 
-		} else {
-			if (options.pan) {
-				this._rawPanBy(offset);
-			}
+    } else {
+      if (options.pan) {
+        this._rawPanBy(offset);
+      }
 
-			this.fire('move');
+      this.fire('move');
 
-			if (options.debounceMoveend) {
-				clearTimeout(this._sizeTimer);
-				this._sizeTimer = setTimeout(L.bind(this.fire, this, 'moveend'), 200);
-			} else {
-				this.fire('moveend');
-			}
-		}
+      if (options.debounceMoveend) {
+        clearTimeout(this._sizeTimer);
+        this._sizeTimer = setTimeout(L.bind(this.fire, this, 'moveend'), 200);
+      } else {
+        this.fire('moveend');
+      }
+    }
 
-		return this.fire('resize', {
-			oldSize: oldSize,
-			newSize: newSize
-		});
-	},
+    return this.fire('resize', {
+      oldSize: oldSize,
+      newSize: newSize
+    });
+  },
 
-	// TODO handler.addTo
-	addHandler: function (name, HandlerClass) {
-		if (!HandlerClass) { return this; }
+  // TODO handler.addTo
+  addHandler: function (name, HandlerClass) {
+    if (!HandlerClass) { return this; }
 
-		var handler = this[name] = new HandlerClass(this);
+    var handler = this[name] = new HandlerClass(this);
 
-		this._handlers.push(handler);
+    this._handlers.push(handler);
 
-		if (this.options[name]) {
-			handler.enable();
-		}
+    if (this.options[name]) {
+      handler.enable();
+    }
 
-		return this;
-	},
+    return this;
+  },
 
-	remove: function () {
-		if (this._loaded) {
-			this.fire('unload');
-		}
+  remove: function () {
+    if (this._loaded) {
+      this.fire('unload');
+    }
 
-		this._initEvents('off');
+    this._initEvents('off');
 
-		try {
-			// throws error in IE6-8
-			delete this._container._leaflet;
-		} catch (e) {
-			this._container._leaflet = undefined;
-		}
+    try {
+      // throws error in IE6-8
+      delete this._container._leaflet;
+    } catch (e) {
+      this._container._leaflet = undefined;
+    }
 
-		this._clearPanes();
-		if (this._clearControlPos) {
-			this._clearControlPos();
-		}
+    this._clearPanes();
+    if (this._clearControlPos) {
+      this._clearControlPos();
+    }
 
-		this._clearHandlers();
+    this._clearHandlers();
 
-		return this;
-	},
+    return this;
+  },
 
 
-	// public methods for getting map state
+  // public methods for getting map state
 
-	getCenter: function () { // (Boolean) -> LatLng
-		this._checkIfLoaded();
+  getCenter: function () { // (Boolean) -> LatLng
+    this._checkIfLoaded();
 
-		if (this._initialCenter && !this._moved()) {
-			return this._initialCenter;
-		}
-		return this.layerPointToLatLng(this._getCenterLayerPoint());
-	},
+    if (this._initialCenter && !this._moved()) {
+      return this._initialCenter;
+    }
+    return this.layerPointToLatLng(this._getCenterLayerPoint());
+  },
 
-	getZoom: function () {
-		return this._zoom;
-	},
+  getZoom: function () {
+    return this._zoom;
+  },
 
-	getBounds: function () {
-		var bounds = this.getPixelBounds(),
-		    sw = this.unproject(bounds.getBottomLeft()),
-		    ne = this.unproject(bounds.getTopRight());
+  getBounds: function () {
+    var bounds = this.getPixelBounds(),
+        sw = this.unproject(bounds.getBottomLeft()),
+        ne = this.unproject(bounds.getTopRight());
 
-		return new L.LatLngBounds(sw, ne);
-	},
+    return new L.LatLngBounds(sw, ne);
+  },
 
-	getMinZoom: function () {
-		return this.options.minZoom === undefined ?
-			(this._layersMinZoom === undefined ? 0 : this._layersMinZoom) :
-			this.options.minZoom;
-	},
+  getMinZoom: function () {
+    return this.options.minZoom === undefined ?
+      (this._layersMinZoom === undefined ? 0 : this._layersMinZoom) :
+      this.options.minZoom;
+  },
 
-	getMaxZoom: function () {
-		return this.options.maxZoom === undefined ?
-			(this._layersMaxZoom === undefined ? Infinity : this._layersMaxZoom) :
-			this.options.maxZoom;
-	},
+  getMaxZoom: function () {
+    return this.options.maxZoom === undefined ?
+      (this._layersMaxZoom === undefined ? Infinity : this._layersMaxZoom) :
+      this.options.maxZoom;
+  },
 
-	getBoundsZoom: function (bounds, inside, padding) { // (LatLngBounds[, Boolean, Point]) -> Number
-		bounds = L.latLngBounds(bounds);
+  getBoundsZoom: function (bounds, inside, padding) { // (LatLngBounds[, Boolean, Point]) -> Number
+    bounds = L.latLngBounds(bounds);
 
-		var zoom = this.getMinZoom() - (inside ? 1 : 0),
-		    maxZoom = this.getMaxZoom(),
-		    size = this.getSize(),
+    var zoom = this.getMinZoom() - (inside ? 1 : 0),
+        maxZoom = this.getMaxZoom(),
+        size = this.getSize(),
 
-		    nw = bounds.getNorthWest(),
-		    se = bounds.getSouthEast(),
+        nw = bounds.getNorthWest(),
+        se = bounds.getSouthEast(),
 
-		    zoomNotFound = true,
-		    boundsSize;
+        zoomNotFound = true,
+        boundsSize;
 
-		padding = L.point(padding || [0, 0]);
+    padding = L.point(padding || [0, 0]);
 
-		do {
-			zoom++;
-			boundsSize = this.project(se, zoom).subtract(this.project(nw, zoom)).add(padding);
-			zoomNotFound = !inside ? size.contains(boundsSize) : boundsSize.x < size.x || boundsSize.y < size.y;
+    do {
+      zoom++;
+      boundsSize = this.project(se, zoom).subtract(this.project(nw, zoom)).add(padding);
+      zoomNotFound = !inside ? size.contains(boundsSize) : boundsSize.x < size.x || boundsSize.y < size.y;
 
-		} while (zoomNotFound && zoom <= maxZoom);
+    } while (zoomNotFound && zoom <= maxZoom);
 
-		if (zoomNotFound && inside) {
-			return null;
-		}
+    if (zoomNotFound && inside) {
+      return null;
+    }
 
-		return inside ? zoom : zoom - 1;
-	},
+    return inside ? zoom : zoom - 1;
+  },
 
-	getSize: function () {
-		if (!this._size || this._sizeChanged) {
-			this._size = new L.Point(
-				this._container.clientWidth,
-				this._container.clientHeight);
+  getSize: function () {
+    if (!this._size || this._sizeChanged) {
+      this._size = new L.Point(
+        this._container.clientWidth,
+        this._container.clientHeight);
 
-			this._sizeChanged = false;
-		}
-		return this._size.clone();
-	},
+      this._sizeChanged = false;
+    }
+    return this._size.clone();
+  },
 
-	getPixelBounds: function () {
-		var topLeftPoint = this._getTopLeftPoint();
-		return new L.Bounds(topLeftPoint, topLeftPoint.add(this.getSize()));
-	},
+  getPixelBounds: function () {
+    var topLeftPoint = this._getTopLeftPoint();
+    return new L.Bounds(topLeftPoint, topLeftPoint.add(this.getSize()));
+  },
 
-	getPixelOrigin: function () {
-		this._checkIfLoaded();
-		return this._initialTopLeftPoint;
-	},
+  getPixelOrigin: function () {
+    this._checkIfLoaded();
+    return this._initialTopLeftPoint;
+  },
 
-	getPanes: function () {
-		return this._panes;
-	},
+  getPanes: function () {
+    return this._panes;
+  },
 
-	getContainer: function () {
-		return this._container;
-	},
+  getContainer: function () {
+    return this._container;
+  },
 
 
-	// TODO replace with universal implementation after refactoring projections
+  // TODO replace with universal implementation after refactoring projections
 
-	getZoomScale: function (toZoom) {
-		var crs = this.options.crs;
-		return crs.scale(toZoom) / crs.scale(this._zoom);
-	},
+  getZoomScale: function (toZoom) {
+    var crs = this.options.crs;
+    return crs.scale(toZoom) / crs.scale(this._zoom);
+  },
 
-	getScaleZoom: function (scale) {
-		return this._zoom + (Math.log(scale) / Math.LN2);
-	},
+  getScaleZoom: function (scale) {
+    return this._zoom + (Math.log(scale) / Math.LN2);
+  },
 
 
-	// conversion methods
+  // conversion methods
 
-	project: function (latlng, zoom) { // (LatLng[, Number]) -> Point
-		zoom = zoom === undefined ? this._zoom : zoom;
-		return this.options.crs.latLngToPoint(L.latLng(latlng), zoom);
-	},
+  project: function (latlng, zoom) { // (LatLng[, Number]) -> Point
+    zoom = zoom === undefined ? this._zoom : zoom;
+    return this.options.crs.latLngToPoint(L.latLng(latlng), zoom);
+  },
 
-	unproject: function (point, zoom) { // (Point[, Number]) -> LatLng
-		zoom = zoom === undefined ? this._zoom : zoom;
-		return this.options.crs.pointToLatLng(L.point(point), zoom);
-	},
+  unproject: function (point, zoom) { // (Point[, Number]) -> LatLng
+    zoom = zoom === undefined ? this._zoom : zoom;
+    return this.options.crs.pointToLatLng(L.point(point), zoom);
+  },
 
-	layerPointToLatLng: function (point) { // (Point)
-		var projectedPoint = L.point(point).add(this.getPixelOrigin());
-		return this.unproject(projectedPoint);
-	},
+  layerPointToLatLng: function (point) { // (Point)
+    var projectedPoint = L.point(point).add(this.getPixelOrigin());
+    return this.unproject(projectedPoint);
+  },
 
-	latLngToLayerPoint: function (latlng) { // (LatLng)
-		var projectedPoint = this.project(L.latLng(latlng))._round();
-		return projectedPoint._subtract(this.getPixelOrigin());
-	},
+  latLngToLayerPoint: function (latlng) { // (LatLng)
+    var projectedPoint = this.project(L.latLng(latlng))._round();
+    return projectedPoint._subtract(this.getPixelOrigin());
+  },
 
-	containerPointToLayerPoint: function (point) { // (Point)
-		return L.point(point).subtract(this._getMapPanePos());
-	},
+  containerPointToLayerPoint: function (point) { // (Point)
+    return L.point(point).subtract(this._getMapPanePos());
+  },
 
-	layerPointToContainerPoint: function (point) { // (Point)
-		return L.point(point).add(this._getMapPanePos());
-	},
+  layerPointToContainerPoint: function (point) { // (Point)
+    return L.point(point).add(this._getMapPanePos());
+  },
 
-	containerPointToLatLng: function (point) {
-		var layerPoint = this.containerPointToLayerPoint(L.point(point));
-		return this.layerPointToLatLng(layerPoint);
-	},
+  containerPointToLatLng: function (point) {
+    var layerPoint = this.containerPointToLayerPoint(L.point(point));
+    return this.layerPointToLatLng(layerPoint);
+  },
 
-	latLngToContainerPoint: function (latlng) {
-		return this.layerPointToContainerPoint(this.latLngToLayerPoint(L.latLng(latlng)));
-	},
+  latLngToContainerPoint: function (latlng) {
+    return this.layerPointToContainerPoint(this.latLngToLayerPoint(L.latLng(latlng)));
+  },
 
-	mouseEventToContainerPoint: function (e) { // (MouseEvent)
-		return L.DomEvent.getMousePosition(e, this._container);
-	},
+  mouseEventToContainerPoint: function (e) { // (MouseEvent)
+    return L.DomEvent.getMousePosition(e, this._container);
+  },
 
-	mouseEventToLayerPoint: function (e) { // (MouseEvent)
-		return this.containerPointToLayerPoint(this.mouseEventToContainerPoint(e));
-	},
+  mouseEventToLayerPoint: function (e) { // (MouseEvent)
+    return this.containerPointToLayerPoint(this.mouseEventToContainerPoint(e));
+  },
 
-	mouseEventToLatLng: function (e) { // (MouseEvent)
-		return this.layerPointToLatLng(this.mouseEventToLayerPoint(e));
-	},
+  mouseEventToLatLng: function (e) { // (MouseEvent)
+    return this.layerPointToLatLng(this.mouseEventToLayerPoint(e));
+  },
 
 
-	// map initialization methods
+  // map initialization methods
 
-	_initContainer: function (id) {
-		var container = this._container = L.DomUtil.get(id);
+  _initContainer: function (id) {
+    var container = this._container = L.DomUtil.get(id);
 
-		if (!container) {
-			throw new Error('Map container not found.');
-		} else if (container._leaflet) {
-			throw new Error('Map container is already initialized.');
-		}
+    if (!container) {
+      throw new Error('Map container not found.');
+    } else if (container._leaflet) {
+      throw new Error('Map container is already initialized.');
+    }
 
-		container._leaflet = true;
-	},
+    container._leaflet = true;
+  },
 
-	_initLayout: function () {
-		var container = this._container;
+  _initLayout: function () {
+    var container = this._container;
 
-		L.DomUtil.addClass(container, 'leaflet-container' +
-			(L.Browser.touch ? ' leaflet-touch' : '') +
-			(L.Browser.retina ? ' leaflet-retina' : '') +
-			(L.Browser.ielt9 ? ' leaflet-oldie' : '') +
-			(this.options.fadeAnimation ? ' leaflet-fade-anim' : ''));
+    L.DomUtil.addClass(container, 'leaflet-container' +
+      (L.Browser.touch ? ' leaflet-touch' : '') +
+      (L.Browser.retina ? ' leaflet-retina' : '') +
+      (L.Browser.ielt9 ? ' leaflet-oldie' : '') +
+      (this.options.fadeAnimation ? ' leaflet-fade-anim' : ''));
 
-		var position = L.DomUtil.getStyle(container, 'position');
+    var position = L.DomUtil.getStyle(container, 'position');
 
-		if (position !== 'absolute' && position !== 'relative' && position !== 'fixed') {
-			container.style.position = 'relative';
-		}
+    if (position !== 'absolute' && position !== 'relative' && position !== 'fixed') {
+      container.style.position = 'relative';
+    }
 
-		this._initPanes();
+    this._initPanes();
 
-		if (this._initControlPos) {
-			this._initControlPos();
-		}
-	},
+    if (this._initControlPos) {
+      this._initControlPos();
+    }
+  },
 
-	_initPanes: function () {
-		var panes = this._panes = {};
+  _initPanes: function () {
+    var panes = this._panes = {};
 
-		this._mapPane = panes.mapPane = this._createPane('leaflet-map-pane', this._container);
+    this._mapPane = panes.mapPane = this._createPane('leaflet-map-pane', this._container);
 
-		this._tilePane = panes.tilePane = this._createPane('leaflet-tile-pane', this._mapPane);
-		panes.objectsPane = this._createPane('leaflet-objects-pane', this._mapPane);
-		panes.shadowPane = this._createPane('leaflet-shadow-pane');
-		panes.overlayPane = this._createPane('leaflet-overlay-pane');
-		panes.markerPane = this._createPane('leaflet-marker-pane');
-		panes.popupPane = this._createPane('leaflet-popup-pane');
+    this._tilePane = panes.tilePane = this._createPane('leaflet-tile-pane', this._mapPane);
+    panes.objectsPane = this._createPane('leaflet-objects-pane', this._mapPane);
+    panes.shadowPane = this._createPane('leaflet-shadow-pane');
+    panes.overlayPane = this._createPane('leaflet-overlay-pane');
+    panes.markerPane = this._createPane('leaflet-marker-pane');
+    panes.popupPane = this._createPane('leaflet-popup-pane');
 
-		var zoomHide = ' leaflet-zoom-hide';
+    var zoomHide = ' leaflet-zoom-hide';
 
-		if (!this.options.markerZoomAnimation) {
-			L.DomUtil.addClass(panes.markerPane, zoomHide);
-			L.DomUtil.addClass(panes.shadowPane, zoomHide);
-			L.DomUtil.addClass(panes.popupPane, zoomHide);
-		}
-	},
+    if (!this.options.markerZoomAnimation) {
+      L.DomUtil.addClass(panes.markerPane, zoomHide);
+      L.DomUtil.addClass(panes.shadowPane, zoomHide);
+      L.DomUtil.addClass(panes.popupPane, zoomHide);
+    }
+  },
 
-	_createPane: function (className, container) {
-		return L.DomUtil.create('div', className, container || this._panes.objectsPane);
-	},
+  _createPane: function (className, container) {
+    return L.DomUtil.create('div', className, container || this._panes.objectsPane);
+  },
 
-	_clearPanes: function () {
-		this._container.removeChild(this._mapPane);
-	},
+  _clearPanes: function () {
+    this._container.removeChild(this._mapPane);
+  },
 
-	_addLayers: function (layers) {
-		layers = layers ? (L.Util.isArray(layers) ? layers : [layers]) : [];
+  _addLayers: function (layers) {
+    layers = layers ? (L.Util.isArray(layers) ? layers : [layers]) : [];
 
-		for (var i = 0, len = layers.length; i < len; i++) {
-			this.addLayer(layers[i]);
-		}
-	},
+    for (var i = 0, len = layers.length; i < len; i++) {
+      this.addLayer(layers[i]);
+    }
+  },
 
 
-	// private methods that modify map state
+  // private methods that modify map state
 
-	_resetView: function (center, zoom, preserveMapOffset, afterZoomAnim) {
+  _resetView: function (center, zoom, preserveMapOffset, afterZoomAnim) {
 
-		var zoomChanged = (this._zoom !== zoom);
+    var zoomChanged = (this._zoom !== zoom);
 
-		if (!afterZoomAnim) {
-			this.fire('movestart');
+    if (!afterZoomAnim) {
+      this.fire('movestart');
 
-			if (zoomChanged) {
-				this.fire('zoomstart');
-			}
-		}
+      if (zoomChanged) {
+        this.fire('zoomstart');
+      }
+    }
 
-		this._zoom = zoom;
-		this._initialCenter = center;
+    this._zoom = zoom;
+    this._initialCenter = center;
 
-		this._initialTopLeftPoint = this._getNewTopLeftPoint(center);
+    this._initialTopLeftPoint = this._getNewTopLeftPoint(center);
 
-		if (!preserveMapOffset) {
-			L.DomUtil.setPosition(this._mapPane, new L.Point(0, 0));
-		} else {
-			this._initialTopLeftPoint._add(this._getMapPanePos());
-		}
+    if (!preserveMapOffset) {
+      L.DomUtil.setPosition(this._mapPane, new L.Point(0, 0));
+    } else {
+      this._initialTopLeftPoint._add(this._getMapPanePos());
+    }
 
-		this._tileLayersToLoad = this._tileLayersNum;
+    this._tileLayersToLoad = this._tileLayersNum;
 
-		var loading = !this._loaded;
-		this._loaded = true;
+    var loading = !this._loaded;
+    this._loaded = true;
 
-		if (loading) {
-			this.fire('load');
-			this.eachLayer(this._layerAdd, this);
-		}
+    if (loading) {
+      this.fire('load');
+      this.eachLayer(this._layerAdd, this);
+    }
 
-		this.fire('viewreset', {hard: !preserveMapOffset});
+    this.fire('viewreset', {hard: !preserveMapOffset});
 
-		this.fire('move');
+    this.fire('move');
 
-		if (zoomChanged || afterZoomAnim) {
-			this.fire('zoomend');
-		}
+    if (zoomChanged || afterZoomAnim) {
+      this.fire('zoomend');
+    }
 
-		this.fire('moveend', {hard: !preserveMapOffset});
-	},
+    this.fire('moveend', {hard: !preserveMapOffset});
+  },
 
-	_rawPanBy: function (offset) {
-		L.DomUtil.setPosition(this._mapPane, this._getMapPanePos().subtract(offset));
-	},
+  _rawPanBy: function (offset) {
+    L.DomUtil.setPosition(this._mapPane, this._getMapPanePos().subtract(offset));
+  },
 
-	_getZoomSpan: function () {
-		return this.getMaxZoom() - this.getMinZoom();
-	},
+  _getZoomSpan: function () {
+    return this.getMaxZoom() - this.getMinZoom();
+  },
 
-	_updateZoomLevels: function () {
-		var i,
-			minZoom = Infinity,
-			maxZoom = -Infinity,
-			oldZoomSpan = this._getZoomSpan();
+  _updateZoomLevels: function () {
+    var i,
+      minZoom = Infinity,
+      maxZoom = -Infinity,
+      oldZoomSpan = this._getZoomSpan();
 
-		for (i in this._zoomBoundLayers) {
-			var layer = this._zoomBoundLayers[i];
-			if (!isNaN(layer.options.minZoom)) {
-				minZoom = Math.min(minZoom, layer.options.minZoom);
-			}
-			if (!isNaN(layer.options.maxZoom)) {
-				maxZoom = Math.max(maxZoom, layer.options.maxZoom);
-			}
-		}
+    for (i in this._zoomBoundLayers) {
+      var layer = this._zoomBoundLayers[i];
+      if (!isNaN(layer.options.minZoom)) {
+        minZoom = Math.min(minZoom, layer.options.minZoom);
+      }
+      if (!isNaN(layer.options.maxZoom)) {
+        maxZoom = Math.max(maxZoom, layer.options.maxZoom);
+      }
+    }
 
-		if (i === undefined) { // we have no tilelayers
-			this._layersMaxZoom = this._layersMinZoom = undefined;
-		} else {
-			this._layersMaxZoom = maxZoom;
-			this._layersMinZoom = minZoom;
-		}
+    if (i === undefined) { // we have no tilelayers
+      this._layersMaxZoom = this._layersMinZoom = undefined;
+    } else {
+      this._layersMaxZoom = maxZoom;
+      this._layersMinZoom = minZoom;
+    }
 
-		if (oldZoomSpan !== this._getZoomSpan()) {
-			this.fire('zoomlevelschange');
-		}
-	},
+    if (oldZoomSpan !== this._getZoomSpan()) {
+      this.fire('zoomlevelschange');
+    }
+  },
 
-	_panInsideMaxBounds: function () {
-		this.panInsideBounds(this.options.maxBounds);
-	},
+  _panInsideMaxBounds: function () {
+    this.panInsideBounds(this.options.maxBounds);
+  },
 
-	_checkIfLoaded: function () {
-		if (!this._loaded) {
-			throw new Error('Set map center and zoom first.');
-		}
-	},
+  _checkIfLoaded: function () {
+    if (!this._loaded) {
+      throw new Error('Set map center and zoom first.');
+    }
+  },
 
-	// map events
+  // map events
 
-	_initEvents: function (onOff) {
-		if (!L.DomEvent) { return; }
+  _initEvents: function (onOff) {
+    if (!L.DomEvent) { return; }
 
-		onOff = onOff || 'on';
+    onOff = onOff || 'on';
 
-		L.DomEvent[onOff](this._container, 'click', this._onMouseClick, this);
+    L.DomEvent[onOff](this._container, 'click', this._onMouseClick, this);
 
-		var events = ['dblclick', 'mousedown', 'mouseup', 'mouseenter',
-		              'mouseleave', 'mousemove', 'contextmenu'],
-		    i, len;
+    var events = ['dblclick', 'mousedown', 'mouseup', 'mouseenter',
+                  'mouseleave', 'mousemove', 'contextmenu'],
+        i, len;
 
-		for (i = 0, len = events.length; i < len; i++) {
-			L.DomEvent[onOff](this._container, events[i], this._fireMouseEvent, this);
-		}
+    for (i = 0, len = events.length; i < len; i++) {
+      L.DomEvent[onOff](this._container, events[i], this._fireMouseEvent, this);
+    }
 
-		if (this.options.trackResize) {
-			L.DomEvent[onOff](window, 'resize', this._onResize, this);
-		}
-	},
+    if (this.options.trackResize) {
+      L.DomEvent[onOff](window, 'resize', this._onResize, this);
+    }
+  },
 
-	_onResize: function () {
-		L.Util.cancelAnimFrame(this._resizeRequest);
-		this._resizeRequest = L.Util.requestAnimFrame(
-		        function () { this.invalidateSize({debounceMoveend: true}); }, this, false, this._container);
-	},
+  _onResize: function () {
+    L.Util.cancelAnimFrame(this._resizeRequest);
+    this._resizeRequest = L.Util.requestAnimFrame(
+            function () { this.invalidateSize({debounceMoveend: true}); }, this, false, this._container);
+  },
 
-	_onMouseClick: function (e) {
-		if (!this._loaded || (!e._simulated &&
-		        ((this.dragging && this.dragging.moved()) ||
-		         (this.boxZoom  && this.boxZoom.moved()))) ||
-		            L.DomEvent._skipped(e)) { return; }
+  _onMouseClick: function (e) {
+    if (!this._loaded || (!e._simulated &&
+            ((this.dragging && this.dragging.moved()) ||
+             (this.boxZoom  && this.boxZoom.moved()))) ||
+                L.DomEvent._skipped(e)) { return; }
 
-		this.fire('preclick');
-		this._fireMouseEvent(e);
-	},
+    this.fire('preclick');
+    this._fireMouseEvent(e);
+  },
 
-	_fireMouseEvent: function (e) {
-		if (!this._loaded || L.DomEvent._skipped(e)) { return; }
+  _fireMouseEvent: function (e) {
+    if (!this._loaded || L.DomEvent._skipped(e)) { return; }
 
-		var type = e.type;
+    var type = e.type;
 
-		type = (type === 'mouseenter' ? 'mouseover' : (type === 'mouseleave' ? 'mouseout' : type));
+    type = (type === 'mouseenter' ? 'mouseover' : (type === 'mouseleave' ? 'mouseout' : type));
 
-		if (!this.hasEventListeners(type)) { return; }
+    if (!this.hasEventListeners(type)) { return; }
 
-		if (type === 'contextmenu') {
-			L.DomEvent.preventDefault(e);
-		}
+    if (type === 'contextmenu') {
+      L.DomEvent.preventDefault(e);
+    }
 
-		var containerPoint = this.mouseEventToContainerPoint(e),
-		    layerPoint = this.containerPointToLayerPoint(containerPoint),
-		    latlng = this.layerPointToLatLng(layerPoint);
+    var containerPoint = this.mouseEventToContainerPoint(e),
+        layerPoint = this.containerPointToLayerPoint(containerPoint),
+        latlng = this.layerPointToLatLng(layerPoint);
 
-		this.fire(type, {
-			latlng: latlng,
-			layerPoint: layerPoint,
-			containerPoint: containerPoint,
-			originalEvent: e
-		});
-	},
+    this.fire(type, {
+      latlng: latlng,
+      layerPoint: layerPoint,
+      containerPoint: containerPoint,
+      originalEvent: e
+    });
+  },
 
-	_onTileLayerLoad: function () {
-		this._tileLayersToLoad--;
-		if (this._tileLayersNum && !this._tileLayersToLoad) {
-			this.fire('tilelayersload');
-		}
-	},
+  _onTileLayerLoad: function () {
+    this._tileLayersToLoad--;
+    if (this._tileLayersNum && !this._tileLayersToLoad) {
+      this.fire('tilelayersload');
+    }
+  },
 
-	_clearHandlers: function () {
-		for (var i = 0, len = this._handlers.length; i < len; i++) {
-			this._handlers[i].disable();
-		}
-	},
+  _clearHandlers: function () {
+    for (var i = 0, len = this._handlers.length; i < len; i++) {
+      this._handlers[i].disable();
+    }
+  },
 
-	whenReady: function (callback, context) {
-		if (this._loaded) {
-			callback.call(context || this, this);
-		} else {
-			this.on('load', callback, context);
-		}
-		return this;
-	},
+  whenReady: function (callback, context) {
+    if (this._loaded) {
+      callback.call(context || this, this);
+    } else {
+      this.on('load', callback, context);
+    }
+    return this;
+  },
 
-	_layerAdd: function (layer) {
-		layer.onAdd(this);
-		this.fire('layeradd', {layer: layer});
-	},
+  _layerAdd: function (layer) {
+    layer.onAdd(this);
+    this.fire('layeradd', {layer: layer});
+  },
 
 
-	// private methods for getting map state
+  // private methods for getting map state
 
-	_getMapPanePos: function () {
-		return L.DomUtil.getPosition(this._mapPane);
-	},
+  _getMapPanePos: function () {
+    return L.DomUtil.getPosition(this._mapPane);
+  },
 
-	_moved: function () {
-		var pos = this._getMapPanePos();
-		return pos && !pos.equals([0, 0]);
-	},
+  _moved: function () {
+    var pos = this._getMapPanePos();
+    return pos && !pos.equals([0, 0]);
+  },
 
-	_getTopLeftPoint: function () {
-		return this.getPixelOrigin().subtract(this._getMapPanePos());
-	},
+  _getTopLeftPoint: function () {
+    return this.getPixelOrigin().subtract(this._getMapPanePos());
+  },
 
-	_getNewTopLeftPoint: function (center, zoom) {
-		var viewHalf = this.getSize()._divideBy(2);
-		// TODO round on display, not calculation to increase precision?
-		return this.project(center, zoom)._subtract(viewHalf)._round();
-	},
+  _getNewTopLeftPoint: function (center, zoom) {
+    var viewHalf = this.getSize()._divideBy(2);
+    // TODO round on display, not calculation to increase precision?
+    return this.project(center, zoom)._subtract(viewHalf)._round();
+  },
 
-	_latLngToNewLayerPoint: function (latlng, newZoom, newCenter) {
-		var topLeft = this._getNewTopLeftPoint(newCenter, newZoom).add(this._getMapPanePos());
-		return this.project(latlng, newZoom)._subtract(topLeft);
-	},
+  _latLngToNewLayerPoint: function (latlng, newZoom, newCenter) {
+    var topLeft = this._getNewTopLeftPoint(newCenter, newZoom).add(this._getMapPanePos());
+    return this.project(latlng, newZoom)._subtract(topLeft);
+  },
 
-	// layer point of the current center
-	_getCenterLayerPoint: function () {
-		return this.containerPointToLayerPoint(this.getSize()._divideBy(2));
-	},
+  // layer point of the current center
+  _getCenterLayerPoint: function () {
+    return this.containerPointToLayerPoint(this.getSize()._divideBy(2));
+  },
 
-	// offset of the specified place to the current center in pixels
-	_getCenterOffset: function (latlng) {
-		return this.latLngToLayerPoint(latlng).subtract(this._getCenterLayerPoint());
-	},
+  // offset of the specified place to the current center in pixels
+  _getCenterOffset: function (latlng) {
+    return this.latLngToLayerPoint(latlng).subtract(this._getCenterLayerPoint());
+  },
 
-	// adjust center for view to get inside bounds
-	_limitCenter: function (center, zoom, bounds) {
+  // adjust center for view to get inside bounds
+  _limitCenter: function (center, zoom, bounds) {
 
-		if (!bounds) { return center; }
+    if (!bounds) { return center; }
 
-		var centerPoint = this.project(center, zoom),
-		    viewHalf = this.getSize().divideBy(2),
-		    viewBounds = new L.Bounds(centerPoint.subtract(viewHalf), centerPoint.add(viewHalf)),
-		    offset = this._getBoundsOffset(viewBounds, bounds, zoom);
+    var centerPoint = this.project(center, zoom),
+        viewHalf = this.getSize().divideBy(2),
+        viewBounds = new L.Bounds(centerPoint.subtract(viewHalf), centerPoint.add(viewHalf)),
+        offset = this._getBoundsOffset(viewBounds, bounds, zoom);
 
-		return this.unproject(centerPoint.add(offset), zoom);
-	},
+    return this.unproject(centerPoint.add(offset), zoom);
+  },
 
-	// adjust offset for view to get inside bounds
-	_limitOffset: function (offset, bounds) {
-		if (!bounds) { return offset; }
+  // adjust offset for view to get inside bounds
+  _limitOffset: function (offset, bounds) {
+    if (!bounds) { return offset; }
 
-		var viewBounds = this.getPixelBounds(),
-		    newBounds = new L.Bounds(viewBounds.min.add(offset), viewBounds.max.add(offset));
+    var viewBounds = this.getPixelBounds(),
+        newBounds = new L.Bounds(viewBounds.min.add(offset), viewBounds.max.add(offset));
 
-		return offset.add(this._getBoundsOffset(newBounds, bounds));
-	},
+    return offset.add(this._getBoundsOffset(newBounds, bounds));
+  },
 
-	// returns offset needed for pxBounds to get inside maxBounds at a specified zoom
-	_getBoundsOffset: function (pxBounds, maxBounds, zoom) {
-		var nwOffset = this.project(maxBounds.getNorthWest(), zoom).subtract(pxBounds.min),
-		    seOffset = this.project(maxBounds.getSouthEast(), zoom).subtract(pxBounds.max),
+  // returns offset needed for pxBounds to get inside maxBounds at a specified zoom
+  _getBoundsOffset: function (pxBounds, maxBounds, zoom) {
+    var nwOffset = this.project(maxBounds.getNorthWest(), zoom).subtract(pxBounds.min),
+        seOffset = this.project(maxBounds.getSouthEast(), zoom).subtract(pxBounds.max),
 
-		    dx = this._rebound(nwOffset.x, -seOffset.x),
-		    dy = this._rebound(nwOffset.y, -seOffset.y);
+        dx = this._rebound(nwOffset.x, -seOffset.x),
+        dy = this._rebound(nwOffset.y, -seOffset.y);
 
-		return new L.Point(dx, dy);
-	},
+    return new L.Point(dx, dy);
+  },
 
-	_rebound: function (left, right) {
-		return left + right > 0 ?
-			Math.round(left - right) / 2 :
-			Math.max(0, Math.ceil(left)) - Math.max(0, Math.floor(right));
-	},
+  _rebound: function (left, right) {
+    return left + right > 0 ?
+      Math.round(left - right) / 2 :
+      Math.max(0, Math.ceil(left)) - Math.max(0, Math.floor(right));
+  },
 
-	_limitZoom: function (zoom) {
-		var min = this.getMinZoom(),
-		    max = this.getMaxZoom();
+  _limitZoom: function (zoom) {
+    var min = this.getMinZoom(),
+        max = this.getMaxZoom();
 
-		return Math.max(min, Math.min(max, zoom));
-	}
+    return Math.max(min, Math.min(max, zoom));
+  }
 });
 
 L.map = function (id, options) {
-	return new L.Map(id, options);
+  return new L.Map(id, options);
 };
 
 
@@ -10313,235 +10313,235 @@ L.map = function (id, options) {
  */
 
 L.DomEvent = {
-	/* inspired by John Resig, Dean Edwards and YUI addEvent implementations */
-	addListener: function (obj, type, fn, context) { // (HTMLElement, String, Function[, Object])
+  /* inspired by John Resig, Dean Edwards and YUI addEvent implementations */
+  addListener: function (obj, type, fn, context) { // (HTMLElement, String, Function[, Object])
 
-		var id = L.stamp(fn),
-		    key = '_leaflet_' + type + id,
-		    handler, originalHandler, newType;
+    var id = L.stamp(fn),
+        key = '_leaflet_' + type + id,
+        handler, originalHandler, newType;
 
-		if (obj[key]) { return this; }
+    if (obj[key]) { return this; }
 
-		handler = function (e) {
-			return fn.call(context || obj, e || L.DomEvent._getEvent());
-		};
+    handler = function (e) {
+      return fn.call(context || obj, e || L.DomEvent._getEvent());
+    };
 
-		if (L.Browser.pointer && type.indexOf('touch') === 0) {
-			return this.addPointerListener(obj, type, handler, id);
-		}
-		if (L.Browser.touch && (type === 'dblclick') && this.addDoubleTapListener) {
-			this.addDoubleTapListener(obj, handler, id);
-		}
+    if (L.Browser.pointer && type.indexOf('touch') === 0) {
+      return this.addPointerListener(obj, type, handler, id);
+    }
+    if (L.Browser.touch && (type === 'dblclick') && this.addDoubleTapListener) {
+      this.addDoubleTapListener(obj, handler, id);
+    }
 
-		if ('addEventListener' in obj) {
+    if ('addEventListener' in obj) {
 
-			if (type === 'mousewheel') {
-				obj.addEventListener('DOMMouseScroll', handler, false);
-				obj.addEventListener(type, handler, false);
+      if (type === 'mousewheel') {
+        obj.addEventListener('DOMMouseScroll', handler, false);
+        obj.addEventListener(type, handler, false);
 
-			} else if ((type === 'mouseenter') || (type === 'mouseleave')) {
+      } else if ((type === 'mouseenter') || (type === 'mouseleave')) {
 
-				originalHandler = handler;
-				newType = (type === 'mouseenter' ? 'mouseover' : 'mouseout');
+        originalHandler = handler;
+        newType = (type === 'mouseenter' ? 'mouseover' : 'mouseout');
 
-				handler = function (e) {
-					if (!L.DomEvent._checkMouse(obj, e)) { return; }
-					return originalHandler(e);
-				};
+        handler = function (e) {
+          if (!L.DomEvent._checkMouse(obj, e)) { return; }
+          return originalHandler(e);
+        };
 
-				obj.addEventListener(newType, handler, false);
+        obj.addEventListener(newType, handler, false);
 
-			} else if (type === 'click' && L.Browser.android) {
-				originalHandler = handler;
-				handler = function (e) {
-					return L.DomEvent._filterClick(e, originalHandler);
-				};
+      } else if (type === 'click' && L.Browser.android) {
+        originalHandler = handler;
+        handler = function (e) {
+          return L.DomEvent._filterClick(e, originalHandler);
+        };
 
-				obj.addEventListener(type, handler, false);
-			} else {
-				obj.addEventListener(type, handler, false);
-			}
+        obj.addEventListener(type, handler, false);
+      } else {
+        obj.addEventListener(type, handler, false);
+      }
 
-		} else if ('attachEvent' in obj) {
-			obj.attachEvent('on' + type, handler);
-		}
+    } else if ('attachEvent' in obj) {
+      obj.attachEvent('on' + type, handler);
+    }
 
-		obj[key] = handler;
+    obj[key] = handler;
 
-		return this;
-	},
+    return this;
+  },
 
-	removeListener: function (obj, type, fn) {  // (HTMLElement, String, Function)
+  removeListener: function (obj, type, fn) {  // (HTMLElement, String, Function)
 
-		var id = L.stamp(fn),
-		    key = '_leaflet_' + type + id,
-		    handler = obj[key];
+    var id = L.stamp(fn),
+        key = '_leaflet_' + type + id,
+        handler = obj[key];
 
-		if (!handler) { return this; }
+    if (!handler) { return this; }
 
-		if (L.Browser.pointer && type.indexOf('touch') === 0) {
-			this.removePointerListener(obj, type, id);
-		} else if (L.Browser.touch && (type === 'dblclick') && this.removeDoubleTapListener) {
-			this.removeDoubleTapListener(obj, id);
+    if (L.Browser.pointer && type.indexOf('touch') === 0) {
+      this.removePointerListener(obj, type, id);
+    } else if (L.Browser.touch && (type === 'dblclick') && this.removeDoubleTapListener) {
+      this.removeDoubleTapListener(obj, id);
 
-		} else if ('removeEventListener' in obj) {
+    } else if ('removeEventListener' in obj) {
 
-			if (type === 'mousewheel') {
-				obj.removeEventListener('DOMMouseScroll', handler, false);
-				obj.removeEventListener(type, handler, false);
+      if (type === 'mousewheel') {
+        obj.removeEventListener('DOMMouseScroll', handler, false);
+        obj.removeEventListener(type, handler, false);
 
-			} else if ((type === 'mouseenter') || (type === 'mouseleave')) {
-				obj.removeEventListener((type === 'mouseenter' ? 'mouseover' : 'mouseout'), handler, false);
-			} else {
-				obj.removeEventListener(type, handler, false);
-			}
-		} else if ('detachEvent' in obj) {
-			obj.detachEvent('on' + type, handler);
-		}
+      } else if ((type === 'mouseenter') || (type === 'mouseleave')) {
+        obj.removeEventListener((type === 'mouseenter' ? 'mouseover' : 'mouseout'), handler, false);
+      } else {
+        obj.removeEventListener(type, handler, false);
+      }
+    } else if ('detachEvent' in obj) {
+      obj.detachEvent('on' + type, handler);
+    }
 
-		obj[key] = null;
+    obj[key] = null;
 
-		return this;
-	},
+    return this;
+  },
 
-	stopPropagation: function (e) {
+  stopPropagation: function (e) {
 
-		if (e.stopPropagation) {
-			e.stopPropagation();
-		} else {
-			e.cancelBubble = true;
-		}
-		L.DomEvent._skipped(e);
+    if (e.stopPropagation) {
+      e.stopPropagation();
+    } else {
+      e.cancelBubble = true;
+    }
+    L.DomEvent._skipped(e);
 
-		return this;
-	},
+    return this;
+  },
 
-	disableScrollPropagation: function (el) {
-		var stop = L.DomEvent.stopPropagation;
+  disableScrollPropagation: function (el) {
+    var stop = L.DomEvent.stopPropagation;
 
-		return L.DomEvent
-			.on(el, 'mousewheel', stop)
-			.on(el, 'MozMousePixelScroll', stop);
-	},
+    return L.DomEvent
+      .on(el, 'mousewheel', stop)
+      .on(el, 'MozMousePixelScroll', stop);
+  },
 
-	disableClickPropagation: function (el) {
-		var stop = L.DomEvent.stopPropagation;
+  disableClickPropagation: function (el) {
+    var stop = L.DomEvent.stopPropagation;
 
-		for (var i = L.Draggable.START.length - 1; i >= 0; i--) {
-			L.DomEvent.on(el, L.Draggable.START[i], stop);
-		}
+    for (var i = L.Draggable.START.length - 1; i >= 0; i--) {
+      L.DomEvent.on(el, L.Draggable.START[i], stop);
+    }
 
-		return L.DomEvent
-			.on(el, 'click', L.DomEvent._fakeStop)
-			.on(el, 'dblclick', stop);
-	},
+    return L.DomEvent
+      .on(el, 'click', L.DomEvent._fakeStop)
+      .on(el, 'dblclick', stop);
+  },
 
-	preventDefault: function (e) {
+  preventDefault: function (e) {
 
-		if (e.preventDefault) {
-			e.preventDefault();
-		} else {
-			e.returnValue = false;
-		}
-		return this;
-	},
+    if (e.preventDefault) {
+      e.preventDefault();
+    } else {
+      e.returnValue = false;
+    }
+    return this;
+  },
 
-	stop: function (e) {
-		return L.DomEvent
-			.preventDefault(e)
-			.stopPropagation(e);
-	},
+  stop: function (e) {
+    return L.DomEvent
+      .preventDefault(e)
+      .stopPropagation(e);
+  },
 
-	getMousePosition: function (e, container) {
-		if (!container) {
-			return new L.Point(e.clientX, e.clientY);
-		}
+  getMousePosition: function (e, container) {
+    if (!container) {
+      return new L.Point(e.clientX, e.clientY);
+    }
 
-		var rect = container.getBoundingClientRect();
+    var rect = container.getBoundingClientRect();
 
-		return new L.Point(
-			e.clientX - rect.left - container.clientLeft,
-			e.clientY - rect.top - container.clientTop);
-	},
+    return new L.Point(
+      e.clientX - rect.left - container.clientLeft,
+      e.clientY - rect.top - container.clientTop);
+  },
 
-	getWheelDelta: function (e) {
+  getWheelDelta: function (e) {
 
-		var delta = 0;
+    var delta = 0;
 
-		if (e.wheelDelta) {
-			delta = e.wheelDelta / 120;
-		}
-		if (e.detail) {
-			delta = -e.detail / 3;
-		}
-		return delta;
-	},
+    if (e.wheelDelta) {
+      delta = e.wheelDelta / 120;
+    }
+    if (e.detail) {
+      delta = -e.detail / 3;
+    }
+    return delta;
+  },
 
-	_skipEvents: {},
+  _skipEvents: {},
 
-	_fakeStop: function (e) {
-		// fakes stopPropagation by setting a special event flag, checked/reset with L.DomEvent._skipped(e)
-		L.DomEvent._skipEvents[e.type] = true;
-	},
+  _fakeStop: function (e) {
+    // fakes stopPropagation by setting a special event flag, checked/reset with L.DomEvent._skipped(e)
+    L.DomEvent._skipEvents[e.type] = true;
+  },
 
-	_skipped: function (e) {
-		var skipped = this._skipEvents[e.type];
-		// reset when checking, as it's only used in map container and propagates outside of the map
-		this._skipEvents[e.type] = false;
-		return skipped;
-	},
+  _skipped: function (e) {
+    var skipped = this._skipEvents[e.type];
+    // reset when checking, as it's only used in map container and propagates outside of the map
+    this._skipEvents[e.type] = false;
+    return skipped;
+  },
 
-	// check if element really left/entered the event target (for mouseenter/mouseleave)
-	_checkMouse: function (el, e) {
+  // check if element really left/entered the event target (for mouseenter/mouseleave)
+  _checkMouse: function (el, e) {
 
-		var related = e.relatedTarget;
+    var related = e.relatedTarget;
 
-		if (!related) { return true; }
+    if (!related) { return true; }
 
-		try {
-			while (related && (related !== el)) {
-				related = related.parentNode;
-			}
-		} catch (err) {
-			return false;
-		}
-		return (related !== el);
-	},
+    try {
+      while (related && (related !== el)) {
+        related = related.parentNode;
+      }
+    } catch (err) {
+      return false;
+    }
+    return (related !== el);
+  },
 
-	_getEvent: function () { // evil magic for IE
-		/*jshint noarg:false */
-		var e = window.event;
-		if (!e) {
-			var caller = arguments.callee.caller;
-			while (caller) {
-				e = caller['arguments'][0];
-				if (e && window.Event === e.constructor) {
-					break;
-				}
-				caller = caller.caller;
-			}
-		}
-		return e;
-	},
+  _getEvent: function () { // evil magic for IE
+    /*jshint noarg:false */
+    var e = window.event;
+    if (!e) {
+      var caller = arguments.callee.caller;
+      while (caller) {
+        e = caller['arguments'][0];
+        if (e && window.Event === e.constructor) {
+          break;
+        }
+        caller = caller.caller;
+      }
+    }
+    return e;
+  },
 
-	// this is a horrible workaround for a bug in Android where a single touch triggers two click events
-	_filterClick: function (e, handler) {
-		var timeStamp = (e.timeStamp || e.originalEvent.timeStamp),
-			elapsed = L.DomEvent._lastClick && (timeStamp - L.DomEvent._lastClick);
+  // this is a horrible workaround for a bug in Android where a single touch triggers two click events
+  _filterClick: function (e, handler) {
+    var timeStamp = (e.timeStamp || e.originalEvent.timeStamp),
+      elapsed = L.DomEvent._lastClick && (timeStamp - L.DomEvent._lastClick);
 
-		// are they closer together than 1000ms yet more than 100ms?
-		// Android typically triggers them ~300ms apart while multiple listeners
-		// on the same event should be triggered far faster;
-		// or check if click is simulated on the element, and if it is, reject any non-simulated events
+    // are they closer together than 1000ms yet more than 100ms?
+    // Android typically triggers them ~300ms apart while multiple listeners
+    // on the same event should be triggered far faster;
+    // or check if click is simulated on the element, and if it is, reject any non-simulated events
 
-		if ((elapsed && elapsed > 100 && elapsed < 1000) || (e.target._simulatedClick && !e._simulated)) {
-			L.DomEvent.stop(e);
-			return;
-		}
-		L.DomEvent._lastClick = timeStamp;
+    if ((elapsed && elapsed > 100 && elapsed < 1000) || (e.target._simulatedClick && !e._simulated)) {
+      L.DomEvent.stop(e);
+      return;
+    }
+    L.DomEvent._lastClick = timeStamp;
 
-		return handler(e);
-	}
+    return handler(e);
+  }
 };
 
 L.DomEvent.on = L.DomEvent.addListener;
@@ -10557,135 +10557,135 @@ L.DomEvent.off = L.DomEvent.removeListener;
  */
 
 L.Draggable = L.Class.extend({
-	includes: L.Mixin.Events,
+  includes: L.Mixin.Events,
 
-	statics: {
-		START: L.Browser.touch ? ['touchstart', 'mousedown'] : ['mousedown'],
-		END: {
-			mousedown: 'mouseup',
-			touchstart: 'touchend',
-			pointerdown: 'touchend',
-			MSPointerDown: 'touchend'
-		},
-		MOVE: {
-			mousedown: 'mousemove',
-			touchstart: 'touchmove',
-			pointerdown: 'touchmove',
-			MSPointerDown: 'touchmove'
-		}
-	},
+  statics: {
+    START: L.Browser.touch ? ['touchstart', 'mousedown'] : ['mousedown'],
+    END: {
+      mousedown: 'mouseup',
+      touchstart: 'touchend',
+      pointerdown: 'touchend',
+      MSPointerDown: 'touchend'
+    },
+    MOVE: {
+      mousedown: 'mousemove',
+      touchstart: 'touchmove',
+      pointerdown: 'touchmove',
+      MSPointerDown: 'touchmove'
+    }
+  },
 
-	initialize: function (element, dragStartTarget) {
-		this._element = element;
-		this._dragStartTarget = dragStartTarget || element;
-	},
+  initialize: function (element, dragStartTarget) {
+    this._element = element;
+    this._dragStartTarget = dragStartTarget || element;
+  },
 
-	enable: function () {
-		if (this._enabled) { return; }
+  enable: function () {
+    if (this._enabled) { return; }
 
-		for (var i = L.Draggable.START.length - 1; i >= 0; i--) {
-			L.DomEvent.on(this._dragStartTarget, L.Draggable.START[i], this._onDown, this);
-		}
+    for (var i = L.Draggable.START.length - 1; i >= 0; i--) {
+      L.DomEvent.on(this._dragStartTarget, L.Draggable.START[i], this._onDown, this);
+    }
 
-		this._enabled = true;
-	},
+    this._enabled = true;
+  },
 
-	disable: function () {
-		if (!this._enabled) { return; }
+  disable: function () {
+    if (!this._enabled) { return; }
 
-		for (var i = L.Draggable.START.length - 1; i >= 0; i--) {
-			L.DomEvent.off(this._dragStartTarget, L.Draggable.START[i], this._onDown, this);
-		}
+    for (var i = L.Draggable.START.length - 1; i >= 0; i--) {
+      L.DomEvent.off(this._dragStartTarget, L.Draggable.START[i], this._onDown, this);
+    }
 
-		this._enabled = false;
-		this._moved = false;
-	},
+    this._enabled = false;
+    this._moved = false;
+  },
 
-	_onDown: function (e) {
-		this._moved = false;
+  _onDown: function (e) {
+    this._moved = false;
 
-		if (e.shiftKey || ((e.which !== 1) && (e.button !== 1) && !e.touches)) { return; }
+    if (e.shiftKey || ((e.which !== 1) && (e.button !== 1) && !e.touches)) { return; }
 
-		L.DomEvent.stopPropagation(e);
+    L.DomEvent.stopPropagation(e);
 
-		if (L.Draggable._disabled) { return; }
+    if (L.Draggable._disabled) { return; }
 
-		L.DomUtil.disableImageDrag();
-		L.DomUtil.disableTextSelection();
+    L.DomUtil.disableImageDrag();
+    L.DomUtil.disableTextSelection();
 
-		if (this._moving) { return; }
+    if (this._moving) { return; }
 
-		var first = e.touches ? e.touches[0] : e;
+    var first = e.touches ? e.touches[0] : e;
 
-		this._startPoint = new L.Point(first.clientX, first.clientY);
-		this._startPos = this._newPos = L.DomUtil.getPosition(this._element);
+    this._startPoint = new L.Point(first.clientX, first.clientY);
+    this._startPos = this._newPos = L.DomUtil.getPosition(this._element);
 
-		L.DomEvent
-		    .on(document, L.Draggable.MOVE[e.type], this._onMove, this)
-		    .on(document, L.Draggable.END[e.type], this._onUp, this);
-	},
+    L.DomEvent
+        .on(document, L.Draggable.MOVE[e.type], this._onMove, this)
+        .on(document, L.Draggable.END[e.type], this._onUp, this);
+  },
 
-	_onMove: function (e) {
-		if (e.touches && e.touches.length > 1) {
-			this._moved = true;
-			return;
-		}
+  _onMove: function (e) {
+    if (e.touches && e.touches.length > 1) {
+      this._moved = true;
+      return;
+    }
 
-		var first = (e.touches && e.touches.length === 1 ? e.touches[0] : e),
-		    newPoint = new L.Point(first.clientX, first.clientY),
-		    offset = newPoint.subtract(this._startPoint);
+    var first = (e.touches && e.touches.length === 1 ? e.touches[0] : e),
+        newPoint = new L.Point(first.clientX, first.clientY),
+        offset = newPoint.subtract(this._startPoint);
 
-		if (!offset.x && !offset.y) { return; }
+    if (!offset.x && !offset.y) { return; }
 
-		L.DomEvent.preventDefault(e);
+    L.DomEvent.preventDefault(e);
 
-		if (!this._moved) {
-			this.fire('dragstart');
+    if (!this._moved) {
+      this.fire('dragstart');
 
-			this._moved = true;
-			this._startPos = L.DomUtil.getPosition(this._element).subtract(offset);
+      this._moved = true;
+      this._startPos = L.DomUtil.getPosition(this._element).subtract(offset);
 
-			L.DomUtil.addClass(document.body, 'leaflet-dragging');
-			L.DomUtil.addClass((e.target || e.srcElement), 'leaflet-drag-target');
-		}
+      L.DomUtil.addClass(document.body, 'leaflet-dragging');
+      L.DomUtil.addClass((e.target || e.srcElement), 'leaflet-drag-target');
+    }
 
-		this._newPos = this._startPos.add(offset);
-		this._moving = true;
+    this._newPos = this._startPos.add(offset);
+    this._moving = true;
 
-		L.Util.cancelAnimFrame(this._animRequest);
-		this._animRequest = L.Util.requestAnimFrame(this._updatePosition, this, true, this._dragStartTarget);
-	},
+    L.Util.cancelAnimFrame(this._animRequest);
+    this._animRequest = L.Util.requestAnimFrame(this._updatePosition, this, true, this._dragStartTarget);
+  },
 
-	_updatePosition: function () {
-		this.fire('predrag');
-		L.DomUtil.setPosition(this._element, this._newPos);
-		this.fire('drag');
-	},
+  _updatePosition: function () {
+    this.fire('predrag');
+    L.DomUtil.setPosition(this._element, this._newPos);
+    this.fire('drag');
+  },
 
-	_onUp: function (e) {
-		L.DomUtil.removeClass(document.body, 'leaflet-dragging');
-		L.DomUtil.removeClass((e.target || e.srcElement), 'leaflet-drag-target');
+  _onUp: function (e) {
+    L.DomUtil.removeClass(document.body, 'leaflet-dragging');
+    L.DomUtil.removeClass((e.target || e.srcElement), 'leaflet-drag-target');
 
-		for (var i in L.Draggable.MOVE) {
-			L.DomEvent
-			    .off(document, L.Draggable.MOVE[i], this._onMove)
-			    .off(document, L.Draggable.END[i], this._onUp);
-		}
+    for (var i in L.Draggable.MOVE) {
+      L.DomEvent
+          .off(document, L.Draggable.MOVE[i], this._onMove)
+          .off(document, L.Draggable.END[i], this._onUp);
+    }
 
-		L.DomUtil.enableImageDrag();
-		L.DomUtil.enableTextSelection();
+    L.DomUtil.enableImageDrag();
+    L.DomUtil.enableTextSelection();
 
-		if (this._moved && this._moving) {
-			// ensure drag is not fired after dragend
-			L.Util.cancelAnimFrame(this._animRequest);
+    if (this._moved && this._moving) {
+      // ensure drag is not fired after dragend
+      L.Util.cancelAnimFrame(this._animRequest);
 
-			this.fire('dragend', {
-				distance: this._newPos.distanceTo(this._startPos)
-			});
-		}
+      this.fire('dragend', {
+        distance: this._newPos.distanceTo(this._startPos)
+      });
+    }
 
-		this._moving = false;
-	}
+    this._moving = false;
+  }
 });
 
 
@@ -10694,32 +10694,32 @@ L.Draggable = L.Class.extend({
 ********************************************** */
 
 /*
-	L.Handler is a base class for handler classes that are used internally to inject
-	interaction features like dragging to classes like Map and Marker.
+  L.Handler is a base class for handler classes that are used internally to inject
+  interaction features like dragging to classes like Map and Marker.
 */
 
 L.Handler = L.Class.extend({
-	initialize: function (map) {
-		this._map = map;
-	},
+  initialize: function (map) {
+    this._map = map;
+  },
 
-	enable: function () {
-		if (this._enabled) { return; }
+  enable: function () {
+    if (this._enabled) { return; }
 
-		this._enabled = true;
-		this.addHooks();
-	},
+    this._enabled = true;
+    this.addHooks();
+  },
 
-	disable: function () {
-		if (!this._enabled) { return; }
+  disable: function () {
+    if (!this._enabled) { return; }
 
-		this._enabled = false;
-		this.removeHooks();
-	},
+    this._enabled = false;
+    this.removeHooks();
+  },
 
-	enabled: function () {
-		return !!this._enabled;
-	}
+  enabled: function () {
+    return !!this._enabled;
+  }
 });
 
 
@@ -10733,116 +10733,116 @@ L.Handler = L.Class.extend({
  */
 
 L.Control = L.Class.extend({
-	options: {
-		position: 'topright'
-	},
+  options: {
+    position: 'topright'
+  },
 
-	initialize: function (options) {
-		L.setOptions(this, options);
-	},
+  initialize: function (options) {
+    L.setOptions(this, options);
+  },
 
-	getPosition: function () {
-		return this.options.position;
-	},
+  getPosition: function () {
+    return this.options.position;
+  },
 
-	setPosition: function (position) {
-		var map = this._map;
+  setPosition: function (position) {
+    var map = this._map;
 
-		if (map) {
-			map.removeControl(this);
-		}
+    if (map) {
+      map.removeControl(this);
+    }
 
-		this.options.position = position;
+    this.options.position = position;
 
-		if (map) {
-			map.addControl(this);
-		}
+    if (map) {
+      map.addControl(this);
+    }
 
-		return this;
-	},
+    return this;
+  },
 
-	getContainer: function () {
-		return this._container;
-	},
+  getContainer: function () {
+    return this._container;
+  },
 
-	addTo: function (map) {
-		this._map = map;
+  addTo: function (map) {
+    this._map = map;
 
-		var container = this._container = this.onAdd(map),
-		    pos = this.getPosition(),
-		    corner = map._controlCorners[pos];
+    var container = this._container = this.onAdd(map),
+        pos = this.getPosition(),
+        corner = map._controlCorners[pos];
 
-		L.DomUtil.addClass(container, 'leaflet-control');
+    L.DomUtil.addClass(container, 'leaflet-control');
 
-		if (pos.indexOf('bottom') !== -1) {
-			corner.insertBefore(container, corner.firstChild);
-		} else {
-			corner.appendChild(container);
-		}
+    if (pos.indexOf('bottom') !== -1) {
+      corner.insertBefore(container, corner.firstChild);
+    } else {
+      corner.appendChild(container);
+    }
 
-		return this;
-	},
+    return this;
+  },
 
-	removeFrom: function (map) {
-		var pos = this.getPosition(),
-		    corner = map._controlCorners[pos];
+  removeFrom: function (map) {
+    var pos = this.getPosition(),
+        corner = map._controlCorners[pos];
 
-		corner.removeChild(this._container);
-		this._map = null;
+    corner.removeChild(this._container);
+    this._map = null;
 
-		if (this.onRemove) {
-			this.onRemove(map);
-		}
+    if (this.onRemove) {
+      this.onRemove(map);
+    }
 
-		return this;
-	},
+    return this;
+  },
 
-	_refocusOnMap: function () {
-		if (this._map) {
-			this._map.getContainer().focus();
-		}
-	}
+  _refocusOnMap: function () {
+    if (this._map) {
+      this._map.getContainer().focus();
+    }
+  }
 });
 
 L.control = function (options) {
-	return new L.Control(options);
+  return new L.Control(options);
 };
 
 
 // adds control-related methods to L.Map
 
 L.Map.include({
-	addControl: function (control) {
-		control.addTo(this);
-		return this;
-	},
+  addControl: function (control) {
+    control.addTo(this);
+    return this;
+  },
 
-	removeControl: function (control) {
-		control.removeFrom(this);
-		return this;
-	},
+  removeControl: function (control) {
+    control.removeFrom(this);
+    return this;
+  },
 
-	_initControlPos: function () {
-		var corners = this._controlCorners = {},
-		    l = 'leaflet-',
-		    container = this._controlContainer =
-		            L.DomUtil.create('div', l + 'control-container', this._container);
+  _initControlPos: function () {
+    var corners = this._controlCorners = {},
+        l = 'leaflet-',
+        container = this._controlContainer =
+                L.DomUtil.create('div', l + 'control-container', this._container);
 
-		function createCorner(vSide, hSide) {
-			var className = l + vSide + ' ' + l + hSide;
+    function createCorner(vSide, hSide) {
+      var className = l + vSide + ' ' + l + hSide;
 
-			corners[vSide + hSide] = L.DomUtil.create('div', className, container);
-		}
+      corners[vSide + hSide] = L.DomUtil.create('div', className, container);
+    }
 
-		createCorner('top', 'left');
-		createCorner('top', 'right');
-		createCorner('bottom', 'left');
-		createCorner('bottom', 'right');
-	},
+    createCorner('top', 'left');
+    createCorner('top', 'right');
+    createCorner('bottom', 'left');
+    createCorner('bottom', 'right');
+  },
 
-	_clearControlPos: function () {
-		this._container.removeChild(this._controlContainer);
-	}
+  _clearControlPos: function () {
+    this._container.removeChild(this._controlContainer);
+  }
 });
 
 
@@ -10855,603 +10855,603 @@ L.Map.include({
  */
 
 L.TileLayer = L.Class.extend({
-	includes: L.Mixin.Events,
-
-	options: {
-		minZoom: 0,
-		maxZoom: 18,
-		tileSize: 256,
-		subdomains: 'abc',
-		errorTileUrl: '',
-		attribution: '',
-		zoomOffset: 0,
-		opacity: 1,
-		/*
-		maxNativeZoom: null,
-		zIndex: null,
-		tms: false,
-		continuousWorld: false,
-		noWrap: false,
-		zoomReverse: false,
-		detectRetina: false,
-		reuseTiles: false,
-		bounds: false,
-		*/
-		unloadInvisibleTiles: L.Browser.mobile,
-		updateWhenIdle: L.Browser.mobile
-	},
-
-	initialize: function (url, options) {
-		options = L.setOptions(this, options);
-
-		// detecting retina displays, adjusting tileSize and zoom levels
-		if (options.detectRetina && L.Browser.retina && options.maxZoom > 0) {
-
-			options.tileSize = Math.floor(options.tileSize / 2);
-			options.zoomOffset++;
-
-			if (options.minZoom > 0) {
-				options.minZoom--;
-			}
-			this.options.maxZoom--;
-		}
-
-		if (options.bounds) {
-			options.bounds = L.latLngBounds(options.bounds);
-		}
-
-		this._url = url;
-
-		var subdomains = this.options.subdomains;
-
-		if (typeof subdomains === 'string') {
-			this.options.subdomains = subdomains.split('');
-		}
-	},
-
-	onAdd: function (map) {
-		this._map = map;
-		this._animated = map._zoomAnimated;
-
-		// create a container div for tiles
-		this._initContainer();
-
-		// set up events
-		map.on({
-			'viewreset': this._reset,
-			'moveend': this._update
-		}, this);
-
-		if (this._animated) {
-			map.on({
-				'zoomanim': this._animateZoom,
-				'zoomend': this._endZoomAnim
-			}, this);
-		}
-
-		if (!this.options.updateWhenIdle) {
-			this._limitedUpdate = L.Util.limitExecByInterval(this._update, 150, this);
-			map.on('move', this._limitedUpdate, this);
-		}
-
-		this._reset();
-		this._update();
-	},
-
-	addTo: function (map) {
-		map.addLayer(this);
-		return this;
-	},
-
-	onRemove: function (map) {
-		this._container.parentNode.removeChild(this._container);
-
-		map.off({
-			'viewreset': this._reset,
-			'moveend': this._update
-		}, this);
-
-		if (this._animated) {
-			map.off({
-				'zoomanim': this._animateZoom,
-				'zoomend': this._endZoomAnim
-			}, this);
-		}
+  includes: L.Mixin.Events,
+
+  options: {
+    minZoom: 0,
+    maxZoom: 18,
+    tileSize: 256,
+    subdomains: 'abc',
+    errorTileUrl: '',
+    attribution: '',
+    zoomOffset: 0,
+    opacity: 1,
+    /*
+    maxNativeZoom: null,
+    zIndex: null,
+    tms: false,
+    continuousWorld: false,
+    noWrap: false,
+    zoomReverse: false,
+    detectRetina: false,
+    reuseTiles: false,
+    bounds: false,
+    */
+    unloadInvisibleTiles: L.Browser.mobile,
+    updateWhenIdle: L.Browser.mobile
+  },
+
+  initialize: function (url, options) {
+    options = L.setOptions(this, options);
+
+    // detecting retina displays, adjusting tileSize and zoom levels
+    if (options.detectRetina && L.Browser.retina && options.maxZoom > 0) {
+
+      options.tileSize = Math.floor(options.tileSize / 2);
+      options.zoomOffset++;
+
+      if (options.minZoom > 0) {
+        options.minZoom--;
+      }
+      this.options.maxZoom--;
+    }
+
+    if (options.bounds) {
+      options.bounds = L.latLngBounds(options.bounds);
+    }
+
+    this._url = url;
+
+    var subdomains = this.options.subdomains;
+
+    if (typeof subdomains === 'string') {
+      this.options.subdomains = subdomains.split('');
+    }
+  },
+
+  onAdd: function (map) {
+    this._map = map;
+    this._animated = map._zoomAnimated;
+
+    // create a container div for tiles
+    this._initContainer();
+
+    // set up events
+    map.on({
+      'viewreset': this._reset,
+      'moveend': this._update
+    }, this);
+
+    if (this._animated) {
+      map.on({
+        'zoomanim': this._animateZoom,
+        'zoomend': this._endZoomAnim
+      }, this);
+    }
+
+    if (!this.options.updateWhenIdle) {
+      this._limitedUpdate = L.Util.limitExecByInterval(this._update, 150, this);
+      map.on('move', this._limitedUpdate, this);
+    }
+
+    this._reset();
+    this._update();
+  },
+
+  addTo: function (map) {
+    map.addLayer(this);
+    return this;
+  },
+
+  onRemove: function (map) {
+    this._container.parentNode.removeChild(this._container);
+
+    map.off({
+      'viewreset': this._reset,
+      'moveend': this._update
+    }, this);
+
+    if (this._animated) {
+      map.off({
+        'zoomanim': this._animateZoom,
+        'zoomend': this._endZoomAnim
+      }, this);
+    }
 
-		if (!this.options.updateWhenIdle) {
-			map.off('move', this._limitedUpdate, this);
-		}
+    if (!this.options.updateWhenIdle) {
+      map.off('move', this._limitedUpdate, this);
+    }
 
-		this._container = null;
-		this._map = null;
-	},
+    this._container = null;
+    this._map = null;
+  },
 
-	bringToFront: function () {
-		var pane = this._map._panes.tilePane;
-
-		if (this._container) {
-			pane.appendChild(this._container);
-			this._setAutoZIndex(pane, Math.max);
-		}
-
-		return this;
-	},
-
-	bringToBack: function () {
-		var pane = this._map._panes.tilePane;
+  bringToFront: function () {
+    var pane = this._map._panes.tilePane;
+
+    if (this._container) {
+      pane.appendChild(this._container);
+      this._setAutoZIndex(pane, Math.max);
+    }
+
+    return this;
+  },
+
+  bringToBack: function () {
+    var pane = this._map._panes.tilePane;
 
-		if (this._container) {
-			pane.insertBefore(this._container, pane.firstChild);
-			this._setAutoZIndex(pane, Math.min);
-		}
+    if (this._container) {
+      pane.insertBefore(this._container, pane.firstChild);
+      this._setAutoZIndex(pane, Math.min);
+    }
 
-		return this;
-	},
+    return this;
+  },
 
-	getAttribution: function () {
-		return this.options.attribution;
-	},
+  getAttribution: function () {
+    return this.options.attribution;
+  },
 
-	getContainer: function () {
-		return this._container;
-	},
+  getContainer: function () {
+    return this._container;
+  },
 
-	setOpacity: function (opacity) {
-		this.options.opacity = opacity;
+  setOpacity: function (opacity) {
+    this.options.opacity = opacity;
 
-		if (this._map) {
-			this._updateOpacity();
-		}
+    if (this._map) {
+      this._updateOpacity();
+    }
 
-		return this;
-	},
+    return this;
+  },
 
-	setZIndex: function (zIndex) {
-		this.options.zIndex = zIndex;
-		this._updateZIndex();
+  setZIndex: function (zIndex) {
+    this.options.zIndex = zIndex;
+    this._updateZIndex();
 
-		return this;
-	},
+    return this;
+  },
 
-	setUrl: function (url, noRedraw) {
-		this._url = url;
+  setUrl: function (url, noRedraw) {
+    this._url = url;
 
-		if (!noRedraw) {
-			this.redraw();
-		}
+    if (!noRedraw) {
+      this.redraw();
+    }
 
-		return this;
-	},
+    return this;
+  },
 
-	redraw: function () {
-		if (this._map) {
-			this._reset({hard: true});
-			this._update();
-		}
-		return this;
-	},
+  redraw: function () {
+    if (this._map) {
+      this._reset({hard: true});
+      this._update();
+    }
+    return this;
+  },
 
-	_updateZIndex: function () {
-		if (this._container && this.options.zIndex !== undefined) {
-			this._container.style.zIndex = this.options.zIndex;
-		}
-	},
+  _updateZIndex: function () {
+    if (this._container && this.options.zIndex !== undefined) {
+      this._container.style.zIndex = this.options.zIndex;
+    }
+  },
 
-	_setAutoZIndex: function (pane, compare) {
+  _setAutoZIndex: function (pane, compare) {
 
-		var layers = pane.children,
-		    edgeZIndex = -compare(Infinity, -Infinity), // -Infinity for max, Infinity for min
-		    zIndex, i, len;
+    var layers = pane.children,
+        edgeZIndex = -compare(Infinity, -Infinity), // -Infinity for max, Infinity for min
+        zIndex, i, len;
 
-		for (i = 0, len = layers.length; i < len; i++) {
+    for (i = 0, len = layers.length; i < len; i++) {
 
-			if (layers[i] !== this._container) {
-				zIndex = parseInt(layers[i].style.zIndex, 10);
+      if (layers[i] !== this._container) {
+        zIndex = parseInt(layers[i].style.zIndex, 10);
 
-				if (!isNaN(zIndex)) {
-					edgeZIndex = compare(edgeZIndex, zIndex);
-				}
-			}
-		}
+        if (!isNaN(zIndex)) {
+          edgeZIndex = compare(edgeZIndex, zIndex);
+        }
+      }
+    }
 
-		this.options.zIndex = this._container.style.zIndex =
-		        (isFinite(edgeZIndex) ? edgeZIndex : 0) + compare(1, -1);
-	},
+    this.options.zIndex = this._container.style.zIndex =
+            (isFinite(edgeZIndex) ? edgeZIndex : 0) + compare(1, -1);
+  },
 
-	_updateOpacity: function () {
-		var i,
-		    tiles = this._tiles;
+  _updateOpacity: function () {
+    var i,
+        tiles = this._tiles;
 
-		if (L.Browser.ielt9) {
-			for (i in tiles) {
-				L.DomUtil.setOpacity(tiles[i], this.options.opacity);
-			}
-		} else {
-			L.DomUtil.setOpacity(this._container, this.options.opacity);
-		}
-	},
+    if (L.Browser.ielt9) {
+      for (i in tiles) {
+        L.DomUtil.setOpacity(tiles[i], this.options.opacity);
+      }
+    } else {
+      L.DomUtil.setOpacity(this._container, this.options.opacity);
+    }
+  },
 
-	_initContainer: function () {
-		var tilePane = this._map._panes.tilePane;
+  _initContainer: function () {
+    var tilePane = this._map._panes.tilePane;
 
-		if (!this._container) {
-			this._container = L.DomUtil.create('div', 'leaflet-layer');
+    if (!this._container) {
+      this._container = L.DomUtil.create('div', 'leaflet-layer');
 
-			this._updateZIndex();
+      this._updateZIndex();
 
-			if (this._animated) {
-				var className = 'leaflet-tile-container';
+      if (this._animated) {
+        var className = 'leaflet-tile-container';
 
-				this._bgBuffer = L.DomUtil.create('div', className, this._container);
-				this._tileContainer = L.DomUtil.create('div', className, this._container);
+        this._bgBuffer = L.DomUtil.create('div', className, this._container);
+        this._tileContainer = L.DomUtil.create('div', className, this._container);
 
-			} else {
-				this._tileContainer = this._container;
-			}
+      } else {
+        this._tileContainer = this._container;
+      }
 
-			tilePane.appendChild(this._container);
+      tilePane.appendChild(this._container);
 
-			if (this.options.opacity < 1) {
-				this._updateOpacity();
-			}
-		}
-	},
+      if (this.options.opacity < 1) {
+        this._updateOpacity();
+      }
+    }
+  },
 
-	_reset: function (e) {
-		for (var key in this._tiles) {
-			this.fire('tileunload', {tile: this._tiles[key]});
-		}
+  _reset: function (e) {
+    for (var key in this._tiles) {
+      this.fire('tileunload', {tile: this._tiles[key]});
+    }
 
-		this._tiles = {};
-		this._tilesToLoad = 0;
+    this._tiles = {};
+    this._tilesToLoad = 0;
 
-		if (this.options.reuseTiles) {
-			this._unusedTiles = [];
-		}
+    if (this.options.reuseTiles) {
+      this._unusedTiles = [];
+    }
 
-		this._tileContainer.innerHTML = '';
+    this._tileContainer.innerHTML = '';
 
-		if (this._animated && e && e.hard) {
-			this._clearBgBuffer();
-		}
+    if (this._animated && e && e.hard) {
+      this._clearBgBuffer();
+    }
 
-		this._initContainer();
-	},
+    this._initContainer();
+  },
 
-	_getTileSize: function () {
-		var map = this._map,
-		    zoom = map.getZoom() + this.options.zoomOffset,
-		    zoomN = this.options.maxNativeZoom,
-		    tileSize = this.options.tileSize;
+  _getTileSize: function () {
+    var map = this._map,
+        zoom = map.getZoom() + this.options.zoomOffset,
+        zoomN = this.options.maxNativeZoom,
+        tileSize = this.options.tileSize;
 
-		if (zoomN && zoom > zoomN) {
-			tileSize = Math.round(map.getZoomScale(zoom) / map.getZoomScale(zoomN) * tileSize);
-		}
+    if (zoomN && zoom > zoomN) {
+      tileSize = Math.round(map.getZoomScale(zoom) / map.getZoomScale(zoomN) * tileSize);
+    }
 
-		return tileSize;
-	},
+    return tileSize;
+  },
 
-	_update: function () {
+  _update: function () {
 
-		if (!this._map) { return; }
+    if (!this._map) { return; }
 
-		var map = this._map,
-		    bounds = map.getPixelBounds(),
-		    zoom = map.getZoom(),
-		    tileSize = this._getTileSize();
+    var map = this._map,
+        bounds = map.getPixelBounds(),
+        zoom = map.getZoom(),
+        tileSize = this._getTileSize();
 
-		if (isNaN(map.getZoom())) {
-			zoom = this.options.minZoom || 1;
-			map.setZoom(zoom);
-		}
+    if (isNaN(map.getZoom())) {
+      zoom = this.options.minZoom || 1;
+      map.setZoom(zoom);
+    }
 
-		if (zoom > this.options.maxZoom || zoom < this.options.minZoom) {
-			return;
-		}
+    if (zoom > this.options.maxZoom || zoom < this.options.minZoom) {
+      return;
+    }
 
-		var tileBounds = L.bounds(
-		        bounds.min.divideBy(tileSize)._floor(),
-		        bounds.max.divideBy(tileSize)._floor());
+    var tileBounds = L.bounds(
+            bounds.min.divideBy(tileSize)._floor(),
+            bounds.max.divideBy(tileSize)._floor());
 
-		this._addTilesFromCenterOut(tileBounds);
+    this._addTilesFromCenterOut(tileBounds);
 
-		if (this.options.unloadInvisibleTiles || this.options.reuseTiles) {
-			this._removeOtherTiles(tileBounds);
-		}
-	},
+    if (this.options.unloadInvisibleTiles || this.options.reuseTiles) {
+      this._removeOtherTiles(tileBounds);
+    }
+  },
 
-	_addTilesFromCenterOut: function (bounds) {
-		var queue = [],
-		    center = bounds.getCenter();
+  _addTilesFromCenterOut: function (bounds) {
+    var queue = [],
+        center = bounds.getCenter();
 
-		var j, i, point;
+    var j, i, point;
 
-		for (j = bounds.min.y; j <= bounds.max.y; j++) {
-			for (i = bounds.min.x; i <= bounds.max.x; i++) {
-				point = new L.Point(i, j);
+    for (j = bounds.min.y; j <= bounds.max.y; j++) {
+      for (i = bounds.min.x; i <= bounds.max.x; i++) {
+        point = new L.Point(i, j);
 
-				if (!(this._tilePointIsCached()) && this._tileShouldBeLoaded(point)) {
-					queue.push(point);
-				}
-			}
-		}
+        if (!(this._tilePointIsCached()) && this._tileShouldBeLoaded(point)) {
+          queue.push(point);
+        }
+      }
+    }
 
-		var tilesToLoad = queue.length;
+    var tilesToLoad = queue.length;
 
-		if (tilesToLoad === 0) { return; }
+    if (tilesToLoad === 0) { return; }
 
-		// load tiles in order of their distance to center
-		queue.sort(function (a, b) {
-			return a.distanceTo(center) - b.distanceTo(center);
-		});
+    // load tiles in order of their distance to center
+    queue.sort(function (a, b) {
+      return a.distanceTo(center) - b.distanceTo(center);
+    });
 
-		var fragment = document.createDocumentFragment();
+    var fragment = document.createDocumentFragment();
 
-		// if its the first batch of tiles to load
-		if (!this._tilesToLoad) {
-			this.fire('loading');
-		}
+    // if its the first batch of tiles to load
+    if (!this._tilesToLoad) {
+      this.fire('loading');
+    }
 
-		this._tilesToLoad += tilesToLoad;
+    this._tilesToLoad += tilesToLoad;
 
-		for (i = 0; i < tilesToLoad; i++) {
-			this._addTile(queue[i], fragment);
-		}
+    for (i = 0; i < tilesToLoad; i++) {
+      this._addTile(queue[i], fragment);
+    }
 
-		this._tileContainer.appendChild(fragment);
-	},
-	_tilePointIsCached: function (tilePoint) {
-		if (typeof(tilePoint) == "undefined") return false;
-		return ((tilePoint.x + ':' + tilePoint.y) in this._tiles);
-	},
-	_tileShouldBeLoaded: function (tilePoint) {
+    this._tileContainer.appendChild(fragment);
+  },
+  _tilePointIsCached: function (tilePoint) {
+    if (typeof(tilePoint) == "undefined") return false;
+    return ((tilePoint.x + ':' + tilePoint.y) in this._tiles);
+  },
+  _tileShouldBeLoaded: function (tilePoint) {
 
-		var options = this.options;
+    var options = this.options;
 
-		if (!options.continuousWorld) {
-			var limit = this._getWrapTileNum();
+    if (!options.continuousWorld) {
+      var limit = this._getWrapTileNum();
 
-			// don't load if exceeds world bounds
-			if ((options.noWrap && (tilePoint.x < 0 || tilePoint.x >= limit.x)) ||
-				tilePoint.y < 0 || tilePoint.y >= limit.y) { return false; }
-		}
+      // don't load if exceeds world bounds
+      if ((options.noWrap && (tilePoint.x < 0 || tilePoint.x >= limit.x)) ||
+        tilePoint.y < 0 || tilePoint.y >= limit.y) { return false; }
+    }
 
-		if (options.bounds) {
-			var tileSize = options.tileSize,
-			    nwPoint = tilePoint.multiplyBy(tileSize),
-			    sePoint = nwPoint.add([tileSize, tileSize]),
-			    nw = this._map.unproject(nwPoint),
-			    se = this._map.unproject(sePoint);
+    if (options.bounds) {
+      var tileSize = options.tileSize,
+          nwPoint = tilePoint.multiplyBy(tileSize),
+          sePoint = nwPoint.add([tileSize, tileSize]),
+          nw = this._map.unproject(nwPoint),
+          se = this._map.unproject(sePoint);
 
-			// TODO temporary hack, will be removed after refactoring projections
-			// https://github.com/Leaflet/Leaflet/issues/1618
-			if (!options.continuousWorld && !options.noWrap) {
-				nw = nw.wrap();
-				se = se.wrap();
-			}
+      // TODO temporary hack, will be removed after refactoring projections
+      // https://github.com/Leaflet/Leaflet/issues/1618
+      if (!options.continuousWorld && !options.noWrap) {
+        nw = nw.wrap();
+        se = se.wrap();
+      }
 
-			if (!options.bounds.intersects([nw, se])) { return false; }
-		}
+      if (!options.bounds.intersects([nw, se])) { return false; }
+    }
 
-		return true;
-	},
+    return true;
+  },
 
-	_removeOtherTiles: function (bounds) {
-		var kArr, x, y, key;
+  _removeOtherTiles: function (bounds) {
+    var kArr, x, y, key;
 
-		for (key in this._tiles) {
-			kArr = key.split(':');
-			x = parseInt(kArr[0], 10);
-			y = parseInt(kArr[1], 10);
+    for (key in this._tiles) {
+      kArr = key.split(':');
+      x = parseInt(kArr[0], 10);
+      y = parseInt(kArr[1], 10);
 
-			// remove tile if it's out of bounds
-			if (x < bounds.min.x || x > bounds.max.x || y < bounds.min.y || y > bounds.max.y) {
-				this._removeTile(key);
-			}
-		}
-	},
+      // remove tile if it's out of bounds
+      if (x < bounds.min.x || x > bounds.max.x || y < bounds.min.y || y > bounds.max.y) {
+        this._removeTile(key);
+      }
+    }
+  },
 
-	_removeTile: function (key) {
-		var tile = this._tiles[key];
+  _removeTile: function (key) {
+    var tile = this._tiles[key];
 
-		this.fire('tileunload', {tile: tile, url: tile.src});
+    this.fire('tileunload', {tile: tile, url: tile.src});
 
-		if (this.options.reuseTiles) {
-			L.DomUtil.removeClass(tile, 'leaflet-tile-loaded');
-			this._unusedTiles.push(tile);
+    if (this.options.reuseTiles) {
+      L.DomUtil.removeClass(tile, 'leaflet-tile-loaded');
+      this._unusedTiles.push(tile);
 
-		} else if (tile.parentNode === this._tileContainer) {
-			this._tileContainer.removeChild(tile);
-		}
+    } else if (tile.parentNode === this._tileContainer) {
+      this._tileContainer.removeChild(tile);
+    }
 
-		// for https://github.com/CloudMade/Leaflet/issues/137
-		if (!L.Browser.android) {
-			tile.onload = null;
-			tile.src = L.Util.emptyImageUrl;
-		}
+    // for https://github.com/CloudMade/Leaflet/issues/137
+    if (!L.Browser.android) {
+      tile.onload = null;
+      tile.src = L.Util.emptyImageUrl;
+    }
 
-		delete this._tiles[key];
-	},
+    delete this._tiles[key];
+  },
 
-	_addTile: function (tilePoint, container) {
+  _addTile: function (tilePoint, container) {
 
-		var tilePos = this._getTilePos(tilePoint);
+    var tilePos = this._getTilePos(tilePoint);
 
-		// get unused tile - or create a new tile
-		var tile = this._getTile();
+    // get unused tile - or create a new tile
+    var tile = this._getTile();
 
-		/*
-		Chrome 20 layouts much faster with top/left (verify with timeline, frames)
-		Android 4 browser has display issues with top/left and requires transform instead
-		(other browsers don't currently care) - see debug/hacks/jitter.html for an example
-		*/
-		L.DomUtil.setPosition(tile, tilePos, L.Browser.chrome);
+    /*
+    Chrome 20 layouts much faster with top/left (verify with timeline, frames)
+    Android 4 browser has display issues with top/left and requires transform instead
+    (other browsers don't currently care) - see debug/hacks/jitter.html for an example
+    */
+    L.DomUtil.setPosition(tile, tilePos, L.Browser.chrome);
 
-		this._tiles[tilePoint.x + ':' + tilePoint.y] = tile;
+    this._tiles[tilePoint.x + ':' + tilePoint.y] = tile;
 
-		this._loadTile(tile, tilePoint);
+    this._loadTile(tile, tilePoint);
 
-		if (tile.parentNode !== this._tileContainer) {
-			container.appendChild(tile);
-		}
-	},
+    if (tile.parentNode !== this._tileContainer) {
+      container.appendChild(tile);
+    }
+  },
 
-	_getZoomForUrl: function () {
+  _getZoomForUrl: function () {
 
-		var options = this.options,
-		    zoom = this._map.getZoom();
+    var options = this.options,
+        zoom = this._map.getZoom();
 
-		if (options.zoomReverse) {
-			zoom = options.maxZoom - zoom;
-		}
+    if (options.zoomReverse) {
+      zoom = options.maxZoom - zoom;
+    }
 
-		zoom += options.zoomOffset;
+    zoom += options.zoomOffset;
 
-		return options.maxNativeZoom ? Math.min(zoom, options.maxNativeZoom) : zoom;
-	},
+    return options.maxNativeZoom ? Math.min(zoom, options.maxNativeZoom) : zoom;
+  },
 
-	_getTilePos: function (tilePoint) {
-		var origin = this._map.getPixelOrigin(),
-		    tileSize = this._getTileSize();
+  _getTilePos: function (tilePoint) {
+    var origin = this._map.getPixelOrigin(),
+        tileSize = this._getTileSize();
 
-		return tilePoint.multiplyBy(tileSize).subtract(origin);
-	},
+    return tilePoint.multiplyBy(tileSize).subtract(origin);
+  },
 
-	// image-specific code (override to implement e.g. Canvas or SVG tile layer)
+  // image-specific code (override to implement e.g. Canvas or SVG tile layer)
 
-	getTileUrl: function (tilePoint) {
-		return L.Util.template(this._url, L.extend({
-			s: this._getSubdomain(tilePoint),
-			z: tilePoint.z,
-			x: tilePoint.x,
-			y: tilePoint.y
-		}, this.options));
-	},
+  getTileUrl: function (tilePoint) {
+    return L.Util.template(this._url, L.extend({
+      s: this._getSubdomain(tilePoint),
+      z: tilePoint.z,
+      x: tilePoint.x,
+      y: tilePoint.y
+    }, this.options));
+  },
 
-	_getWrapTileNum: function () {
-		var crs = this._map.options.crs,
-		    size = crs.getSize(this._map.getZoom());
-		return size.divideBy(this._getTileSize())._floor();
-	},
+  _getWrapTileNum: function () {
+    var crs = this._map.options.crs,
+        size = crs.getSize(this._map.getZoom());
+    return size.divideBy(this._getTileSize())._floor();
+  },
 
-	_adjustTilePoint: function (tilePoint) {
+  _adjustTilePoint: function (tilePoint) {
 
-		var limit = this._getWrapTileNum();
+    var limit = this._getWrapTileNum();
 
-		// wrap tile coordinates
-		if (!this.options.continuousWorld && !this.options.noWrap) {
-			tilePoint.x = ((tilePoint.x % limit.x) + limit.x) % limit.x;
-		}
+    // wrap tile coordinates
+    if (!this.options.continuousWorld && !this.options.noWrap) {
+      tilePoint.x = ((tilePoint.x % limit.x) + limit.x) % limit.x;
+    }
 
-		if (this.options.tms) {
-			tilePoint.y = limit.y - tilePoint.y - 1;
-		}
+    if (this.options.tms) {
+      tilePoint.y = limit.y - tilePoint.y - 1;
+    }
 
-		tilePoint.z = this._getZoomForUrl();
-	},
+    tilePoint.z = this._getZoomForUrl();
+  },
 
-	_getSubdomain: function (tilePoint) {
-		var index = Math.abs(tilePoint.x + tilePoint.y) % this.options.subdomains.length;
-		return this.options.subdomains[index];
-	},
+  _getSubdomain: function (tilePoint) {
+    var index = Math.abs(tilePoint.x + tilePoint.y) % this.options.subdomains.length;
+    return this.options.subdomains[index];
+  },
 
-	_getTile: function () {
-		if (this.options.reuseTiles && this._unusedTiles.length > 0) {
-			var tile = this._unusedTiles.pop();
-			this._resetTile(tile);
-			return tile;
-		}
-		return this._createTile();
-	},
+  _getTile: function () {
+    if (this.options.reuseTiles && this._unusedTiles.length > 0) {
+      var tile = this._unusedTiles.pop();
+      this._resetTile(tile);
+      return tile;
+    }
+    return this._createTile();
+  },
 
-	// Override if data stored on a tile needs to be cleaned up before reuse
-	_resetTile: function (/*tile*/) {},
+  // Override if data stored on a tile needs to be cleaned up before reuse
+  _resetTile: function (/*tile*/) {},
 
-	_createTile: function () {
-		var tile = L.DomUtil.create('img', 'leaflet-tile');
-		tile.style.width = tile.style.height = this._getTileSize() + 'px';
-		tile.galleryimg = 'no';
+  _createTile: function () {
+    var tile = L.DomUtil.create('img', 'leaflet-tile');
+    tile.style.width = tile.style.height = this._getTileSize() + 'px';
+    tile.galleryimg = 'no';
 
-		tile.onselectstart = tile.onmousemove = L.Util.falseFn;
+    tile.onselectstart = tile.onmousemove = L.Util.falseFn;
 
-		if (L.Browser.ielt9 && this.options.opacity !== undefined) {
-			L.DomUtil.setOpacity(tile, this.options.opacity);
-		}
-		// without this hack, tiles disappear after zoom on Chrome for Android
-		// https://github.com/Leaflet/Leaflet/issues/2078
-		if (L.Browser.mobileWebkit3d) {
-			tile.style.WebkitBackfaceVisibility = 'hidden';
-		}
-		return tile;
-	},
+    if (L.Browser.ielt9 && this.options.opacity !== undefined) {
+      L.DomUtil.setOpacity(tile, this.options.opacity);
+    }
+    // without this hack, tiles disappear after zoom on Chrome for Android
+    // https://github.com/Leaflet/Leaflet/issues/2078
+    if (L.Browser.mobileWebkit3d) {
+      tile.style.WebkitBackfaceVisibility = 'hidden';
+    }
+    return tile;
+  },
 
-	_loadTile: function (tile, tilePoint) {
-		tile._layer  = this;
-		tile.onload  = this._tileOnLoad;
-		tile.onerror = this._tileOnError;
+  _loadTile: function (tile, tilePoint) {
+    tile._layer  = this;
+    tile.onload  = this._tileOnLoad;
+    tile.onerror = this._tileOnError;
 
-		this._adjustTilePoint(tilePoint);
-		tile.src     = this.getTileUrl(tilePoint);
+    this._adjustTilePoint(tilePoint);
+    tile.src     = this.getTileUrl(tilePoint);
 
-		this.fire('tileloadstart', {
-			tile: tile,
-			url: tile.src
-		});
-	},
+    this.fire('tileloadstart', {
+      tile: tile,
+      url: tile.src
+    });
+  },
 
-	_tileLoaded: function () {
-		this._tilesToLoad--;
+  _tileLoaded: function () {
+    this._tilesToLoad--;
 
-		if (this._animated) {
-			L.DomUtil.addClass(this._tileContainer, 'leaflet-zoom-animated');
-		}
+    if (this._animated) {
+      L.DomUtil.addClass(this._tileContainer, 'leaflet-zoom-animated');
+    }
 
-		if (!this._tilesToLoad) {
-			this.fire('load');
+    if (!this._tilesToLoad) {
+      this.fire('load');
 
-			if (this._animated) {
-				// clear scaled tiles after all new tiles are loaded (for performance)
-				clearTimeout(this._clearBgBufferTimer);
-				this._clearBgBufferTimer = setTimeout(L.bind(this._clearBgBuffer, this), 500);
-			}
-		}
-	},
+      if (this._animated) {
+        // clear scaled tiles after all new tiles are loaded (for performance)
+        clearTimeout(this._clearBgBufferTimer);
+        this._clearBgBufferTimer = setTimeout(L.bind(this._clearBgBuffer, this), 500);
+      }
+    }
+  },
 
-	_tileOnLoad: function () {
-		var layer = this._layer;
+  _tileOnLoad: function () {
+    var layer = this._layer;
 
-		//Only if we are loading an actual image
-		if (this.src !== L.Util.emptyImageUrl) {
-			L.DomUtil.addClass(this, 'leaflet-tile-loaded');
+    //Only if we are loading an actual image
+    if (this.src !== L.Util.emptyImageUrl) {
+      L.DomUtil.addClass(this, 'leaflet-tile-loaded');
 
-			layer.fire('tileload', {
-				tile: this,
-				url: this.src
-			});
-		}
+      layer.fire('tileload', {
+        tile: this,
+        url: this.src
+      });
+    }
 
-		layer._tileLoaded();
-	},
+    layer._tileLoaded();
+  },
 
-	_tileOnError: function () {
-		var layer = this._layer;
+  _tileOnError: function () {
+    var layer = this._layer;
 
-		layer.fire('tileerror', {
-			tile: this,
-			url: this.src
-		});
+    layer.fire('tileerror', {
+      tile: this,
+      url: this.src
+    });
 
-		var newUrl = layer.options.errorTileUrl;
-		if (newUrl) {
-			this.src = newUrl;
-		}
+    var newUrl = layer.options.errorTileUrl;
+    if (newUrl) {
+      this.src = newUrl;
+    }
 
-		layer._tileLoaded();
-	}
+    layer._tileLoaded();
+  }
 });
 
 L.tileLayer = function (url, options) {
-	return new L.TileLayer(url, options);
+  return new L.TileLayer(url, options);
 };
 
 
@@ -11465,60 +11465,60 @@ L.tileLayer = function (url, options) {
  */
 
 L.TileLayer.Canvas = L.TileLayer.extend({
-	options: {
-		async: false
-	},
+  options: {
+    async: false
+  },
 
-	initialize: function (options) {
-		L.setOptions(this, options);
-	},
+  initialize: function (options) {
+    L.setOptions(this, options);
+  },
 
-	redraw: function () {
-		if (this._map) {
-			this._reset({hard: true});
-			this._update();
-		}
+  redraw: function () {
+    if (this._map) {
+      this._reset({hard: true});
+      this._update();
+    }
 
-		for (var i in this._tiles) {
-			this._redrawTile(this._tiles[i]);
-		}
-		return this;
-	},
+    for (var i in this._tiles) {
+      this._redrawTile(this._tiles[i]);
+    }
+    return this;
+  },
 
-	_redrawTile: function (tile) {
-		this.drawTile(tile, tile._tilePoint, this._map._zoom);
-	},
+  _redrawTile: function (tile) {
+    this.drawTile(tile, tile._tilePoint, this._map._zoom);
+  },
 
-	_createTile: function () {
-		var tile = L.DomUtil.create('canvas', 'leaflet-tile');
-		tile.width = tile.height = this.options.tileSize;
-		tile.onselectstart = tile.onmousemove = L.Util.falseFn;
-		return tile;
-	},
+  _createTile: function () {
+    var tile = L.DomUtil.create('canvas', 'leaflet-tile');
+    tile.width = tile.height = this.options.tileSize;
+    tile.onselectstart = tile.onmousemove = L.Util.falseFn;
+    return tile;
+  },
 
-	_loadTile: function (tile, tilePoint) {
-		tile._layer = this;
-		tile._tilePoint = tilePoint;
+  _loadTile: function (tile, tilePoint) {
+    tile._layer = this;
+    tile._tilePoint = tilePoint;
 
-		this._redrawTile(tile);
+    this._redrawTile(tile);
 
-		if (!this.options.async) {
-			this.tileDrawn(tile);
-		}
-	},
+    if (!this.options.async) {
+      this.tileDrawn(tile);
+    }
+  },
 
-	drawTile: function (/*tile, tilePoint*/) {
-		// override with rendering code
-	},
+  drawTile: function (/*tile, tilePoint*/) {
+    // override with rendering code
+  },
 
-	tileDrawn: function (tile) {
-		this._tileOnLoad.call(tile);
-	}
+  tileDrawn: function (tile) {
+    this._tileOnLoad.call(tile);
+  }
 });
 
 
 L.tileLayer.canvas = function (options) {
-	return new L.TileLayer.Canvas(options);
+  return new L.TileLayer.Canvas(options);
 };
 
 
@@ -11531,141 +11531,141 @@ L.tileLayer.canvas = function (options) {
  */
 
 L.ImageOverlay = L.Class.extend({
-	includes: L.Mixin.Events,
+  includes: L.Mixin.Events,
 
-	options: {
-		opacity: 1
-	},
+  options: {
+    opacity: 1
+  },
 
-	initialize: function (url, bounds, options) { // (String, LatLngBounds, Object)
-		this._url = url;
-		this._bounds = L.latLngBounds(bounds);
+  initialize: function (url, bounds, options) { // (String, LatLngBounds, Object)
+    this._url = url;
+    this._bounds = L.latLngBounds(bounds);
 
-		L.setOptions(this, options);
-	},
+    L.setOptions(this, options);
+  },
 
-	onAdd: function (map) {
-		this._map = map;
+  onAdd: function (map) {
+    this._map = map;
 
-		if (!this._image) {
-			this._initImage();
-		}
+    if (!this._image) {
+      this._initImage();
+    }
 
-		map._panes.overlayPane.appendChild(this._image);
+    map._panes.overlayPane.appendChild(this._image);
 
-		map.on('viewreset', this._reset, this);
+    map.on('viewreset', this._reset, this);
 
-		if (map.options.zoomAnimation && L.Browser.any3d) {
-			map.on('zoomanim', this._animateZoom, this);
-		}
+    if (map.options.zoomAnimation && L.Browser.any3d) {
+      map.on('zoomanim', this._animateZoom, this);
+    }
 
-		this._reset();
-	},
+    this._reset();
+  },
 
-	onRemove: function (map) {
-		map.getPanes().overlayPane.removeChild(this._image);
+  onRemove: function (map) {
+    map.getPanes().overlayPane.removeChild(this._image);
 
-		map.off('viewreset', this._reset, this);
+    map.off('viewreset', this._reset, this);
 
-		if (map.options.zoomAnimation) {
-			map.off('zoomanim', this._animateZoom, this);
-		}
-	},
+    if (map.options.zoomAnimation) {
+      map.off('zoomanim', this._animateZoom, this);
+    }
+  },
 
-	addTo: function (map) {
-		map.addLayer(this);
-		return this;
-	},
+  addTo: function (map) {
+    map.addLayer(this);
+    return this;
+  },
 
-	setOpacity: function (opacity) {
-		this.options.opacity = opacity;
-		this._updateOpacity();
-		return this;
-	},
+  setOpacity: function (opacity) {
+    this.options.opacity = opacity;
+    this._updateOpacity();
+    return this;
+  },
 
-	// TODO remove bringToFront/bringToBack duplication from TileLayer/Path
-	bringToFront: function () {
-		if (this._image) {
-			this._map._panes.overlayPane.appendChild(this._image);
-		}
-		return this;
-	},
+  // TODO remove bringToFront/bringToBack duplication from TileLayer/Path
+  bringToFront: function () {
+    if (this._image) {
+      this._map._panes.overlayPane.appendChild(this._image);
+    }
+    return this;
+  },
 
-	bringToBack: function () {
-		var pane = this._map._panes.overlayPane;
-		if (this._image) {
-			pane.insertBefore(this._image, pane.firstChild);
-		}
-		return this;
-	},
+  bringToBack: function () {
+    var pane = this._map._panes.overlayPane;
+    if (this._image) {
+      pane.insertBefore(this._image, pane.firstChild);
+    }
+    return this;
+  },
 
-	setUrl: function (url) {
-		this._url = url;
-		this._image.src = this._url;
-	},
+  setUrl: function (url) {
+    this._url = url;
+    this._image.src = this._url;
+  },
 
-	getAttribution: function () {
-		return this.options.attribution;
-	},
+  getAttribution: function () {
+    return this.options.attribution;
+  },
 
-	_initImage: function () {
-		this._image = L.DomUtil.create('img', 'leaflet-image-layer');
+  _initImage: function () {
+    this._image = L.DomUtil.create('img', 'leaflet-image-layer');
 
-		if (this._map.options.zoomAnimation && L.Browser.any3d) {
-			L.DomUtil.addClass(this._image, 'leaflet-zoom-animated');
-		} else {
-			L.DomUtil.addClass(this._image, 'leaflet-zoom-hide');
-		}
+    if (this._map.options.zoomAnimation && L.Browser.any3d) {
+      L.DomUtil.addClass(this._image, 'leaflet-zoom-animated');
+    } else {
+      L.DomUtil.addClass(this._image, 'leaflet-zoom-hide');
+    }
 
-		this._updateOpacity();
+    this._updateOpacity();
 
-		//TODO createImage util method to remove duplication
-		L.extend(this._image, {
-			galleryimg: 'no',
-			onselectstart: L.Util.falseFn,
-			onmousemove: L.Util.falseFn,
-			onload: L.bind(this._onImageLoad, this),
-			src: this._url
-		});
-	},
+    //TODO createImage util method to remove duplication
+    L.extend(this._image, {
+      galleryimg: 'no',
+      onselectstart: L.Util.falseFn,
+      onmousemove: L.Util.falseFn,
+      onload: L.bind(this._onImageLoad, this),
+      src: this._url
+    });
+  },
 
-	_animateZoom: function (e) {
-		var map = this._map,
-		    image = this._image,
-		    scale = map.getZoomScale(e.zoom),
-		    nw = this._bounds.getNorthWest(),
-		    se = this._bounds.getSouthEast(),
+  _animateZoom: function (e) {
+    var map = this._map,
+        image = this._image,
+        scale = map.getZoomScale(e.zoom),
+        nw = this._bounds.getNorthWest(),
+        se = this._bounds.getSouthEast(),
 
-		    topLeft = map._latLngToNewLayerPoint(nw, e.zoom, e.center),
-		    size = map._latLngToNewLayerPoint(se, e.zoom, e.center)._subtract(topLeft),
-		    origin = topLeft._add(size._multiplyBy((1 / 2) * (1 - 1 / scale)));
+        topLeft = map._latLngToNewLayerPoint(nw, e.zoom, e.center),
+        size = map._latLngToNewLayerPoint(se, e.zoom, e.center)._subtract(topLeft),
+        origin = topLeft._add(size._multiplyBy((1 / 2) * (1 - 1 / scale)));
 
-		image.style[L.DomUtil.TRANSFORM] =
-		        L.DomUtil.getTranslateString(origin) + ' scale(' + scale + ') ';
-	},
+    image.style[L.DomUtil.TRANSFORM] =
+            L.DomUtil.getTranslateString(origin) + ' scale(' + scale + ') ';
+  },
 
-	_reset: function () {
-		var image   = this._image,
-		    topLeft = this._map.latLngToLayerPoint(this._bounds.getNorthWest()),
-		    size = this._map.latLngToLayerPoint(this._bounds.getSouthEast())._subtract(topLeft);
+  _reset: function () {
+    var image   = this._image,
+        topLeft = this._map.latLngToLayerPoint(this._bounds.getNorthWest()),
+        size = this._map.latLngToLayerPoint(this._bounds.getSouthEast())._subtract(topLeft);
 
-		L.DomUtil.setPosition(image, topLeft);
+    L.DomUtil.setPosition(image, topLeft);
 
-		image.style.width  = size.x + 'px';
-		image.style.height = size.y + 'px';
-	},
+    image.style.width  = size.x + 'px';
+    image.style.height = size.y + 'px';
+  },
 
-	_onImageLoad: function () {
-		this.fire('load');
-	},
+  _onImageLoad: function () {
+    this.fire('load');
+  },
 
-	_updateOpacity: function () {
-		L.DomUtil.setOpacity(this._image, this.options.opacity);
-	}
+  _updateOpacity: function () {
+    L.DomUtil.setOpacity(this._image, this.options.opacity);
+  }
 });
 
 L.imageOverlay = function (url, bounds, options) {
-	return new L.ImageOverlay(url, bounds, options);
+  return new L.ImageOverlay(url, bounds, options);
 };
 
 
@@ -11678,98 +11678,98 @@ L.imageOverlay = function (url, bounds, options) {
  */
 
 L.Icon = L.Class.extend({
-	options: {
-		/*
-		iconUrl: (String) (required)
-		iconRetinaUrl: (String) (optional, used for retina devices if detected)
-		iconSize: (Point) (can be set through CSS)
-		iconAnchor: (Point) (centered by default, can be set in CSS with negative margins)
-		popupAnchor: (Point) (if not specified, popup opens in the anchor point)
-		shadowUrl: (String) (no shadow by default)
-		shadowRetinaUrl: (String) (optional, used for retina devices if detected)
-		shadowSize: (Point)
-		shadowAnchor: (Point)
-		*/
-		className: ''
-	},
+  options: {
+    /*
+    iconUrl: (String) (required)
+    iconRetinaUrl: (String) (optional, used for retina devices if detected)
+    iconSize: (Point) (can be set through CSS)
+    iconAnchor: (Point) (centered by default, can be set in CSS with negative margins)
+    popupAnchor: (Point) (if not specified, popup opens in the anchor point)
+    shadowUrl: (String) (no shadow by default)
+    shadowRetinaUrl: (String) (optional, used for retina devices if detected)
+    shadowSize: (Point)
+    shadowAnchor: (Point)
+    */
+    className: ''
+  },
 
-	initialize: function (options) {
-		L.setOptions(this, options);
-	},
+  initialize: function (options) {
+    L.setOptions(this, options);
+  },
 
-	createIcon: function (oldIcon) {
-		return this._createIcon('icon', oldIcon);
-	},
+  createIcon: function (oldIcon) {
+    return this._createIcon('icon', oldIcon);
+  },
 
-	createShadow: function (oldIcon) {
-		return this._createIcon('shadow', oldIcon);
-	},
+  createShadow: function (oldIcon) {
+    return this._createIcon('shadow', oldIcon);
+  },
 
-	_createIcon: function (name, oldIcon) {
-		var src = this._getIconUrl(name);
+  _createIcon: function (name, oldIcon) {
+    var src = this._getIconUrl(name);
 
-		if (!src) {
-			if (name === 'icon') {
-				throw new Error('iconUrl not set in Icon options (see the docs).');
-			}
-			return null;
-		}
+    if (!src) {
+      if (name === 'icon') {
+        throw new Error('iconUrl not set in Icon options (see the docs).');
+      }
+      return null;
+    }
 
-		var img;
-		if (!oldIcon || oldIcon.tagName !== 'IMG') {
-			img = this._createImg(src);
-		} else {
-			img = this._createImg(src, oldIcon);
-		}
-		this._setIconStyles(img, name);
+    var img;
+    if (!oldIcon || oldIcon.tagName !== 'IMG') {
+      img = this._createImg(src);
+    } else {
+      img = this._createImg(src, oldIcon);
+    }
+    this._setIconStyles(img, name);
 
-		return img;
-	},
+    return img;
+  },
 
-	_setIconStyles: function (img, name) {
-		var options = this.options,
-		    size = L.point(options[name + 'Size']),
-		    anchor;
+  _setIconStyles: function (img, name) {
+    var options = this.options,
+        size = L.point(options[name + 'Size']),
+        anchor;
 
-		if (name === 'shadow') {
-			anchor = L.point(options.shadowAnchor || options.iconAnchor);
-		} else {
-			anchor = L.point(options.iconAnchor);
-		}
+    if (name === 'shadow') {
+      anchor = L.point(options.shadowAnchor || options.iconAnchor);
+    } else {
+      anchor = L.point(options.iconAnchor);
+    }
 
-		if (!anchor && size) {
-			anchor = size.divideBy(2, true);
-		}
+    if (!anchor && size) {
+      anchor = size.divideBy(2, true);
+    }
 
-		img.className = 'leaflet-marker-' + name + ' ' + options.className;
+    img.className = 'leaflet-marker-' + name + ' ' + options.className;
 
-		if (anchor) {
-			img.style.marginLeft = (-anchor.x) + 'px';
-			img.style.marginTop  = (-anchor.y) + 'px';
-		}
+    if (anchor) {
+      img.style.marginLeft = (-anchor.x) + 'px';
+      img.style.marginTop  = (-anchor.y) + 'px';
+    }
 
-		if (size) {
-			img.style.width  = size.x + 'px';
-			img.style.height = size.y + 'px';
-		}
-	},
+    if (size) {
+      img.style.width  = size.x + 'px';
+      img.style.height = size.y + 'px';
+    }
+  },
 
-	_createImg: function (src, el) {
-		el = el || document.createElement('img');
-		el.src = src;
-		return el;
-	},
+  _createImg: function (src, el) {
+    el = el || document.createElement('img');
+    el.src = src;
+    return el;
+  },
 
-	_getIconUrl: function (name) {
-		if (L.Browser.retina && this.options[name + 'RetinaUrl']) {
-			return this.options[name + 'RetinaUrl'];
-		}
-		return this.options[name + 'Url'];
-	}
+  _getIconUrl: function (name) {
+    if (L.Browser.retina && this.options[name + 'RetinaUrl']) {
+      return this.options[name + 'RetinaUrl'];
+    }
+    return this.options[name + 'Url'];
+  }
 });
 
 L.icon = function (options) {
-	return new L.Icon(options);
+  return new L.Icon(options);
 };
 
 
@@ -11783,50 +11783,50 @@ L.icon = function (options) {
 
 L.Icon.Default = L.Icon.extend({
 
-	options: {
-		iconSize: [25, 41],
-		iconAnchor: [12, 41],
-		popupAnchor: [1, -34],
+  options: {
+    iconSize: [25, 41],
+    iconAnchor: [12, 41],
+    popupAnchor: [1, -34],
 
-		shadowSize: [41, 41]
-	},
+    shadowSize: [41, 41]
+  },
 
-	_getIconUrl: function (name) {
-		var key = name + 'Url';
+  _getIconUrl: function (name) {
+    var key = name + 'Url';
 
-		if (this.options[key]) {
-			return this.options[key];
-		}
+    if (this.options[key]) {
+      return this.options[key];
+    }
 
-		if (L.Browser.retina && name === 'icon') {
-			name += '-2x';
-		}
+    if (L.Browser.retina && name === 'icon') {
+      name += '-2x';
+    }
 
-		var path = L.Icon.Default.imagePath;
+    var path = L.Icon.Default.imagePath;
 
-		if (!path) {
-			throw new Error('Couldn\'t autodetect L.Icon.Default.imagePath, set it manually.');
-		}
+    if (!path) {
+      throw new Error('Couldn\'t autodetect L.Icon.Default.imagePath, set it manually.');
+    }
 
-		return path + '/marker-' + name + '.png';
-	}
+    return path + '/marker-' + name + '.png';
+  }
 });
 
 L.Icon.Default.imagePath = (function () {
-	var scripts = document.getElementsByTagName('script'),
-	    leafletRe = /[\/^]leaflet[\-\._]?([\w\-\._]*)\.js\??/;
+  var scripts = document.getElementsByTagName('script'),
+      leafletRe = /[\/^]leaflet[\-\._]?([\w\-\._]*)\.js\??/;
 
-	var i, len, src, matches, path;
+  var i, len, src, matches, path;
 
-	for (i = 0, len = scripts.length; i < len; i++) {
-		src = scripts[i].src;
-		matches = src.match(leafletRe);
+  for (i = 0, len = scripts.length; i < len; i++) {
+    src = scripts[i].src;
+    matches = src.match(leafletRe);
 
-		if (matches) {
-			path = src.split(leafletRe)[0];
-			return (path ? path + '/' : '') + 'images';
-		}
-	}
+    if (matches) {
+      path = src.split(leafletRe)[0];
+      return (path ? path + '/' : '') + 'images';
+    }
+  }
 }());
 
 
@@ -11840,317 +11840,317 @@ L.Icon.Default.imagePath = (function () {
 
 L.Marker = L.Class.extend({
 
-	includes: L.Mixin.Events,
+  includes: L.Mixin.Events,
 
-	options: {
-		icon: new L.Icon.Default(),
-		title: '',
-		alt: '',
-		clickable: true,
-		draggable: false,
-		keyboard: true,
-		zIndexOffset: 0,
-		opacity: 1,
-		riseOnHover: false,
-		riseOffset: 250
-	},
-
-	initialize: function (latlng, options) {
-		L.setOptions(this, options);
-		this._latlng = L.latLng(latlng);
-	},
-
-	onAdd: function (map) {
-		this._map = map;
-
-		map.on('viewreset', this.update, this);
-
-		this._initIcon();
-		this.update();
-		this.fire('add');
-
-		if (map.options.zoomAnimation && map.options.markerZoomAnimation) {
-			map.on('zoomanim', this._animateZoom, this);
-		}
-	},
-
-	addTo: function (map) {
-		map.addLayer(this);
-		return this;
-	},
-
-	onRemove: function (map) {
-		if (this.dragging) {
-			this.dragging.disable();
-		}
-
-		this._removeIcon();
-		this._removeShadow();
-
-		this.fire('remove');
-
-		map.off({
-			'viewreset': this.update,
-			'zoomanim': this._animateZoom
-		}, this);
-
-		this._map = null;
-	},
+  options: {
+    icon: new L.Icon.Default(),
+    title: '',
+    alt: '',
+    clickable: true,
+    draggable: false,
+    keyboard: true,
+    zIndexOffset: 0,
+    opacity: 1,
+    riseOnHover: false,
+    riseOffset: 250
+  },
+
+  initialize: function (latlng, options) {
+    L.setOptions(this, options);
+    this._latlng = L.latLng(latlng);
+  },
+
+  onAdd: function (map) {
+    this._map = map;
+
+    map.on('viewreset', this.update, this);
+
+    this._initIcon();
+    this.update();
+    this.fire('add');
 
-	getLatLng: function () {
-		return this._latlng;
-	},
+    if (map.options.zoomAnimation && map.options.markerZoomAnimation) {
+      map.on('zoomanim', this._animateZoom, this);
+    }
+  },
+
+  addTo: function (map) {
+    map.addLayer(this);
+    return this;
+  },
 
-	setLatLng: function (latlng) {
-		this._latlng = L.latLng(latlng);
+  onRemove: function (map) {
+    if (this.dragging) {
+      this.dragging.disable();
+    }
 
-		this.update();
+    this._removeIcon();
+    this._removeShadow();
 
-		return this.fire('move', { latlng: this._latlng });
-	},
+    this.fire('remove');
 
-	setZIndexOffset: function (offset) {
-		this.options.zIndexOffset = offset;
-		this.update();
+    map.off({
+      'viewreset': this.update,
+      'zoomanim': this._animateZoom
+    }, this);
+
+    this._map = null;
+  },
 
-		return this;
-	},
+  getLatLng: function () {
+    return this._latlng;
+  },
 
-	setIcon: function (icon) {
-
-		this.options.icon = icon;
+  setLatLng: function (latlng) {
+    this._latlng = L.latLng(latlng);
 
-		if (this._map) {
-			this._initIcon();
-			this.update();
-		}
+    this.update();
 
-		if (this._popup) {
-			this.bindPopup(this._popup);
-		}
+    return this.fire('move', { latlng: this._latlng });
+  },
 
-		return this;
-	},
+  setZIndexOffset: function (offset) {
+    this.options.zIndexOffset = offset;
+    this.update();
 
-	update: function () {
-		if (this._icon) {
-			var pos = this._map.latLngToLayerPoint(this._latlng).round();
-			this._setPos(pos);
-		}
-
-		return this;
-	},
+    return this;
+  },
 
-	_initIcon: function () {
-		var options = this.options,
-		    map = this._map,
-		    animation = (map.options.zoomAnimation && map.options.markerZoomAnimation),
-		    classToAdd = animation ? 'leaflet-zoom-animated' : 'leaflet-zoom-hide';
+  setIcon: function (icon) {
 
-		var icon = options.icon.createIcon(this._icon),
-			addIcon = false;
+    this.options.icon = icon;
 
-		// if we're not reusing the icon, remove the old one and init new one
-		if (icon !== this._icon) {
-			if (this._icon) {
-				this._removeIcon();
-			}
-			addIcon = true;
+    if (this._map) {
+      this._initIcon();
+      this.update();
+    }
 
-			if (options.title) {
-				icon.title = options.title;
-			}
-			
-			if (options.alt) {
-				icon.alt = options.alt;
-			}
-		}
+    if (this._popup) {
+      this.bindPopup(this._popup);
+    }
 
-		L.DomUtil.addClass(icon, classToAdd);
+    return this;
+  },
 
-		if (options.keyboard) {
-			icon.tabIndex = '0';
-		}
+  update: function () {
+    if (this._icon) {
+      var pos = this._map.latLngToLayerPoint(this._latlng).round();
+      this._setPos(pos);
+    }
 
-		this._icon = icon;
+    return this;
+  },
 
-		this._initInteraction();
+  _initIcon: function () {
+    var options = this.options,
+        map = this._map,
+        animation = (map.options.zoomAnimation && map.options.markerZoomAnimation),
+        classToAdd = animation ? 'leaflet-zoom-animated' : 'leaflet-zoom-hide';
 
-		if (options.riseOnHover) {
-			L.DomEvent
-				.on(icon, 'mouseover', this._bringToFront, this)
-				.on(icon, 'mouseout', this._resetZIndex, this);
-		}
+    var icon = options.icon.createIcon(this._icon),
+      addIcon = false;
 
-		var newShadow = options.icon.createShadow(this._shadow),
-			addShadow = false;
+    // if we're not reusing the icon, remove the old one and init new one
+    if (icon !== this._icon) {
+      if (this._icon) {
+        this._removeIcon();
+      }
+      addIcon = true;
 
-		if (newShadow !== this._shadow) {
-			this._removeShadow();
-			addShadow = true;
-		}
+      if (options.title) {
+        icon.title = options.title;
+      }
 
-		if (newShadow) {
-			L.DomUtil.addClass(newShadow, classToAdd);
-		}
-		this._shadow = newShadow;
+      if (options.alt) {
+        icon.alt = options.alt;
+      }
+    }
 
+    L.DomUtil.addClass(icon, classToAdd);
 
-		if (options.opacity < 1) {
-			this._updateOpacity();
-		}
+    if (options.keyboard) {
+      icon.tabIndex = '0';
+    }
 
+    this._icon = icon;
 
-		var panes = this._map._panes;
+    this._initInteraction();
 
-		if (addIcon) {
-			panes.markerPane.appendChild(this._icon);
-		}
+    if (options.riseOnHover) {
+      L.DomEvent
+        .on(icon, 'mouseover', this._bringToFront, this)
+        .on(icon, 'mouseout', this._resetZIndex, this);
+    }
 
-		if (newShadow && addShadow) {
-			panes.shadowPane.appendChild(this._shadow);
-		}
-	},
+    var newShadow = options.icon.createShadow(this._shadow),
+      addShadow = false;
 
-	_removeIcon: function () {
-		if (this.options.riseOnHover) {
-			L.DomEvent
-			    .off(this._icon, 'mouseover', this._bringToFront)
-			    .off(this._icon, 'mouseout', this._resetZIndex);
-		}
+    if (newShadow !== this._shadow) {
+      this._removeShadow();
+      addShadow = true;
+    }
 
-		this._map._panes.markerPane.removeChild(this._icon);
+    if (newShadow) {
+      L.DomUtil.addClass(newShadow, classToAdd);
+    }
+    this._shadow = newShadow;
 
-		this._icon = null;
-	},
 
-	_removeShadow: function () {
-		if (this._shadow) {
-			this._map._panes.shadowPane.removeChild(this._shadow);
-		}
-		this._shadow = null;
-	},
+    if (options.opacity < 1) {
+      this._updateOpacity();
+    }
 
-	_setPos: function (pos) {
-		L.DomUtil.setPosition(this._icon, pos);
 
-		if (this._shadow) {
-			L.DomUtil.setPosition(this._shadow, pos);
-		}
-
-		this._zIndex = pos.y + this.options.zIndexOffset;
-
-		this._resetZIndex();
-	},
-
-	_updateZIndex: function (offset) {
-		this._icon.style.zIndex = this._zIndex + offset;
-	},
-
-	_animateZoom: function (opt) {
-		var pos = this._map._latLngToNewLayerPoint(this._latlng, opt.zoom, opt.center).round();
-
-		this._setPos(pos);
-	},
-
-	_initInteraction: function () {
-
-		if (!this.options.clickable) { return; }
-
-		// TODO refactor into something shared with Map/Path/etc. to DRY it up
-
-		var icon = this._icon,
-		    events = ['dblclick', 'mousedown', 'mouseover', 'mouseout', 'contextmenu'];
-
-		L.DomUtil.addClass(icon, 'leaflet-clickable');
-		L.DomEvent.on(icon, 'click', this._onMouseClick, this);
-		L.DomEvent.on(icon, 'keypress', this._onKeyPress, this);
-
-		for (var i = 0; i < events.length; i++) {
-			L.DomEvent.on(icon, events[i], this._fireMouseEvent, this);
-		}
-
-		if (L.Handler.MarkerDrag) {
-			this.dragging = new L.Handler.MarkerDrag(this);
-
-			if (this.options.draggable) {
-				this.dragging.enable();
-			}
-		}
-	},
-
-	_onMouseClick: function (e) {
-		var wasDragged = this.dragging && this.dragging.moved();
-
-		if (this.hasEventListeners(e.type) || wasDragged) {
-			L.DomEvent.stopPropagation(e);
-		}
-
-		if (wasDragged) { return; }
-
-		if ((!this.dragging || !this.dragging._enabled) && this._map.dragging && this._map.dragging.moved()) { return; }
-
-		this.fire(e.type, {
-			originalEvent: e,
-			latlng: this._latlng
-		});
-	},
-
-	_onKeyPress: function (e) {
-		if (e.keyCode === 13) {
-			this.fire('click', {
-				originalEvent: e,
-				latlng: this._latlng
-			});
-		}
-	},
-
-	_fireMouseEvent: function (e) {
-
-		this.fire(e.type, {
-			originalEvent: e,
-			latlng: this._latlng
-		});
-
-		// TODO proper custom event propagation
-		// this line will always be called if marker is in a FeatureGroup
-		if (e.type === 'contextmenu' && this.hasEventListeners(e.type)) {
-			L.DomEvent.preventDefault(e);
-		}
-		if (e.type !== 'mousedown') {
-			L.DomEvent.stopPropagation(e);
-		} else {
-			L.DomEvent.preventDefault(e);
-		}
-	},
-
-	setOpacity: function (opacity) {
-		this.options.opacity = opacity;
-		if (this._map) {
-			this._updateOpacity();
-		}
-
-		return this;
-	},
-
-	_updateOpacity: function () {
-		L.DomUtil.setOpacity(this._icon, this.options.opacity);
-		if (this._shadow) {
-			L.DomUtil.setOpacity(this._shadow, this.options.opacity);
-		}
-	},
-
-	_bringToFront: function () {
-		this._updateZIndex(this.options.riseOffset);
-	},
-
-	_resetZIndex: function () {
-		this._updateZIndex(0);
-	}
+    var panes = this._map._panes;
+
+    if (addIcon) {
+      panes.markerPane.appendChild(this._icon);
+    }
+
+    if (newShadow && addShadow) {
+      panes.shadowPane.appendChild(this._shadow);
+    }
+  },
+
+  _removeIcon: function () {
+    if (this.options.riseOnHover) {
+      L.DomEvent
+          .off(this._icon, 'mouseover', this._bringToFront)
+          .off(this._icon, 'mouseout', this._resetZIndex);
+    }
+
+    this._map._panes.markerPane.removeChild(this._icon);
+
+    this._icon = null;
+  },
+
+  _removeShadow: function () {
+    if (this._shadow) {
+      this._map._panes.shadowPane.removeChild(this._shadow);
+    }
+    this._shadow = null;
+  },
+
+  _setPos: function (pos) {
+    L.DomUtil.setPosition(this._icon, pos);
+
+    if (this._shadow) {
+      L.DomUtil.setPosition(this._shadow, pos);
+    }
+
+    this._zIndex = pos.y + this.options.zIndexOffset;
+
+    this._resetZIndex();
+  },
+
+  _updateZIndex: function (offset) {
+    this._icon.style.zIndex = this._zIndex + offset;
+  },
+
+  _animateZoom: function (opt) {
+    var pos = this._map._latLngToNewLayerPoint(this._latlng, opt.zoom, opt.center).round();
+
+    this._setPos(pos);
+  },
+
+  _initInteraction: function () {
+
+    if (!this.options.clickable) { return; }
+
+    // TODO refactor into something shared with Map/Path/etc. to DRY it up
+
+    var icon = this._icon,
+        events = ['dblclick', 'mousedown', 'mouseover', 'mouseout', 'contextmenu'];
+
+    L.DomUtil.addClass(icon, 'leaflet-clickable');
+    L.DomEvent.on(icon, 'click', this._onMouseClick, this);
+    L.DomEvent.on(icon, 'keypress', this._onKeyPress, this);
+
+    for (var i = 0; i < events.length; i++) {
+      L.DomEvent.on(icon, events[i], this._fireMouseEvent, this);
+    }
+
+    if (L.Handler.MarkerDrag) {
+      this.dragging = new L.Handler.MarkerDrag(this);
+
+      if (this.options.draggable) {
+        this.dragging.enable();
+      }
+    }
+  },
+
+  _onMouseClick: function (e) {
+    var wasDragged = this.dragging && this.dragging.moved();
+
+    if (this.hasEventListeners(e.type) || wasDragged) {
+      L.DomEvent.stopPropagation(e);
+    }
+
+    if (wasDragged) { return; }
+
+    if ((!this.dragging || !this.dragging._enabled) && this._map.dragging && this._map.dragging.moved()) { return; }
+
+    this.fire(e.type, {
+      originalEvent: e,
+      latlng: this._latlng
+    });
+  },
+
+  _onKeyPress: function (e) {
+    if (e.keyCode === 13) {
+      this.fire('click', {
+        originalEvent: e,
+        latlng: this._latlng
+      });
+    }
+  },
+
+  _fireMouseEvent: function (e) {
+
+    this.fire(e.type, {
+      originalEvent: e,
+      latlng: this._latlng
+    });
+
+    // TODO proper custom event propagation
+    // this line will always be called if marker is in a FeatureGroup
+    if (e.type === 'contextmenu' && this.hasEventListeners(e.type)) {
+      L.DomEvent.preventDefault(e);
+    }
+    if (e.type !== 'mousedown') {
+      L.DomEvent.stopPropagation(e);
+    } else {
+      L.DomEvent.preventDefault(e);
+    }
+  },
+
+  setOpacity: function (opacity) {
+    this.options.opacity = opacity;
+    if (this._map) {
+      this._updateOpacity();
+    }
+
+    return this;
+  },
+
+  _updateOpacity: function () {
+    L.DomUtil.setOpacity(this._icon, this.options.opacity);
+    if (this._shadow) {
+      L.DomUtil.setOpacity(this._shadow, this.options.opacity);
+    }
+  },
+
+  _bringToFront: function () {
+    this._updateZIndex(this.options.riseOffset);
+  },
+
+  _resetZIndex: function () {
+    this._updateZIndex(0);
+  }
 });
 
 L.marker = function (latlng, options) {
-	return new L.Marker(latlng, options);
+  return new L.Marker(latlng, options);
 };
 
 
@@ -12164,44 +12164,44 @@ L.marker = function (latlng, options) {
  */
 
 L.DivIcon = L.Icon.extend({
-	options: {
-		iconSize: [12, 12], // also can be set through CSS
-		/*
-		iconAnchor: (Point)
-		popupAnchor: (Point)
-		html: (String)
-		bgPos: (Point)
-		*/
-		className: 'leaflet-div-icon',
-		html: false
-	},
+  options: {
+    iconSize: [12, 12], // also can be set through CSS
+    /*
+    iconAnchor: (Point)
+    popupAnchor: (Point)
+    html: (String)
+    bgPos: (Point)
+    */
+    className: 'leaflet-div-icon',
+    html: false
+  },
 
-	createIcon: function (oldIcon) {
-		var div = (oldIcon && oldIcon.tagName === 'DIV') ? oldIcon : document.createElement('div'),
-		    options = this.options;
+  createIcon: function (oldIcon) {
+    var div = (oldIcon && oldIcon.tagName === 'DIV') ? oldIcon : document.createElement('div'),
+        options = this.options;
 
-		if (options.html !== false) {
-			div.innerHTML = options.html;
-		} else {
-			div.innerHTML = '';
-		}
+    if (options.html !== false) {
+      div.innerHTML = options.html;
+    } else {
+      div.innerHTML = '';
+    }
 
-		if (options.bgPos) {
-			div.style.backgroundPosition =
-			        (-options.bgPos.x) + 'px ' + (-options.bgPos.y) + 'px';
-		}
+    if (options.bgPos) {
+      div.style.backgroundPosition =
+              (-options.bgPos.x) + 'px ' + (-options.bgPos.y) + 'px';
+    }
 
-		this._setIconStyles(div, 'icon');
-		return div;
-	},
+    this._setIconStyles(div, 'icon');
+    return div;
+  },
 
-	createShadow: function () {
-		return null;
-	}
+  createShadow: function () {
+    return null;
+  }
 });
 
 L.divIcon = function (options) {
-	return new L.DivIcon(options);
+  return new L.DivIcon(options);
 };
 
 
@@ -12215,114 +12215,114 @@ L.divIcon = function (options) {
  */
 
 L.LayerGroup = L.Class.extend({
-	initialize: function (layers) {
-		this._layers = {};
+  initialize: function (layers) {
+    this._layers = {};
 
-		var i, len;
+    var i, len;
 
-		if (layers) {
-			for (i = 0, len = layers.length; i < len; i++) {
-				this.addLayer(layers[i]);
-			}
-		}
-	},
+    if (layers) {
+      for (i = 0, len = layers.length; i < len; i++) {
+        this.addLayer(layers[i]);
+      }
+    }
+  },
 
-	addLayer: function (layer) {
-		var id = this.getLayerId(layer);
+  addLayer: function (layer) {
+    var id = this.getLayerId(layer);
 
-		this._layers[id] = layer;
+    this._layers[id] = layer;
 
-		if (this._map) {
-			this._map.addLayer(layer);
-		}
+    if (this._map) {
+      this._map.addLayer(layer);
+    }
 
-		return this;
-	},
+    return this;
+  },
 
-	removeLayer: function (layer) {
-		var id = layer in this._layers ? layer : this.getLayerId(layer);
+  removeLayer: function (layer) {
+    var id = layer in this._layers ? layer : this.getLayerId(layer);
 
-		if (this._map && this._layers[id]) {
-			this._map.removeLayer(this._layers[id]);
-		}
+    if (this._map && this._layers[id]) {
+      this._map.removeLayer(this._layers[id]);
+    }
 
-		delete this._layers[id];
+    delete this._layers[id];
 
-		return this;
-	},
+    return this;
+  },
 
-	hasLayer: function (layer) {
-		if (!layer) { return false; }
+  hasLayer: function (layer) {
+    if (!layer) { return false; }
 
-		return (layer in this._layers || this.getLayerId(layer) in this._layers);
-	},
+    return (layer in this._layers || this.getLayerId(layer) in this._layers);
+  },
 
-	clearLayers: function () {
-		this.eachLayer(this.removeLayer, this);
-		return this;
-	},
+  clearLayers: function () {
+    this.eachLayer(this.removeLayer, this);
+    return this;
+  },
 
-	invoke: function (methodName) {
-		var args = Array.prototype.slice.call(arguments, 1),
-		    i, layer;
+  invoke: function (methodName) {
+    var args = Array.prototype.slice.call(arguments, 1),
+        i, layer;
 
-		for (i in this._layers) {
-			layer = this._layers[i];
+    for (i in this._layers) {
+      layer = this._layers[i];
 
-			if (layer[methodName]) {
-				layer[methodName].apply(layer, args);
-			}
-		}
+      if (layer[methodName]) {
+        layer[methodName].apply(layer, args);
+      }
+    }
 
-		return this;
-	},
+    return this;
+  },
 
-	onAdd: function (map) {
-		this._map = map;
-		this.eachLayer(map.addLayer, map);
-	},
+  onAdd: function (map) {
+    this._map = map;
+    this.eachLayer(map.addLayer, map);
+  },
 
-	onRemove: function (map) {
-		this.eachLayer(map.removeLayer, map);
-		this._map = null;
-	},
+  onRemove: function (map) {
+    this.eachLayer(map.removeLayer, map);
+    this._map = null;
+  },
 
-	addTo: function (map) {
-		map.addLayer(this);
-		return this;
-	},
+  addTo: function (map) {
+    map.addLayer(this);
+    return this;
+  },
 
-	eachLayer: function (method, context) {
-		for (var i in this._layers) {
-			method.call(context, this._layers[i]);
-		}
-		return this;
-	},
+  eachLayer: function (method, context) {
+    for (var i in this._layers) {
+      method.call(context, this._layers[i]);
+    }
+    return this;
+  },
 
-	getLayer: function (id) {
-		return this._layers[id];
-	},
+  getLayer: function (id) {
+    return this._layers[id];
+  },
 
-	getLayers: function () {
-		var layers = [];
+  getLayers: function () {
+    var layers = [];
 
-		for (var i in this._layers) {
-			layers.push(this._layers[i]);
-		}
-		return layers;
-	},
+    for (var i in this._layers) {
+      layers.push(this._layers[i]);
+    }
+    return layers;
+  },
 
-	setZIndex: function (zIndex) {
-		return this.invoke('setZIndex', zIndex);
-	},
+  setZIndex: function (zIndex) {
+    return this.invoke('setZIndex', zIndex);
+  },
 
-	getLayerId: function (layer) {
-		return L.stamp(layer);
-	}
+  getLayerId: function (layer) {
+    return L.stamp(layer);
+  }
 });
 
 L.layerGroup = function (layers) {
-	return new L.LayerGroup(layers);
+  return new L.LayerGroup(layers);
 };
 
 
@@ -12336,97 +12336,97 @@ L.layerGroup = function (layers) {
  */
 
 L.FeatureGroup = L.LayerGroup.extend({
-	includes: L.Mixin.Events,
+  includes: L.Mixin.Events,
 
-	statics: {
-		EVENTS: 'click dblclick mouseover mouseout mousemove contextmenu popupopen popupclose'
-	},
+  statics: {
+    EVENTS: 'click dblclick mouseover mouseout mousemove contextmenu popupopen popupclose'
+  },
 
-	addLayer: function (layer) {
-		if (this.hasLayer(layer)) {
-			return this;
-		}
+  addLayer: function (layer) {
+    if (this.hasLayer(layer)) {
+      return this;
+    }
 
-		if ('on' in layer) {
-			layer.on(L.FeatureGroup.EVENTS, this._propagateEvent, this);
-		}
+    if ('on' in layer) {
+      layer.on(L.FeatureGroup.EVENTS, this._propagateEvent, this);
+    }
 
-		L.LayerGroup.prototype.addLayer.call(this, layer);
+    L.LayerGroup.prototype.addLayer.call(this, layer);
 
-		if (this._popupContent && layer.bindPopup) {
-			layer.bindPopup(this._popupContent, this._popupOptions);
-		}
+    if (this._popupContent && layer.bindPopup) {
+      layer.bindPopup(this._popupContent, this._popupOptions);
+    }
 
-		return this.fire('layeradd', {layer: layer});
-	},
+    return this.fire('layeradd', {layer: layer});
+  },
 
-	removeLayer: function (layer) {
-		if (!this.hasLayer(layer)) {
-			return this;
-		}
-		if (layer in this._layers) {
-			layer = this._layers[layer];
-		}
+  removeLayer: function (layer) {
+    if (!this.hasLayer(layer)) {
+      return this;
+    }
+    if (layer in this._layers) {
+      layer = this._layers[layer];
+    }
 
-		layer.off(L.FeatureGroup.EVENTS, this._propagateEvent, this);
+    layer.off(L.FeatureGroup.EVENTS, this._propagateEvent, this);
 
-		L.LayerGroup.prototype.removeLayer.call(this, layer);
+    L.LayerGroup.prototype.removeLayer.call(this, layer);
 
-		if (this._popupContent) {
-			this.invoke('unbindPopup');
-		}
+    if (this._popupContent) {
+      this.invoke('unbindPopup');
+    }
 
-		return this.fire('layerremove', {layer: layer});
-	},
+    return this.fire('layerremove', {layer: layer});
+  },
 
-	bindPopup: function (content, options) {
-		this._popupContent = content;
-		this._popupOptions = options;
-		return this.invoke('bindPopup', content, options);
-	},
+  bindPopup: function (content, options) {
+    this._popupContent = content;
+    this._popupOptions = options;
+    return this.invoke('bindPopup', content, options);
+  },
 
-	openPopup: function (latlng) {
-		// open popup on the first layer
-		for (var id in this._layers) {
-			this._layers[id].openPopup(latlng);
-			break;
-		}
-		return this;
-	},
+  openPopup: function (latlng) {
+    // open popup on the first layer
+    for (var id in this._layers) {
+      this._layers[id].openPopup(latlng);
+      break;
+    }
+    return this;
+  },
 
-	setStyle: function (style) {
-		return this.invoke('setStyle', style);
-	},
+  setStyle: function (style) {
+    return this.invoke('setStyle', style);
+  },
 
-	bringToFront: function () {
-		return this.invoke('bringToFront');
-	},
+  bringToFront: function () {
+    return this.invoke('bringToFront');
+  },
 
-	bringToBack: function () {
-		return this.invoke('bringToBack');
-	},
+  bringToBack: function () {
+    return this.invoke('bringToBack');
+  },
 
-	getBounds: function () {
-		var bounds = new L.LatLngBounds();
+  getBounds: function () {
+    var bounds = new L.LatLngBounds();
 
-		this.eachLayer(function (layer) {
-			bounds.extend(layer instanceof L.Marker ? layer.getLatLng() : layer.getBounds());
-		});
+    this.eachLayer(function (layer) {
+      bounds.extend(layer instanceof L.Marker ? layer.getLatLng() : layer.getBounds());
+    });
 
-		return bounds;
-	},
+    return bounds;
+  },
 
-	_propagateEvent: function (e) {
-		e = L.extend({
-			layer: e.target,
-			target: this
-		}, e);
-		this.fire(e.type, e);
-	}
+  _propagateEvent: function (e) {
+    e = L.extend({
+      layer: e.target,
+      target: this
+    }, e);
+    this.fire(e.type, e);
+  }
 });
 
 L.featureGroup = function (layers) {
-	return new L.FeatureGroup(layers);
+  return new L.FeatureGroup(layers);
 };
 
 
@@ -12439,119 +12439,119 @@ L.featureGroup = function (layers) {
  */
 
 L.Path = L.Class.extend({
-	includes: [L.Mixin.Events],
+  includes: [L.Mixin.Events],
 
-	statics: {
-		// how much to extend the clip area around the map view
-		// (relative to its size, e.g. 0.5 is half the screen in each direction)
-		// set it so that SVG element doesn't exceed 1280px (vectors flicker on dragend if it is)
-		CLIP_PADDING: (function () {
-			var max = L.Browser.mobile ? 1280 : 2000,
-			    target = (max / Math.max(window.outerWidth, window.outerHeight) - 1) / 2;
-			return Math.max(0, Math.min(0.5, target));
-		})()
-	},
+  statics: {
+    // how much to extend the clip area around the map view
+    // (relative to its size, e.g. 0.5 is half the screen in each direction)
+    // set it so that SVG element doesn't exceed 1280px (vectors flicker on dragend if it is)
+    CLIP_PADDING: (function () {
+      var max = L.Browser.mobile ? 1280 : 2000,
+          target = (max / Math.max(window.outerWidth, window.outerHeight) - 1) / 2;
+      return Math.max(0, Math.min(0.5, target));
+    })()
+  },
 
-	options: {
-		stroke: true,
-		color: '#0033ff',
-		dashArray: null,
-		lineCap: null,
-		lineJoin: null,
-		weight: 5,
-		opacity: 0.5,
+  options: {
+    stroke: true,
+    color: '#0033ff',
+    dashArray: null,
+    lineCap: null,
+    lineJoin: null,
+    weight: 5,
+    opacity: 0.5,
 
-		fill: false,
-		fillColor: null, //same as color by default
-		fillOpacity: 0.2,
+    fill: false,
+    fillColor: null, //same as color by default
+    fillOpacity: 0.2,
 
-		clickable: true
-	},
+    clickable: true
+  },
 
-	initialize: function (options) {
-		L.setOptions(this, options);
-	},
+  initialize: function (options) {
+    L.setOptions(this, options);
+  },
 
-	onAdd: function (map) {
-		this._map = map;
+  onAdd: function (map) {
+    this._map = map;
 
-		if (!this._container) {
-			this._initElements();
-			this._initEvents();
-		}
+    if (!this._container) {
+      this._initElements();
+      this._initEvents();
+    }
 
-		this.projectLatlngs();
-		this._updatePath();
+    this.projectLatlngs();
+    this._updatePath();
 
-		if (this._container) {
-			this._map._pathRoot.appendChild(this._container);
-		}
+    if (this._container) {
+      this._map._pathRoot.appendChild(this._container);
+    }
 
-		this.fire('add');
+    this.fire('add');
 
-		map.on({
-			'viewreset': this.projectLatlngs,
-			'moveend': this._updatePath
-		}, this);
-	},
+    map.on({
+      'viewreset': this.projectLatlngs,
+      'moveend': this._updatePath
+    }, this);
+  },
 
-	addTo: function (map) {
-		map.addLayer(this);
-		return this;
-	},
+  addTo: function (map) {
+    map.addLayer(this);
+    return this;
+  },
 
-	onRemove: function (map) {
-		map._pathRoot.removeChild(this._container);
+  onRemove: function (map) {
+    map._pathRoot.removeChild(this._container);
 
-		// Need to fire remove event before we set _map to null as the event hooks might need the object
-		this.fire('remove');
-		this._map = null;
+    // Need to fire remove event before we set _map to null as the event hooks might need the object
+    this.fire('remove');
+    this._map = null;
 
-		if (L.Browser.vml) {
-			this._container = null;
-			this._stroke = null;
-			this._fill = null;
-		}
+    if (L.Browser.vml) {
+      this._container = null;
+      this._stroke = null;
+      this._fill = null;
+    }
 
-		map.off({
-			'viewreset': this.projectLatlngs,
-			'moveend': this._updatePath
-		}, this);
-	},
+    map.off({
+      'viewreset': this.projectLatlngs,
+      'moveend': this._updatePath
+    }, this);
+  },
 
-	projectLatlngs: function () {
-		// do all projection stuff here
-	},
+  projectLatlngs: function () {
+    // do all projection stuff here
+  },
 
-	setStyle: function (style) {
-		L.setOptions(this, style);
+  setStyle: function (style) {
+    L.setOptions(this, style);
 
-		if (this._container) {
-			this._updateStyle();
-		}
+    if (this._container) {
+      this._updateStyle();
+    }
 
-		return this;
-	},
+    return this;
+  },
 
-	redraw: function () {
-		if (this._map) {
-			this.projectLatlngs();
-			this._updatePath();
-		}
-		return this;
-	}
+  redraw: function () {
+    if (this._map) {
+      this.projectLatlngs();
+      this._updatePath();
+    }
+    return this;
+  }
 });
 
 L.Map.include({
-	_updatePathViewport: function () {
-		var p = L.Path.CLIP_PADDING,
-		    size = this.getSize(),
-		    panePos = L.DomUtil.getPosition(this._mapPane),
-		    min = panePos.multiplyBy(-1)._subtract(size.multiplyBy(p)._round()),
-		    max = min.add(size.multiplyBy(1 + p * 2)._round());
+  _updatePathViewport: function () {
+    var p = L.Path.CLIP_PADDING,
+        size = this.getSize(),
+        panePos = L.DomUtil.getPosition(this._mapPane),
+        min = panePos.multiplyBy(-1)._subtract(size.multiplyBy(p)._round()),
+        max = min.add(size.multiplyBy(1 + p * 2)._round());
 
-		this._pathViewport = new L.Bounds(min, max);
-	}
+    this._pathViewport = new L.Bounds(min, max);
+  }
 });
 
 
@@ -12568,226 +12568,226 @@ L.Path.SVG_NS = 'http://www.w3.org/2000/svg';
 L.Browser.svg = !!(document.createElementNS && document.createElementNS(L.Path.SVG_NS, 'svg').createSVGRect);
 
 L.Path = L.Path.extend({
-	statics: {
-		SVG: L.Browser.svg
-	},
+  statics: {
+    SVG: L.Browser.svg
+  },
 
-	bringToFront: function () {
-		var root = this._map._pathRoot,
-		    path = this._container;
+  bringToFront: function () {
+    var root = this._map._pathRoot,
+        path = this._container;
 
-		if (path && root.lastChild !== path) {
-			root.appendChild(path);
-		}
-		return this;
-	},
+    if (path && root.lastChild !== path) {
+      root.appendChild(path);
+    }
+    return this;
+  },
 
-	bringToBack: function () {
-		var root = this._map._pathRoot,
-		    path = this._container,
-		    first = root.firstChild;
+  bringToBack: function () {
+    var root = this._map._pathRoot,
+        path = this._container,
+        first = root.firstChild;
 
-		if (path && first !== path) {
-			root.insertBefore(path, first);
-		}
-		return this;
-	},
+    if (path && first !== path) {
+      root.insertBefore(path, first);
+    }
+    return this;
+  },
 
-	getPathString: function () {
-		// form path string here
-	},
+  getPathString: function () {
+    // form path string here
+  },
 
-	_createElement: function (name) {
-		return document.createElementNS(L.Path.SVG_NS, name);
-	},
+  _createElement: function (name) {
+    return document.createElementNS(L.Path.SVG_NS, name);
+  },
 
-	_initElements: function () {
-		this._map._initPathRoot();
-		this._initPath();
-		this._initStyle();
-	},
+  _initElements: function () {
+    this._map._initPathRoot();
+    this._initPath();
+    this._initStyle();
+  },
 
-	_initPath: function () {
-		this._container = this._createElement('g');
+  _initPath: function () {
+    this._container = this._createElement('g');
 
-		this._path = this._createElement('path');
+    this._path = this._createElement('path');
 
-		if (this.options.className) {
-			L.DomUtil.addClass(this._path, this.options.className);
-		}
+    if (this.options.className) {
+      L.DomUtil.addClass(this._path, this.options.className);
+    }
 
-		this._container.appendChild(this._path);
-	},
+    this._container.appendChild(this._path);
+  },
 
-	_initStyle: function () {
-		if (this.options.stroke) {
-			this._path.setAttribute('stroke-linejoin', 'round');
-			this._path.setAttribute('stroke-linecap', 'round');
-		}
-		if (this.options.fill) {
-			this._path.setAttribute('fill-rule', 'evenodd');
-		}
-		if (this.options.pointerEvents) {
-			this._path.setAttribute('pointer-events', this.options.pointerEvents);
-		}
-		if (!this.options.clickable && !this.options.pointerEvents) {
-			this._path.setAttribute('pointer-events', 'none');
-		}
-		this._updateStyle();
-	},
+  _initStyle: function () {
+    if (this.options.stroke) {
+      this._path.setAttribute('stroke-linejoin', 'round');
+      this._path.setAttribute('stroke-linecap', 'round');
+    }
+    if (this.options.fill) {
+      this._path.setAttribute('fill-rule', 'evenodd');
+    }
+    if (this.options.pointerEvents) {
+      this._path.setAttribute('pointer-events', this.options.pointerEvents);
+    }
+    if (!this.options.clickable && !this.options.pointerEvents) {
+      this._path.setAttribute('pointer-events', 'none');
+    }
+    this._updateStyle();
+  },
 
-	_updateStyle: function () {
-		if (this.options.stroke) {
-			this._path.setAttribute('stroke', this.options.color);
-			this._path.setAttribute('stroke-opacity', this.options.opacity);
-			this._path.setAttribute('stroke-width', this.options.weight);
-			if (this.options.dashArray) {
-				this._path.setAttribute('stroke-dasharray', this.options.dashArray);
-			} else {
-				this._path.removeAttribute('stroke-dasharray');
-			}
-			if (this.options.lineCap) {
-				this._path.setAttribute('stroke-linecap', this.options.lineCap);
-			}
-			if (this.options.lineJoin) {
-				this._path.setAttribute('stroke-linejoin', this.options.lineJoin);
-			}
-		} else {
-			this._path.setAttribute('stroke', 'none');
-		}
-		if (this.options.fill) {
-			this._path.setAttribute('fill', this.options.fillColor || this.options.color);
-			this._path.setAttribute('fill-opacity', this.options.fillOpacity);
-		} else {
-			this._path.setAttribute('fill', 'none');
-		}
-	},
+  _updateStyle: function () {
+    if (this.options.stroke) {
+      this._path.setAttribute('stroke', this.options.color);
+      this._path.setAttribute('stroke-opacity', this.options.opacity);
+      this._path.setAttribute('stroke-width', this.options.weight);
+      if (this.options.dashArray) {
+        this._path.setAttribute('stroke-dasharray', this.options.dashArray);
+      } else {
+        this._path.removeAttribute('stroke-dasharray');
+      }
+      if (this.options.lineCap) {
+        this._path.setAttribute('stroke-linecap', this.options.lineCap);
+      }
+      if (this.options.lineJoin) {
+        this._path.setAttribute('stroke-linejoin', this.options.lineJoin);
+      }
+    } else {
+      this._path.setAttribute('stroke', 'none');
+    }
+    if (this.options.fill) {
+      this._path.setAttribute('fill', this.options.fillColor || this.options.color);
+      this._path.setAttribute('fill-opacity', this.options.fillOpacity);
+    } else {
+      this._path.setAttribute('fill', 'none');
+    }
+  },
 
-	_updatePath: function () {
-		var str = this.getPathString();
-		if (!str) {
-			// fix webkit empty string parsing bug
-			str = 'M0 0';
-		}
-		this._path.setAttribute('d', str);
-	},
+  _updatePath: function () {
+    var str = this.getPathString();
+    if (!str) {
+      // fix webkit empty string parsing bug
+      str = 'M0 0';
+    }
+    this._path.setAttribute('d', str);
+  },
 
-	// TODO remove duplication with L.Map
-	_initEvents: function () {
-		if (this.options.clickable) {
-			if (L.Browser.svg || !L.Browser.vml) {
-				L.DomUtil.addClass(this._path, 'leaflet-clickable');
-			}
+  // TODO remove duplication with L.Map
+  _initEvents: function () {
+    if (this.options.clickable) {
+      if (L.Browser.svg || !L.Browser.vml) {
+        L.DomUtil.addClass(this._path, 'leaflet-clickable');
+      }
 
-			L.DomEvent.on(this._container, 'click', this._onMouseClick, this);
+      L.DomEvent.on(this._container, 'click', this._onMouseClick, this);
 
-			var events = ['dblclick', 'mousedown', 'mouseover',
-			              'mouseout', 'mousemove', 'contextmenu'];
-			for (var i = 0; i < events.length; i++) {
-				L.DomEvent.on(this._container, events[i], this._fireMouseEvent, this);
-			}
-		}
-	},
+      var events = ['dblclick', 'mousedown', 'mouseover',
+                    'mouseout', 'mousemove', 'contextmenu'];
+      for (var i = 0; i < events.length; i++) {
+        L.DomEvent.on(this._container, events[i], this._fireMouseEvent, this);
+      }
+    }
+  },
 
-	_onMouseClick: function (e) {
-		if (this._map.dragging && this._map.dragging.moved()) { return; }
+  _onMouseClick: function (e) {
+    if (this._map.dragging && this._map.dragging.moved()) { return; }
 
-		this._fireMouseEvent(e);
-	},
+    this._fireMouseEvent(e);
+  },
 
-	_fireMouseEvent: function (e) {
-		if (!this.hasEventListeners(e.type)) { return; }
+  _fireMouseEvent: function (e) {
+    if (!this.hasEventListeners(e.type)) { return; }
 
-		var map = this._map,
-		    containerPoint = map.mouseEventToContainerPoint(e),
-		    layerPoint = map.containerPointToLayerPoint(containerPoint),
-		    latlng = map.layerPointToLatLng(layerPoint);
+    var map = this._map,
+        containerPoint = map.mouseEventToContainerPoint(e),
+        layerPoint = map.containerPointToLayerPoint(containerPoint),
+        latlng = map.layerPointToLatLng(layerPoint);
 
-		this.fire(e.type, {
-			latlng: latlng,
-			layerPoint: layerPoint,
-			containerPoint: containerPoint,
-			originalEvent: e
-		});
+    this.fire(e.type, {
+      latlng: latlng,
+      layerPoint: layerPoint,
+      containerPoint: containerPoint,
+      originalEvent: e
+    });
 
-		if (e.type === 'contextmenu') {
-			L.DomEvent.preventDefault(e);
-		}
-		if (e.type !== 'mousemove') {
-			L.DomEvent.stopPropagation(e);
-		}
-	}
+    if (e.type === 'contextmenu') {
+      L.DomEvent.preventDefault(e);
+    }
+    if (e.type !== 'mousemove') {
+      L.DomEvent.stopPropagation(e);
+    }
+  }
 });
 
 L.Map.include({
-	_initPathRoot: function () {
-		if (!this._pathRoot) {
-			this._pathRoot = L.Path.prototype._createElement('svg');
-			this._panes.overlayPane.appendChild(this._pathRoot);
+  _initPathRoot: function () {
+    if (!this._pathRoot) {
+      this._pathRoot = L.Path.prototype._createElement('svg');
+      this._panes.overlayPane.appendChild(this._pathRoot);
 
-			if (this.options.zoomAnimation && L.Browser.any3d) {
-				L.DomUtil.addClass(this._pathRoot, 'leaflet-zoom-animated');
+      if (this.options.zoomAnimation && L.Browser.any3d) {
+        L.DomUtil.addClass(this._pathRoot, 'leaflet-zoom-animated');
 
-				this.on({
-					'zoomanim': this._animatePathZoom,
-					'zoomend': this._endPathZoom
-				});
-			} else {
-				L.DomUtil.addClass(this._pathRoot, 'leaflet-zoom-hide');
-			}
+        this.on({
+          'zoomanim': this._animatePathZoom,
+          'zoomend': this._endPathZoom
+        });
+      } else {
+        L.DomUtil.addClass(this._pathRoot, 'leaflet-zoom-hide');
+      }
 
-			this.on('moveend', this._updateSvgViewport);
-			this._updateSvgViewport();
-		}
-	},
+      this.on('moveend', this._updateSvgViewport);
+      this._updateSvgViewport();
+    }
+  },
 
-	_animatePathZoom: function (e) {
-		var scale = this.getZoomScale(e.zoom),
-		    offset = this._getCenterOffset(e.center)._multiplyBy(-scale)._add(this._pathViewport.min);
+  _animatePathZoom: function (e) {
+    var scale = this.getZoomScale(e.zoom),
+        offset = this._getCenterOffset(e.center)._multiplyBy(-scale)._add(this._pathViewport.min);
 
-		this._pathRoot.style[L.DomUtil.TRANSFORM] =
-		        L.DomUtil.getTranslateString(offset) + ' scale(' + scale + ') ';
+    this._pathRoot.style[L.DomUtil.TRANSFORM] =
+            L.DomUtil.getTranslateString(offset) + ' scale(' + scale + ') ';
 
-		this._pathZooming = true;
-	},
+    this._pathZooming = true;
+  },
 
-	_endPathZoom: function () {
-		this._pathZooming = false;
-	},
+  _endPathZoom: function () {
+    this._pathZooming = false;
+  },
 
-	_updateSvgViewport: function () {
+  _updateSvgViewport: function () {
 
-		if (this._pathZooming) {
-			// Do not update SVGs while a zoom animation is going on otherwise the animation will break.
-			// When the zoom animation ends we will be updated again anyway
-			// This fixes the case where you do a momentum move and zoom while the move is still ongoing.
-			return;
-		}
+    if (this._pathZooming) {
+      // Do not update SVGs while a zoom animation is going on otherwise the animation will break.
+      // When the zoom animation ends we will be updated again anyway
+      // This fixes the case where you do a momentum move and zoom while the move is still ongoing.
+      return;
+    }
 
-		this._updatePathViewport();
+    this._updatePathViewport();
 
-		var vp = this._pathViewport,
-		    min = vp.min,
-		    max = vp.max,
-		    width = max.x - min.x,
-		    height = max.y - min.y,
-		    root = this._pathRoot,
-		    pane = this._panes.overlayPane;
+    var vp = this._pathViewport,
+        min = vp.min,
+        max = vp.max,
+        width = max.x - min.x,
+        height = max.y - min.y,
+        root = this._pathRoot,
+        pane = this._panes.overlayPane;
 
-		// Hack to make flicker on drag end on mobile webkit less irritating
-		if (L.Browser.mobileWebkit) {
-			pane.removeChild(root);
-		}
+    // Hack to make flicker on drag end on mobile webkit less irritating
+    if (L.Browser.mobileWebkit) {
+      pane.removeChild(root);
+    }
 
-		L.DomUtil.setPosition(root, min);
-		root.setAttribute('width', width);
-		root.setAttribute('height', height);
-		root.setAttribute('viewBox', [min.x, min.y, width, height].join(' '));
+    L.DomUtil.setPosition(root, min);
+    root.setAttribute('width', width);
+    root.setAttribute('height', height);
+    root.setAttribute('viewBox', [min.x, min.y, width, height].join(' '));
 
-		if (L.Browser.mobileWebkit) {
-			pane.appendChild(root);
-		}
-	}
+    if (L.Browser.mobileWebkit) {
+      pane.appendChild(root);
+    }
+  }
 });
 
 
@@ -12800,197 +12800,197 @@ L.Map.include({
  */
 
 L.Browser.canvas = (function () {
-	return !!document.createElement('canvas').getContext;
+  return !!document.createElement('canvas').getContext;
 }());
 
 L.Path = (L.Path.SVG && !window.L_PREFER_CANVAS) || !L.Browser.canvas ? L.Path : L.Path.extend({
-	statics: {
-		//CLIP_PADDING: 0.02, // not sure if there's a need to set it to a small value
-		CANVAS: true,
-		SVG: false
-	},
+  statics: {
+    //CLIP_PADDING: 0.02, // not sure if there's a need to set it to a small value
+    CANVAS: true,
+    SVG: false
+  },
 
-	redraw: function () {
-		if (this._map) {
-			this.projectLatlngs();
-			this._requestUpdate();
-		}
-		return this;
-	},
+  redraw: function () {
+    if (this._map) {
+      this.projectLatlngs();
+      this._requestUpdate();
+    }
+    return this;
+  },
 
-	setStyle: function (style) {
-		L.setOptions(this, style);
+  setStyle: function (style) {
+    L.setOptions(this, style);
 
-		if (this._map) {
-			this._updateStyle();
-			this._requestUpdate();
-		}
-		return this;
-	},
+    if (this._map) {
+      this._updateStyle();
+      this._requestUpdate();
+    }
+    return this;
+  },
 
-	onRemove: function (map) {
-		map
-		    .off('viewreset', this.projectLatlngs, this)
-		    .off('moveend', this._updatePath, this);
+  onRemove: function (map) {
+    map
+        .off('viewreset', this.projectLatlngs, this)
+        .off('moveend', this._updatePath, this);
 
-		if (this.options.clickable) {
-			this._map.off('click', this._onClick, this);
-			this._map.off('mousemove', this._onMouseMove, this);
-		}
+    if (this.options.clickable) {
+      this._map.off('click', this._onClick, this);
+      this._map.off('mousemove', this._onMouseMove, this);
+    }
 
-		this._requestUpdate();
+    this._requestUpdate();
 
-		this._map = null;
-	},
+    this._map = null;
+  },
 
-	_requestUpdate: function () {
-		if (this._map && !L.Path._updateRequest) {
-			L.Path._updateRequest = L.Util.requestAnimFrame(this._fireMapMoveEnd, this._map);
-		}
-	},
+  _requestUpdate: function () {
+    if (this._map && !L.Path._updateRequest) {
+      L.Path._updateRequest = L.Util.requestAnimFrame(this._fireMapMoveEnd, this._map);
+    }
+  },
 
-	_fireMapMoveEnd: function () {
-		L.Path._updateRequest = null;
-		this.fire('moveend');
-	},
+  _fireMapMoveEnd: function () {
+    L.Path._updateRequest = null;
+    this.fire('moveend');
+  },
 
-	_initElements: function () {
-		this._map._initPathRoot();
-		this._ctx = this._map._canvasCtx;
-	},
+  _initElements: function () {
+    this._map._initPathRoot();
+    this._ctx = this._map._canvasCtx;
+  },
 
-	_updateStyle: function () {
-		var options = this.options;
+  _updateStyle: function () {
+    var options = this.options;
 
-		if (options.stroke) {
-			this._ctx.lineWidth = options.weight;
-			this._ctx.strokeStyle = options.color;
-		}
-		if (options.fill) {
-			this._ctx.fillStyle = options.fillColor || options.color;
-		}
-	},
+    if (options.stroke) {
+      this._ctx.lineWidth = options.weight;
+      this._ctx.strokeStyle = options.color;
+    }
+    if (options.fill) {
+      this._ctx.fillStyle = options.fillColor || options.color;
+    }
+  },
 
-	_drawPath: function () {
-		var i, j, len, len2, point, drawMethod;
+  _drawPath: function () {
+    var i, j, len, len2, point, drawMethod;
 
-		this._ctx.beginPath();
+    this._ctx.beginPath();
 
-		for (i = 0, len = this._parts.length; i < len; i++) {
-			for (j = 0, len2 = this._parts[i].length; j < len2; j++) {
-				point = this._parts[i][j];
-				drawMethod = (j === 0 ? 'move' : 'line') + 'To';
+    for (i = 0, len = this._parts.length; i < len; i++) {
+      for (j = 0, len2 = this._parts[i].length; j < len2; j++) {
+        point = this._parts[i][j];
+        drawMethod = (j === 0 ? 'move' : 'line') + 'To';
 
-				this._ctx[drawMethod](point.x, point.y);
-			}
-			// TODO refactor ugly hack
-			if (this instanceof L.Polygon) {
-				this._ctx.closePath();
-			}
-		}
-	},
+        this._ctx[drawMethod](point.x, point.y);
+      }
+      // TODO refactor ugly hack
+      if (this instanceof L.Polygon) {
+        this._ctx.closePath();
+      }
+    }
+  },
 
-	_checkIfEmpty: function () {
-		return !this._parts.length;
-	},
+  _checkIfEmpty: function () {
+    return !this._parts.length;
+  },
 
-	_updatePath: function () {
-		if (this._checkIfEmpty()) { return; }
+  _updatePath: function () {
+    if (this._checkIfEmpty()) { return; }
 
-		var ctx = this._ctx,
-		    options = this.options;
+    var ctx = this._ctx,
+        options = this.options;
 
-		this._drawPath();
-		ctx.save();
-		this._updateStyle();
+    this._drawPath();
+    ctx.save();
+    this._updateStyle();
 
-		if (options.fill) {
-			ctx.globalAlpha = options.fillOpacity;
-			ctx.fill();
-		}
+    if (options.fill) {
+      ctx.globalAlpha = options.fillOpacity;
+      ctx.fill();
+    }
 
-		if (options.stroke) {
-			ctx.globalAlpha = options.opacity;
-			ctx.stroke();
-		}
+    if (options.stroke) {
+      ctx.globalAlpha = options.opacity;
+      ctx.stroke();
+    }
 
-		ctx.restore();
+    ctx.restore();
 
-		// TODO optimization: 1 fill/stroke for all features with equal style instead of 1 for each feature
-	},
+    // TODO optimization: 1 fill/stroke for all features with equal style instead of 1 for each feature
+  },
 
-	_initEvents: function () {
-		if (this.options.clickable) {
-			// TODO dblclick
-			this._map.on('mousemove', this._onMouseMove, this);
-			this._map.on('click', this._onClick, this);
-		}
-	},
+  _initEvents: function () {
+    if (this.options.clickable) {
+      // TODO dblclick
+      this._map.on('mousemove', this._onMouseMove, this);
+      this._map.on('click', this._onClick, this);
+    }
+  },
 
-	_onClick: function (e) {
-		if (this._containsPoint(e.layerPoint)) {
-			this.fire('click', e);
-		}
-	},
+  _onClick: function (e) {
+    if (this._containsPoint(e.layerPoint)) {
+      this.fire('click', e);
+    }
+  },
 
-	_onMouseMove: function (e) {
-		if (!this._map || this._map._animatingZoom) { return; }
+  _onMouseMove: function (e) {
+    if (!this._map || this._map._animatingZoom) { return; }
 
-		// TODO don't do on each move
-		if (this._containsPoint(e.layerPoint)) {
-			this._ctx.canvas.style.cursor = 'pointer';
-			this._mouseInside = true;
-			this.fire('mouseover', e);
+    // TODO don't do on each move
+    if (this._containsPoint(e.layerPoint)) {
+      this._ctx.canvas.style.cursor = 'pointer';
+      this._mouseInside = true;
+      this.fire('mouseover', e);
 
-		} else if (this._mouseInside) {
-			this._ctx.canvas.style.cursor = '';
-			this._mouseInside = false;
-			this.fire('mouseout', e);
-		}
-	}
+    } else if (this._mouseInside) {
+      this._ctx.canvas.style.cursor = '';
+      this._mouseInside = false;
+      this.fire('mouseout', e);
+    }
+  }
 });
 
 L.Map.include((L.Path.SVG && !window.L_PREFER_CANVAS) || !L.Browser.canvas ? {} : {
-	_initPathRoot: function () {
-		var root = this._pathRoot,
-		    ctx;
+  _initPathRoot: function () {
+    var root = this._pathRoot,
+        ctx;
 
-		if (!root) {
-			root = this._pathRoot = document.createElement('canvas');
-			root.style.position = 'absolute';
-			ctx = this._canvasCtx = root.getContext('2d');
+    if (!root) {
+      root = this._pathRoot = document.createElement('canvas');
+      root.style.position = 'absolute';
+      ctx = this._canvasCtx = root.getContext('2d');
 
-			ctx.lineCap = 'round';
-			ctx.lineJoin = 'round';
+      ctx.lineCap = 'round';
+      ctx.lineJoin = 'round';
 
-			this._panes.overlayPane.appendChild(root);
+      this._panes.overlayPane.appendChild(root);
 
-			if (this.options.zoomAnimation) {
-				this._pathRoot.className = 'leaflet-zoom-animated';
-				this.on('zoomanim', this._animatePathZoom);
-				this.on('zoomend', this._endPathZoom);
-			}
-			this.on('moveend', this._updateCanvasViewport);
-			this._updateCanvasViewport();
-		}
-	},
+      if (this.options.zoomAnimation) {
+        this._pathRoot.className = 'leaflet-zoom-animated';
+        this.on('zoomanim', this._animatePathZoom);
+        this.on('zoomend', this._endPathZoom);
+      }
+      this.on('moveend', this._updateCanvasViewport);
+      this._updateCanvasViewport();
+    }
+  },
 
-	_updateCanvasViewport: function () {
-		// don't redraw while zooming. See _updateSvgViewport for more details
-		if (this._pathZooming) { return; }
-		this._updatePathViewport();
+  _updateCanvasViewport: function () {
+    // don't redraw while zooming. See _updateSvgViewport for more details
+    if (this._pathZooming) { return; }
+    this._updatePathViewport();
 
-		var vp = this._pathViewport,
-		    min = vp.min,
-		    size = vp.max.subtract(min),
-		    root = this._pathRoot;
+    var vp = this._pathViewport,
+        min = vp.min,
+        size = vp.max.subtract(min),
+        root = this._pathRoot;
 
-		//TODO check if this works properly on mobile webkit
-		L.DomUtil.setPosition(root, min);
-		root.width = size.x;
-		root.height = size.y;
-		root.getContext('2d').translate(-min.x, -min.y);
-	}
+    //TODO check if this works properly on mobile webkit
+    L.DomUtil.setPosition(root, min);
+    root.width = size.x;
+    root.height = size.y;
+    root.getContext('2d').translate(-min.x, -min.y);
+  }
 });
 
 
@@ -13007,198 +13007,198 @@ L.Map.include((L.Path.SVG && !window.L_PREFER_CANVAS) || !L.Browser.canvas ? {} 
 
 L.LineUtil = {
 
-	// Simplify polyline with vertex reduction and Douglas-Peucker simplification.
-	// Improves rendering performance dramatically by lessening the number of points to draw.
+  // Simplify polyline with vertex reduction and Douglas-Peucker simplification.
+  // Improves rendering performance dramatically by lessening the number of points to draw.
 
-	simplify: function (/*Point[]*/ points, /*Number*/ tolerance) {
-		if (!tolerance || !points.length) {
-			return points.slice();
-		}
+  simplify: function (/*Point[]*/ points, /*Number*/ tolerance) {
+    if (!tolerance || !points.length) {
+      return points.slice();
+    }
 
-		var sqTolerance = tolerance * tolerance;
+    var sqTolerance = tolerance * tolerance;
 
-		// stage 1: vertex reduction
-		points = this._reducePoints(points, sqTolerance);
+    // stage 1: vertex reduction
+    points = this._reducePoints(points, sqTolerance);
 
-		// stage 2: Douglas-Peucker simplification
-		points = this._simplifyDP(points, sqTolerance);
+    // stage 2: Douglas-Peucker simplification
+    points = this._simplifyDP(points, sqTolerance);
 
-		return points;
-	},
+    return points;
+  },
 
-	// distance from a point to a segment between two points
-	pointToSegmentDistance:  function (/*Point*/ p, /*Point*/ p1, /*Point*/ p2) {
-		return Math.sqrt(this._sqClosestPointOnSegment(p, p1, p2, true));
-	},
+  // distance from a point to a segment between two points
+  pointToSegmentDistance:  function (/*Point*/ p, /*Point*/ p1, /*Point*/ p2) {
+    return Math.sqrt(this._sqClosestPointOnSegment(p, p1, p2, true));
+  },
 
-	closestPointOnSegment: function (/*Point*/ p, /*Point*/ p1, /*Point*/ p2) {
-		return this._sqClosestPointOnSegment(p, p1, p2);
-	},
+  closestPointOnSegment: function (/*Point*/ p, /*Point*/ p1, /*Point*/ p2) {
+    return this._sqClosestPointOnSegment(p, p1, p2);
+  },
 
-	// Douglas-Peucker simplification, see http://en.wikipedia.org/wiki/Douglas-Peucker_algorithm
-	_simplifyDP: function (points, sqTolerance) {
+  // Douglas-Peucker simplification, see http://en.wikipedia.org/wiki/Douglas-Peucker_algorithm
+  _simplifyDP: function (points, sqTolerance) {
 
-		var len = points.length,
-		    ArrayConstructor = typeof Uint8Array !== undefined + '' ? Uint8Array : Array,
-		    markers = new ArrayConstructor(len);
+    var len = points.length,
+        ArrayConstructor = typeof Uint8Array !== undefined + '' ? Uint8Array : Array,
+        markers = new ArrayConstructor(len);
 
-		markers[0] = markers[len - 1] = 1;
+    markers[0] = markers[len - 1] = 1;
 
-		this._simplifyDPStep(points, markers, sqTolerance, 0, len - 1);
+    this._simplifyDPStep(points, markers, sqTolerance, 0, len - 1);
 
-		var i,
-		    newPoints = [];
+    var i,
+        newPoints = [];
 
-		for (i = 0; i < len; i++) {
-			if (markers[i]) {
-				newPoints.push(points[i]);
-			}
-		}
+    for (i = 0; i < len; i++) {
+      if (markers[i]) {
+        newPoints.push(points[i]);
+      }
+    }
 
-		return newPoints;
-	},
+    return newPoints;
+  },
 
-	_simplifyDPStep: function (points, markers, sqTolerance, first, last) {
+  _simplifyDPStep: function (points, markers, sqTolerance, first, last) {
 
-		var maxSqDist = 0,
-		    index, i, sqDist;
+    var maxSqDist = 0,
+        index, i, sqDist;
 
-		for (i = first + 1; i <= last - 1; i++) {
-			sqDist = this._sqClosestPointOnSegment(points[i], points[first], points[last], true);
+    for (i = first + 1; i <= last - 1; i++) {
+      sqDist = this._sqClosestPointOnSegment(points[i], points[first], points[last], true);
 
-			if (sqDist > maxSqDist) {
-				index = i;
-				maxSqDist = sqDist;
-			}
-		}
+      if (sqDist > maxSqDist) {
+        index = i;
+        maxSqDist = sqDist;
+      }
+    }
 
-		if (maxSqDist > sqTolerance) {
-			markers[index] = 1;
+    if (maxSqDist > sqTolerance) {
+      markers[index] = 1;
 
-			this._simplifyDPStep(points, markers, sqTolerance, first, index);
-			this._simplifyDPStep(points, markers, sqTolerance, index, last);
-		}
-	},
+      this._simplifyDPStep(points, markers, sqTolerance, first, index);
+      this._simplifyDPStep(points, markers, sqTolerance, index, last);
+    }
+  },
 
-	// reduce points that are too close to each other to a single point
-	_reducePoints: function (points, sqTolerance) {
-		var reducedPoints = [points[0]];
+  // reduce points that are too close to each other to a single point
+  _reducePoints: function (points, sqTolerance) {
+    var reducedPoints = [points[0]];
 
-		for (var i = 1, prev = 0, len = points.length; i < len; i++) {
-			if (this._sqDist(points[i], points[prev]) > sqTolerance) {
-				reducedPoints.push(points[i]);
-				prev = i;
-			}
-		}
-		if (prev < len - 1) {
-			reducedPoints.push(points[len - 1]);
-		}
-		return reducedPoints;
-	},
+    for (var i = 1, prev = 0, len = points.length; i < len; i++) {
+      if (this._sqDist(points[i], points[prev]) > sqTolerance) {
+        reducedPoints.push(points[i]);
+        prev = i;
+      }
+    }
+    if (prev < len - 1) {
+      reducedPoints.push(points[len - 1]);
+    }
+    return reducedPoints;
+  },
 
-	// Cohen-Sutherland line clipping algorithm.
-	// Used to avoid rendering parts of a polyline that are not currently visible.
+  // Cohen-Sutherland line clipping algorithm.
+  // Used to avoid rendering parts of a polyline that are not currently visible.
 
-	clipSegment: function (a, b, bounds, useLastCode) {
-		var codeA = useLastCode ? this._lastCode : this._getBitCode(a, bounds),
-		    codeB = this._getBitCode(b, bounds),
+  clipSegment: function (a, b, bounds, useLastCode) {
+    var codeA = useLastCode ? this._lastCode : this._getBitCode(a, bounds),
+        codeB = this._getBitCode(b, bounds),
 
-		    codeOut, p, newCode;
+        codeOut, p, newCode;
 
-		// save 2nd code to avoid calculating it on the next segment
-		this._lastCode = codeB;
+    // save 2nd code to avoid calculating it on the next segment
+    this._lastCode = codeB;
 
-		while (true) {
-			// if a,b is inside the clip window (trivial accept)
-			if (!(codeA | codeB)) {
-				return [a, b];
-			// if a,b is outside the clip window (trivial reject)
-			} else if (codeA & codeB) {
-				return false;
-			// other cases
-			} else {
-				codeOut = codeA || codeB;
-				p = this._getEdgeIntersection(a, b, codeOut, bounds);
-				newCode = this._getBitCode(p, bounds);
+    while (true) {
+      // if a,b is inside the clip window (trivial accept)
+      if (!(codeA | codeB)) {
+        return [a, b];
+      // if a,b is outside the clip window (trivial reject)
+      } else if (codeA & codeB) {
+        return false;
+      // other cases
+      } else {
+        codeOut = codeA || codeB;
+        p = this._getEdgeIntersection(a, b, codeOut, bounds);
+        newCode = this._getBitCode(p, bounds);
 
-				if (codeOut === codeA) {
-					a = p;
-					codeA = newCode;
-				} else {
-					b = p;
-					codeB = newCode;
-				}
-			}
-		}
-	},
+        if (codeOut === codeA) {
+          a = p;
+          codeA = newCode;
+        } else {
+          b = p;
+          codeB = newCode;
+        }
+      }
+    }
+  },
 
-	_getEdgeIntersection: function (a, b, code, bounds) {
-		var dx = b.x - a.x,
-		    dy = b.y - a.y,
-		    min = bounds.min,
-		    max = bounds.max;
+  _getEdgeIntersection: function (a, b, code, bounds) {
+    var dx = b.x - a.x,
+        dy = b.y - a.y,
+        min = bounds.min,
+        max = bounds.max;
 
-		if (code & 8) { // top
-			return new L.Point(a.x + dx * (max.y - a.y) / dy, max.y);
-		} else if (code & 4) { // bottom
-			return new L.Point(a.x + dx * (min.y - a.y) / dy, min.y);
-		} else if (code & 2) { // right
-			return new L.Point(max.x, a.y + dy * (max.x - a.x) / dx);
-		} else if (code & 1) { // left
-			return new L.Point(min.x, a.y + dy * (min.x - a.x) / dx);
-		}
-	},
+    if (code & 8) { // top
+      return new L.Point(a.x + dx * (max.y - a.y) / dy, max.y);
+    } else if (code & 4) { // bottom
+      return new L.Point(a.x + dx * (min.y - a.y) / dy, min.y);
+    } else if (code & 2) { // right
+      return new L.Point(max.x, a.y + dy * (max.x - a.x) / dx);
+    } else if (code & 1) { // left
+      return new L.Point(min.x, a.y + dy * (min.x - a.x) / dx);
+    }
+  },
 
-	_getBitCode: function (/*Point*/ p, bounds) {
-		var code = 0;
+  _getBitCode: function (/*Point*/ p, bounds) {
+    var code = 0;
 
-		if (p.x < bounds.min.x) { // left
-			code |= 1;
-		} else if (p.x > bounds.max.x) { // right
-			code |= 2;
-		}
-		if (p.y < bounds.min.y) { // bottom
-			code |= 4;
-		} else if (p.y > bounds.max.y) { // top
-			code |= 8;
-		}
+    if (p.x < bounds.min.x) { // left
+      code |= 1;
+    } else if (p.x > bounds.max.x) { // right
+      code |= 2;
+    }
+    if (p.y < bounds.min.y) { // bottom
+      code |= 4;
+    } else if (p.y > bounds.max.y) { // top
+      code |= 8;
+    }
 
-		return code;
-	},
+    return code;
+  },
 
-	// square distance (to avoid unnecessary Math.sqrt calls)
-	_sqDist: function (p1, p2) {
-		var dx = p2.x - p1.x,
-		    dy = p2.y - p1.y;
-		return dx * dx + dy * dy;
-	},
+  // square distance (to avoid unnecessary Math.sqrt calls)
+  _sqDist: function (p1, p2) {
+    var dx = p2.x - p1.x,
+        dy = p2.y - p1.y;
+    return dx * dx + dy * dy;
+  },
 
-	// return closest point on segment or distance to that point
-	_sqClosestPointOnSegment: function (p, p1, p2, sqDist) {
-		var x = p1.x,
-		    y = p1.y,
-		    dx = p2.x - x,
-		    dy = p2.y - y,
-		    dot = dx * dx + dy * dy,
-		    t;
+  // return closest point on segment or distance to that point
+  _sqClosestPointOnSegment: function (p, p1, p2, sqDist) {
+    var x = p1.x,
+        y = p1.y,
+        dx = p2.x - x,
+        dy = p2.y - y,
+        dot = dx * dx + dy * dy,
+        t;
 
-		if (dot > 0) {
-			t = ((p.x - x) * dx + (p.y - y) * dy) / dot;
+    if (dot > 0) {
+      t = ((p.x - x) * dx + (p.y - y) * dy) / dot;
 
-			if (t > 1) {
-				x = p2.x;
-				y = p2.y;
-			} else if (t > 0) {
-				x += dx * t;
-				y += dy * t;
-			}
-		}
+      if (t > 1) {
+        x = p2.x;
+        y = p2.y;
+      } else if (t > 0) {
+        x += dx * t;
+        y += dy * t;
+      }
+    }
 
-		dx = p.x - x;
-		dy = p.y - y;
+    dx = p.x - x;
+    dy = p.y - y;
 
-		return sqDist ? dx * dx + dy * dy : new L.Point(x, y);
-	}
+    return sqDist ? dx * dx + dy * dy : new L.Point(x, y);
+  }
 };
 
 
@@ -13211,164 +13211,164 @@ L.LineUtil = {
  */
 
 L.Polyline = L.Path.extend({
-	initialize: function (latlngs, options) {
-		L.Path.prototype.initialize.call(this, options);
+  initialize: function (latlngs, options) {
+    L.Path.prototype.initialize.call(this, options);
 
-		this._latlngs = this._convertLatLngs(latlngs);
-	},
+    this._latlngs = this._convertLatLngs(latlngs);
+  },
 
-	options: {
-		// how much to simplify the polyline on each zoom level
-		// more = better performance and smoother look, less = more accurate
-		smoothFactor: 1.0,
-		noClip: false
-	},
+  options: {
+    // how much to simplify the polyline on each zoom level
+    // more = better performance and smoother look, less = more accurate
+    smoothFactor: 1.0,
+    noClip: false
+  },
 
-	projectLatlngs: function () {
-		this._originalPoints = [];
+  projectLatlngs: function () {
+    this._originalPoints = [];
 
-		for (var i = 0, len = this._latlngs.length; i < len; i++) {
-			this._originalPoints[i] = this._map.latLngToLayerPoint(this._latlngs[i]);
-		}
-	},
+    for (var i = 0, len = this._latlngs.length; i < len; i++) {
+      this._originalPoints[i] = this._map.latLngToLayerPoint(this._latlngs[i]);
+    }
+  },
 
-	getPathString: function () {
-		for (var i = 0, len = this._parts.length, str = ''; i < len; i++) {
-			str += this._getPathPartStr(this._parts[i]);
-		}
-		return str;
-	},
+  getPathString: function () {
+    for (var i = 0, len = this._parts.length, str = ''; i < len; i++) {
+      str += this._getPathPartStr(this._parts[i]);
+    }
+    return str;
+  },
 
-	getLatLngs: function () {
-		return this._latlngs;
-	},
+  getLatLngs: function () {
+    return this._latlngs;
+  },
 
-	setLatLngs: function (latlngs) {
-		this._latlngs = this._convertLatLngs(latlngs);
-		return this.redraw();
-	},
+  setLatLngs: function (latlngs) {
+    this._latlngs = this._convertLatLngs(latlngs);
+    return this.redraw();
+  },
 
-	addLatLng: function (latlng) {
-		this._latlngs.push(L.latLng(latlng));
-		return this.redraw();
-	},
+  addLatLng: function (latlng) {
+    this._latlngs.push(L.latLng(latlng));
+    return this.redraw();
+  },
 
-	spliceLatLngs: function () { // (Number index, Number howMany)
-		var removed = [].splice.apply(this._latlngs, arguments);
-		this._convertLatLngs(this._latlngs, true);
-		this.redraw();
-		return removed;
-	},
+  spliceLatLngs: function () { // (Number index, Number howMany)
+    var removed = [].splice.apply(this._latlngs, arguments);
+    this._convertLatLngs(this._latlngs, true);
+    this.redraw();
+    return removed;
+  },
 
-	closestLayerPoint: function (p) {
-		var minDistance = Infinity, parts = this._parts, p1, p2, minPoint = null;
+  closestLayerPoint: function (p) {
+    var minDistance = Infinity, parts = this._parts, p1, p2, minPoint = null;
 
-		for (var j = 0, jLen = parts.length; j < jLen; j++) {
-			var points = parts[j];
-			for (var i = 1, len = points.length; i < len; i++) {
-				p1 = points[i - 1];
-				p2 = points[i];
-				var sqDist = L.LineUtil._sqClosestPointOnSegment(p, p1, p2, true);
-				if (sqDist < minDistance) {
-					minDistance = sqDist;
-					minPoint = L.LineUtil._sqClosestPointOnSegment(p, p1, p2);
-				}
-			}
-		}
-		if (minPoint) {
-			minPoint.distance = Math.sqrt(minDistance);
-		}
-		return minPoint;
-	},
+    for (var j = 0, jLen = parts.length; j < jLen; j++) {
+      var points = parts[j];
+      for (var i = 1, len = points.length; i < len; i++) {
+        p1 = points[i - 1];
+        p2 = points[i];
+        var sqDist = L.LineUtil._sqClosestPointOnSegment(p, p1, p2, true);
+        if (sqDist < minDistance) {
+          minDistance = sqDist;
+          minPoint = L.LineUtil._sqClosestPointOnSegment(p, p1, p2);
+        }
+      }
+    }
+    if (minPoint) {
+      minPoint.distance = Math.sqrt(minDistance);
+    }
+    return minPoint;
+  },
 
-	getBounds: function () {
-		return new L.LatLngBounds(this.getLatLngs());
-	},
+  getBounds: function () {
+    return new L.LatLngBounds(this.getLatLngs());
+  },
 
-	_convertLatLngs: function (latlngs, overwrite) {
-		var i, len, target = overwrite ? latlngs : [];
+  _convertLatLngs: function (latlngs, overwrite) {
+    var i, len, target = overwrite ? latlngs : [];
 
-		for (i = 0, len = latlngs.length; i < len; i++) {
-			if (L.Util.isArray(latlngs[i]) && typeof latlngs[i][0] !== 'number') {
-				return;
-			}
-			target[i] = L.latLng(latlngs[i]);
-		}
-		return target;
-	},
+    for (i = 0, len = latlngs.length; i < len; i++) {
+      if (L.Util.isArray(latlngs[i]) && typeof latlngs[i][0] !== 'number') {
+        return;
+      }
+      target[i] = L.latLng(latlngs[i]);
+    }
+    return target;
+  },
 
-	_initEvents: function () {
-		L.Path.prototype._initEvents.call(this);
-	},
+  _initEvents: function () {
+    L.Path.prototype._initEvents.call(this);
+  },
 
-	_getPathPartStr: function (points) {
-		var round = L.Path.VML;
+  _getPathPartStr: function (points) {
+    var round = L.Path.VML;
 
-		for (var j = 0, len2 = points.length, str = '', p; j < len2; j++) {
-			p = points[j];
-			if (round) {
-				p._round();
-			}
-			str += (j ? 'L' : 'M') + p.x + ' ' + p.y;
-		}
-		return str;
-	},
+    for (var j = 0, len2 = points.length, str = '', p; j < len2; j++) {
+      p = points[j];
+      if (round) {
+        p._round();
+      }
+      str += (j ? 'L' : 'M') + p.x + ' ' + p.y;
+    }
+    return str;
+  },
 
-	_clipPoints: function () {
-		var points = this._originalPoints,
-		    len = points.length,
-		    i, k, segment;
+  _clipPoints: function () {
+    var points = this._originalPoints,
+        len = points.length,
+        i, k, segment;
 
-		if (this.options.noClip) {
-			this._parts = [points];
-			return;
-		}
+    if (this.options.noClip) {
+      this._parts = [points];
+      return;
+    }
 
-		this._parts = [];
+    this._parts = [];
 
-		var parts = this._parts,
-		    vp = this._map._pathViewport,
-		    lu = L.LineUtil;
+    var parts = this._parts,
+        vp = this._map._pathViewport,
+        lu = L.LineUtil;
 
-		for (i = 0, k = 0; i < len - 1; i++) {
-			segment = lu.clipSegment(points[i], points[i + 1], vp, i);
-			if (!segment) {
-				continue;
-			}
+    for (i = 0, k = 0; i < len - 1; i++) {
+      segment = lu.clipSegment(points[i], points[i + 1], vp, i);
+      if (!segment) {
+        continue;
+      }
 
-			parts[k] = parts[k] || [];
-			parts[k].push(segment[0]);
+      parts[k] = parts[k] || [];
+      parts[k].push(segment[0]);
 
-			// if segment goes out of screen, or it's the last one, it's the end of the line part
-			if ((segment[1] !== points[i + 1]) || (i === len - 2)) {
-				parts[k].push(segment[1]);
-				k++;
-			}
-		}
-	},
+      // if segment goes out of screen, or it's the last one, it's the end of the line part
+      if ((segment[1] !== points[i + 1]) || (i === len - 2)) {
+        parts[k].push(segment[1]);
+        k++;
+      }
+    }
+  },
 
-	// simplify each clipped part of the polyline
-	_simplifyPoints: function () {
-		var parts = this._parts,
-		    lu = L.LineUtil;
+  // simplify each clipped part of the polyline
+  _simplifyPoints: function () {
+    var parts = this._parts,
+        lu = L.LineUtil;
 
-		for (var i = 0, len = parts.length; i < len; i++) {
-			parts[i] = lu.simplify(parts[i], this.options.smoothFactor);
-		}
-	},
+    for (var i = 0, len = parts.length; i < len; i++) {
+      parts[i] = lu.simplify(parts[i], this.options.smoothFactor);
+    }
+  },
 
-	_updatePath: function () {
-		if (!this._map) { return; }
+  _updatePath: function () {
+    if (!this._map) { return; }
 
-		this._clipPoints();
-		this._simplifyPoints();
+    this._clipPoints();
+    this._simplifyPoints();
 
-		L.Path.prototype._updatePath.call(this);
-	}
+    L.Path.prototype._updatePath.call(this);
+  }
 });
 
 L.polyline = function (latlngs, options) {
-	return new L.Polyline(latlngs, options);
+  return new L.Polyline(latlngs, options);
 };
 
 
@@ -13389,47 +13389,47 @@ L.PolyUtil = {};
  * Used to avoid rendering parts of a polygon that are not currently visible.
  */
 L.PolyUtil.clipPolygon = function (points, bounds) {
-	var clippedPoints,
-	    edges = [1, 4, 2, 8],
-	    i, j, k,
-	    a, b,
-	    len, edge, p,
-	    lu = L.LineUtil;
+  var clippedPoints,
+      edges = [1, 4, 2, 8],
+      i, j, k,
+      a, b,
+      len, edge, p,
+      lu = L.LineUtil;
 
-	for (i = 0, len = points.length; i < len; i++) {
-		points[i]._code = lu._getBitCode(points[i], bounds);
-	}
+  for (i = 0, len = points.length; i < len; i++) {
+    points[i]._code = lu._getBitCode(points[i], bounds);
+  }
 
-	// for each edge (left, bottom, right, top)
-	for (k = 0; k < 4; k++) {
-		edge = edges[k];
-		clippedPoints = [];
+  // for each edge (left, bottom, right, top)
+  for (k = 0; k < 4; k++) {
+    edge = edges[k];
+    clippedPoints = [];
 
-		for (i = 0, len = points.length, j = len - 1; i < len; j = i++) {
-			a = points[i];
-			b = points[j];
+    for (i = 0, len = points.length, j = len - 1; i < len; j = i++) {
+      a = points[i];
+      b = points[j];
 
-			// if a is inside the clip window
-			if (!(a._code & edge)) {
-				// if b is outside the clip window (a->b goes out of screen)
-				if (b._code & edge) {
-					p = lu._getEdgeIntersection(b, a, edge, bounds);
-					p._code = lu._getBitCode(p, bounds);
-					clippedPoints.push(p);
-				}
-				clippedPoints.push(a);
+      // if a is inside the clip window
+      if (!(a._code & edge)) {
+        // if b is outside the clip window (a->b goes out of screen)
+        if (b._code & edge) {
+          p = lu._getEdgeIntersection(b, a, edge, bounds);
+          p._code = lu._getBitCode(p, bounds);
+          clippedPoints.push(p);
+        }
+        clippedPoints.push(a);
 
-			// else if b is inside the clip window (a->b enters the screen)
-			} else if (!(b._code & edge)) {
-				p = lu._getEdgeIntersection(b, a, edge, bounds);
-				p._code = lu._getBitCode(p, bounds);
-				clippedPoints.push(p);
-			}
-		}
-		points = clippedPoints;
-	}
+      // else if b is inside the clip window (a->b enters the screen)
+      } else if (!(b._code & edge)) {
+        p = lu._getEdgeIntersection(b, a, edge, bounds);
+        p._code = lu._getBitCode(p, bounds);
+        clippedPoints.push(p);
+      }
+    }
+    points = clippedPoints;
+  }
 
-	return points;
+  return points;
 };
 
 
@@ -13442,92 +13442,92 @@ L.PolyUtil.clipPolygon = function (points, bounds) {
  */
 
 L.Polygon = L.Polyline.extend({
-	options: {
-		fill: true
-	},
+  options: {
+    fill: true
+  },
 
-	initialize: function (latlngs, options) {
-		L.Polyline.prototype.initialize.call(this, latlngs, options);
-		this._initWithHoles(latlngs);
-	},
+  initialize: function (latlngs, options) {
+    L.Polyline.prototype.initialize.call(this, latlngs, options);
+    this._initWithHoles(latlngs);
+  },
 
-	_initWithHoles: function (latlngs) {
-		var i, len, hole;
-		if (latlngs && L.Util.isArray(latlngs[0]) && (typeof latlngs[0][0] !== 'number')) {
-			this._latlngs = this._convertLatLngs(latlngs[0]);
-			this._holes = latlngs.slice(1);
+  _initWithHoles: function (latlngs) {
+    var i, len, hole;
+    if (latlngs && L.Util.isArray(latlngs[0]) && (typeof latlngs[0][0] !== 'number')) {
+      this._latlngs = this._convertLatLngs(latlngs[0]);
+      this._holes = latlngs.slice(1);
 
-			for (i = 0, len = this._holes.length; i < len; i++) {
-				hole = this._holes[i] = this._convertLatLngs(this._holes[i]);
-				if (hole[0].equals(hole[hole.length - 1])) {
-					hole.pop();
-				}
-			}
-		}
+      for (i = 0, len = this._holes.length; i < len; i++) {
+        hole = this._holes[i] = this._convertLatLngs(this._holes[i]);
+        if (hole[0].equals(hole[hole.length - 1])) {
+          hole.pop();
+        }
+      }
+    }
 
-		// filter out last point if its equal to the first one
-		latlngs = this._latlngs;
+    // filter out last point if its equal to the first one
+    latlngs = this._latlngs;
 
-		if (latlngs.length >= 2 && latlngs[0].equals(latlngs[latlngs.length - 1])) {
-			latlngs.pop();
-		}
-	},
+    if (latlngs.length >= 2 && latlngs[0].equals(latlngs[latlngs.length - 1])) {
+      latlngs.pop();
+    }
+  },
 
-	projectLatlngs: function () {
-		L.Polyline.prototype.projectLatlngs.call(this);
+  projectLatlngs: function () {
+    L.Polyline.prototype.projectLatlngs.call(this);
 
-		// project polygon holes points
-		// TODO move this logic to Polyline to get rid of duplication
-		this._holePoints = [];
+    // project polygon holes points
+    // TODO move this logic to Polyline to get rid of duplication
+    this._holePoints = [];
 
-		if (!this._holes) { return; }
+    if (!this._holes) { return; }
 
-		var i, j, len, len2;
+    var i, j, len, len2;
 
-		for (i = 0, len = this._holes.length; i < len; i++) {
-			this._holePoints[i] = [];
+    for (i = 0, len = this._holes.length; i < len; i++) {
+      this._holePoints[i] = [];
 
-			for (j = 0, len2 = this._holes[i].length; j < len2; j++) {
-				this._holePoints[i][j] = this._map.latLngToLayerPoint(this._holes[i][j]);
-			}
-		}
-	},
+      for (j = 0, len2 = this._holes[i].length; j < len2; j++) {
+        this._holePoints[i][j] = this._map.latLngToLayerPoint(this._holes[i][j]);
+      }
+    }
+  },
 
-	setLatLngs: function (latlngs) {
-		if (latlngs && L.Util.isArray(latlngs[0]) && (typeof latlngs[0][0] !== 'number')) {
-			this._initWithHoles(latlngs);
-			return this.redraw();
-		} else {
-			return L.Polyline.prototype.setLatLngs.call(this, latlngs);
-		}
-	},
+  setLatLngs: function (latlngs) {
+    if (latlngs && L.Util.isArray(latlngs[0]) && (typeof latlngs[0][0] !== 'number')) {
+      this._initWithHoles(latlngs);
+      return this.redraw();
+    } else {
+      return L.Polyline.prototype.setLatLngs.call(this, latlngs);
+    }
+  },
 
-	_clipPoints: function () {
-		var points = this._originalPoints,
-		    newParts = [];
+  _clipPoints: function () {
+    var points = this._originalPoints,
+        newParts = [];
 
-		this._parts = [points].concat(this._holePoints);
+    this._parts = [points].concat(this._holePoints);
 
-		if (this.options.noClip) { return; }
+    if (this.options.noClip) { return; }
 
-		for (var i = 0, len = this._parts.length; i < len; i++) {
-			var clipped = L.PolyUtil.clipPolygon(this._parts[i], this._map._pathViewport);
-			if (clipped.length) {
-				newParts.push(clipped);
-			}
-		}
+    for (var i = 0, len = this._parts.length; i < len; i++) {
+      var clipped = L.PolyUtil.clipPolygon(this._parts[i], this._map._pathViewport);
+      if (clipped.length) {
+        newParts.push(clipped);
+      }
+    }
 
-		this._parts = newParts;
-	},
+    this._parts = newParts;
+  },
 
-	_getPathPartStr: function (points) {
-		var str = L.Polyline.prototype._getPathPartStr.call(this, points);
-		return str + (L.Browser.svg ? 'z' : 'x');
-	}
+  _getPathPartStr: function (points) {
+    var str = L.Polyline.prototype._getPathPartStr.call(this, points);
+    return str + (L.Browser.svg ? 'z' : 'x');
+  }
 });
 
 L.polygon = function (latlngs, options) {
-	return new L.Polygon(latlngs, options);
+  return new L.Polygon(latlngs, options);
 };
 
 
@@ -13540,57 +13540,57 @@ L.polygon = function (latlngs, options) {
  */
 
 (function () {
-	function createMulti(Klass) {
+  function createMulti(Klass) {
 
-		return L.FeatureGroup.extend({
+    return L.FeatureGroup.extend({
 
-			initialize: function (latlngs, options) {
-				this._layers = {};
-				this._options = options;
-				this.setLatLngs(latlngs);
-			},
+      initialize: function (latlngs, options) {
+        this._layers = {};
+        this._options = options;
+        this.setLatLngs(latlngs);
+      },
 
-			setLatLngs: function (latlngs) {
-				var i = 0,
-				    len = latlngs.length;
+      setLatLngs: function (latlngs) {
+        var i = 0,
+            len = latlngs.length;
 
-				this.eachLayer(function (layer) {
-					if (i < len) {
-						layer.setLatLngs(latlngs[i++]);
-					} else {
-						this.removeLayer(layer);
-					}
-				}, this);
+        this.eachLayer(function (layer) {
+          if (i < len) {
+            layer.setLatLngs(latlngs[i++]);
+          } else {
+            this.removeLayer(layer);
+          }
+        }, this);
 
-				while (i < len) {
-					this.addLayer(new Klass(latlngs[i++], this._options));
-				}
+        while (i < len) {
+          this.addLayer(new Klass(latlngs[i++], this._options));
+        }
 
-				return this;
-			},
+        return this;
+      },
 
-			getLatLngs: function () {
-				var latlngs = [];
+      getLatLngs: function () {
+        var latlngs = [];
 
-				this.eachLayer(function (layer) {
-					latlngs.push(layer.getLatLngs());
-				});
+        this.eachLayer(function (layer) {
+          latlngs.push(layer.getLatLngs());
+        });
 
-				return latlngs;
-			}
-		});
-	}
+        return latlngs;
+      }
+    });
+  }
 
-	L.MultiPolyline = createMulti(L.Polyline);
-	L.MultiPolygon = createMulti(L.Polygon);
+  L.MultiPolyline = createMulti(L.Polyline);
+  L.MultiPolygon = createMulti(L.Polygon);
 
-	L.multiPolyline = function (latlngs, options) {
-		return new L.MultiPolyline(latlngs, options);
-	};
+  L.multiPolyline = function (latlngs, options) {
+    return new L.MultiPolyline(latlngs, options);
+  };
 
-	L.multiPolygon = function (latlngs, options) {
-		return new L.MultiPolygon(latlngs, options);
-	};
+  L.multiPolygon = function (latlngs, options) {
+    return new L.MultiPolygon(latlngs, options);
+  };
 }());
 
 
@@ -13603,27 +13603,27 @@ L.polygon = function (latlngs, options) {
  */
 
 L.Rectangle = L.Polygon.extend({
-	initialize: function (latLngBounds, options) {
-		L.Polygon.prototype.initialize.call(this, this._boundsToLatLngs(latLngBounds), options);
-	},
+  initialize: function (latLngBounds, options) {
+    L.Polygon.prototype.initialize.call(this, this._boundsToLatLngs(latLngBounds), options);
+  },
 
-	setBounds: function (latLngBounds) {
-		this.setLatLngs(this._boundsToLatLngs(latLngBounds));
-	},
+  setBounds: function (latLngBounds) {
+    this.setLatLngs(this._boundsToLatLngs(latLngBounds));
+  },
 
-	_boundsToLatLngs: function (latLngBounds) {
-		latLngBounds = L.latLngBounds(latLngBounds);
-		return [
-			latLngBounds.getSouthWest(),
-			latLngBounds.getNorthWest(),
-			latLngBounds.getNorthEast(),
-			latLngBounds.getSouthEast()
-		];
-	}
+  _boundsToLatLngs: function (latLngBounds) {
+    latLngBounds = L.latLngBounds(latLngBounds);
+    return [
+      latLngBounds.getSouthWest(),
+      latLngBounds.getNorthWest(),
+      latLngBounds.getNorthEast(),
+      latLngBounds.getSouthEast()
+    ];
+  }
 });
 
 L.rectangle = function (latLngBounds, options) {
-	return new L.Rectangle(latLngBounds, options);
+  return new L.Rectangle(latLngBounds, options);
 };
 
 
@@ -13636,98 +13636,98 @@ L.rectangle = function (latLngBounds, options) {
  */
 
 L.Circle = L.Path.extend({
-	initialize: function (latlng, radius, options) {
-		L.Path.prototype.initialize.call(this, options);
+  initialize: function (latlng, radius, options) {
+    L.Path.prototype.initialize.call(this, options);
 
-		this._latlng = L.latLng(latlng);
-		this._mRadius = radius;
-	},
+    this._latlng = L.latLng(latlng);
+    this._mRadius = radius;
+  },
 
-	options: {
-		fill: true
-	},
+  options: {
+    fill: true
+  },
 
-	setLatLng: function (latlng) {
-		this._latlng = L.latLng(latlng);
-		return this.redraw();
-	},
+  setLatLng: function (latlng) {
+    this._latlng = L.latLng(latlng);
+    return this.redraw();
+  },
 
-	setRadius: function (radius) {
-		this._mRadius = radius;
-		return this.redraw();
-	},
+  setRadius: function (radius) {
+    this._mRadius = radius;
+    return this.redraw();
+  },
 
-	projectLatlngs: function () {
-		var lngRadius = this._getLngRadius(),
-		    latlng = this._latlng,
-		    pointLeft = this._map.latLngToLayerPoint([latlng.lat, latlng.lng - lngRadius]);
+  projectLatlngs: function () {
+    var lngRadius = this._getLngRadius(),
+        latlng = this._latlng,
+        pointLeft = this._map.latLngToLayerPoint([latlng.lat, latlng.lng - lngRadius]);
 
-		this._point = this._map.latLngToLayerPoint(latlng);
-		this._radius = Math.max(this._point.x - pointLeft.x, 1);
-	},
+    this._point = this._map.latLngToLayerPoint(latlng);
+    this._radius = Math.max(this._point.x - pointLeft.x, 1);
+  },
 
-	getBounds: function () {
-		var lngRadius = this._getLngRadius(),
-		    latRadius = (this._mRadius / 40075017) * 360,
-		    latlng = this._latlng;
+  getBounds: function () {
+    var lngRadius = this._getLngRadius(),
+        latRadius = (this._mRadius / 40075017) * 360,
+        latlng = this._latlng;
 
-		return new L.LatLngBounds(
-		        [latlng.lat - latRadius, latlng.lng - lngRadius],
-		        [latlng.lat + latRadius, latlng.lng + lngRadius]);
-	},
+    return new L.LatLngBounds(
+            [latlng.lat - latRadius, latlng.lng - lngRadius],
+            [latlng.lat + latRadius, latlng.lng + lngRadius]);
+  },
 
-	getLatLng: function () {
-		return this._latlng;
-	},
+  getLatLng: function () {
+    return this._latlng;
+  },
 
-	getPathString: function () {
-		var p = this._point,
-		    r = this._radius;
+  getPathString: function () {
+    var p = this._point,
+        r = this._radius;
 
-		if (this._checkIfEmpty()) {
-			return '';
-		}
+    if (this._checkIfEmpty()) {
+      return '';
+    }
 
-		if (L.Browser.svg) {
-			return 'M' + p.x + ',' + (p.y - r) +
-			       'A' + r + ',' + r + ',0,1,1,' +
-			       (p.x - 0.1) + ',' + (p.y - r) + ' z';
-		} else {
-			p._round();
-			r = Math.round(r);
-			return 'AL ' + p.x + ',' + p.y + ' ' + r + ',' + r + ' 0,' + (65535 * 360);
-		}
-	},
+    if (L.Browser.svg) {
+      return 'M' + p.x + ',' + (p.y - r) +
+             'A' + r + ',' + r + ',0,1,1,' +
+             (p.x - 0.1) + ',' + (p.y - r) + ' z';
+    } else {
+      p._round();
+      r = Math.round(r);
+      return 'AL ' + p.x + ',' + p.y + ' ' + r + ',' + r + ' 0,' + (65535 * 360);
+    }
+  },
 
-	getRadius: function () {
-		return this._mRadius;
-	},
+  getRadius: function () {
+    return this._mRadius;
+  },
 
-	// TODO Earth hardcoded, move into projection code!
+  // TODO Earth hardcoded, move into projection code!
 
-	_getLatRadius: function () {
-		return (this._mRadius / 40075017) * 360;
-	},
+  _getLatRadius: function () {
+    return (this._mRadius / 40075017) * 360;
+  },
 
-	_getLngRadius: function () {
-		return this._getLatRadius() / Math.cos(L.LatLng.DEG_TO_RAD * this._latlng.lat);
-	},
+  _getLngRadius: function () {
+    return this._getLatRadius() / Math.cos(L.LatLng.DEG_TO_RAD * this._latlng.lat);
+  },
 
-	_checkIfEmpty: function () {
-		if (!this._map) {
-			return false;
-		}
-		var vp = this._map._pathViewport,
-		    r = this._radius,
-		    p = this._point;
+  _checkIfEmpty: function () {
+    if (!this._map) {
+      return false;
+    }
+    var vp = this._map._pathViewport,
+        r = this._radius,
+        p = this._point;
 
-		return p.x - r > vp.max.x || p.y - r > vp.max.y ||
-		       p.x + r < vp.min.x || p.y + r < vp.min.y;
-	}
+    return p.x - r > vp.max.x || p.y - r > vp.max.y ||
+           p.x + r < vp.min.x || p.y + r < vp.min.y;
+  }
 });
 
 L.circle = function (latlng, radius, options) {
-	return new L.Circle(latlng, radius, options);
+  return new L.Circle(latlng, radius, options);
 };
 
 
@@ -13740,45 +13740,45 @@ L.circle = function (latlng, radius, options) {
  */
 
 L.CircleMarker = L.Circle.extend({
-	options: {
-		radius: 10,
-		weight: 2
-	},
+  options: {
+    radius: 10,
+    weight: 2
+  },
 
-	initialize: function (latlng, options) {
-		L.Circle.prototype.initialize.call(this, latlng, null, options);
-		this._radius = this.options.radius;
-	},
+  initialize: function (latlng, options) {
+    L.Circle.prototype.initialize.call(this, latlng, null, options);
+    this._radius = this.options.radius;
+  },
 
-	projectLatlngs: function () {
-		this._point = this._map.latLngToLayerPoint(this._latlng);
-	},
+  projectLatlngs: function () {
+    this._point = this._map.latLngToLayerPoint(this._latlng);
+  },
 
-	_updateStyle : function () {
-		L.Circle.prototype._updateStyle.call(this);
-		this.setRadius(this.options.radius);
-	},
+  _updateStyle : function () {
+    L.Circle.prototype._updateStyle.call(this);
+    this.setRadius(this.options.radius);
+  },
 
-	setLatLng: function (latlng) {
-		L.Circle.prototype.setLatLng.call(this, latlng);
-		if (this._popup && this._popup._isOpen) {
-			this._popup.setLatLng(latlng);
-		}
-		return this;
-	},
+  setLatLng: function (latlng) {
+    L.Circle.prototype.setLatLng.call(this, latlng);
+    if (this._popup && this._popup._isOpen) {
+      this._popup.setLatLng(latlng);
+    }
+    return this;
+  },
 
-	setRadius: function (radius) {
-		this.options.radius = this._radius = radius;
-		return this.redraw();
-	},
+  setRadius: function (radius) {
+    this.options.radius = this._radius = radius;
+    return this.redraw();
+  },
 
-	getRadius: function () {
-		return this._radius;
-	}
+  getRadius: function () {
+    return this._radius;
+  }
 });
 
 L.circleMarker = function (latlng, options) {
-	return new L.CircleMarker(latlng, options);
+  return new L.CircleMarker(latlng, options);
 };
 
 
@@ -13791,30 +13791,30 @@ L.circleMarker = function (latlng, options) {
  */
 
 L.Polyline.include(!L.Path.CANVAS ? {} : {
-	_containsPoint: function (p, closed) {
-		var i, j, k, len, len2, dist, part,
-		    w = this.options.weight / 2;
+  _containsPoint: function (p, closed) {
+    var i, j, k, len, len2, dist, part,
+        w = this.options.weight / 2;
 
-		if (L.Browser.touch) {
-			w += 10; // polyline click tolerance on touch devices
-		}
+    if (L.Browser.touch) {
+      w += 10; // polyline click tolerance on touch devices
+    }
 
-		for (i = 0, len = this._parts.length; i < len; i++) {
-			part = this._parts[i];
-			for (j = 0, len2 = part.length, k = len2 - 1; j < len2; k = j++) {
-				if (!closed && (j === 0)) {
-					continue;
-				}
+    for (i = 0, len = this._parts.length; i < len; i++) {
+      part = this._parts[i];
+      for (j = 0, len2 = part.length, k = len2 - 1; j < len2; k = j++) {
+        if (!closed && (j === 0)) {
+          continue;
+        }
 
-				dist = L.LineUtil.pointToSegmentDistance(p, part[k], part[j]);
+        dist = L.LineUtil.pointToSegmentDistance(p, part[k], part[j]);
 
-				if (dist <= w) {
-					return true;
-				}
-			}
-		}
-		return false;
-	}
+        if (dist <= w) {
+          return true;
+        }
+      }
+    }
+    return false;
+  }
 });
 
 
@@ -13827,150 +13827,150 @@ L.Polyline.include(!L.Path.CANVAS ? {} : {
  */
 
 L.Map.mergeOptions({
-	dragging: true,
+  dragging: true,
 
-	inertia: !L.Browser.android23,
-	inertiaDeceleration: 3400, // px/s^2
-	inertiaMaxSpeed: Infinity, // px/s
-	inertiaThreshold: L.Browser.touch ? 32 : 18, // ms
-	easeLinearity: 0.25,
+  inertia: !L.Browser.android23,
+  inertiaDeceleration: 3400, // px/s^2
+  inertiaMaxSpeed: Infinity, // px/s
+  inertiaThreshold: L.Browser.touch ? 32 : 18, // ms
+  easeLinearity: 0.25,
 
-	// TODO refactor, move to CRS
-	worldCopyJump: false
+  // TODO refactor, move to CRS
+  worldCopyJump: false
 });
 
 L.Map.Drag = L.Handler.extend({
-	addHooks: function () {
-		if (!this._draggable) {
-			var map = this._map;
+  addHooks: function () {
+    if (!this._draggable) {
+      var map = this._map;
 
-			this._draggable = new L.Draggable(map._mapPane, map._container);
+      this._draggable = new L.Draggable(map._mapPane, map._container);
 
-			this._draggable.on({
-				'dragstart': this._onDragStart,
-				'drag': this._onDrag,
-				'dragend': this._onDragEnd
-			}, this);
+      this._draggable.on({
+        'dragstart': this._onDragStart,
+        'drag': this._onDrag,
+        'dragend': this._onDragEnd
+      }, this);
 
-			if (map.options.worldCopyJump) {
-				this._draggable.on('predrag', this._onPreDrag, this);
-				map.on('viewreset', this._onViewReset, this);
+      if (map.options.worldCopyJump) {
+        this._draggable.on('predrag', this._onPreDrag, this);
+        map.on('viewreset', this._onViewReset, this);
 
-				map.whenReady(this._onViewReset, this);
-			}
-		}
-		this._draggable.enable();
-	},
+        map.whenReady(this._onViewReset, this);
+      }
+    }
+    this._draggable.enable();
+  },
 
-	removeHooks: function () {
-		this._draggable.disable();
-	},
+  removeHooks: function () {
+    this._draggable.disable();
+  },
 
-	moved: function () {
-		return this._draggable && this._draggable._moved;
-	},
+  moved: function () {
+    return this._draggable && this._draggable._moved;
+  },
 
-	_onDragStart: function () {
-		var map = this._map;
+  _onDragStart: function () {
+    var map = this._map;
 
-		if (map._panAnim) {
-			map._panAnim.stop();
-		}
+    if (map._panAnim) {
+      map._panAnim.stop();
+    }
 
-		map
-		    .fire('movestart')
-		    .fire('dragstart');
+    map
+        .fire('movestart')
+        .fire('dragstart');
 
-		if (map.options.inertia) {
-			this._positions = [];
-			this._times = [];
-		}
-	},
+    if (map.options.inertia) {
+      this._positions = [];
+      this._times = [];
+    }
+  },
 
-	_onDrag: function () {
-		if (this._map.options.inertia) {
-			var time = this._lastTime = +new Date(),
-			    pos = this._lastPos = this._draggable._newPos;
+  _onDrag: function () {
+    if (this._map.options.inertia) {
+      var time = this._lastTime = +new Date(),
+          pos = this._lastPos = this._draggable._newPos;
 
-			this._positions.push(pos);
-			this._times.push(time);
+      this._positions.push(pos);
+      this._times.push(time);
 
-			if (time - this._times[0] > 200) {
-				this._positions.shift();
-				this._times.shift();
-			}
-		}
+      if (time - this._times[0] > 200) {
+        this._positions.shift();
+        this._times.shift();
+      }
+    }
 
-		this._map
-		    .fire('move')
-		    .fire('drag');
-	},
+    this._map
+        .fire('move')
+        .fire('drag');
+  },
 
-	_onViewReset: function () {
-		// TODO fix hardcoded Earth values
-		var pxCenter = this._map.getSize()._divideBy(2),
-		    pxWorldCenter = this._map.latLngToLayerPoint([0, 0]);
+  _onViewReset: function () {
+    // TODO fix hardcoded Earth values
+    var pxCenter = this._map.getSize()._divideBy(2),
+        pxWorldCenter = this._map.latLngToLayerPoint([0, 0]);
 
-		this._initialWorldOffset = pxWorldCenter.subtract(pxCenter).x;
-		this._worldWidth = this._map.project([0, 180]).x;
-	},
+    this._initialWorldOffset = pxWorldCenter.subtract(pxCenter).x;
+    this._worldWidth = this._map.project([0, 180]).x;
+  },
 
-	_onPreDrag: function () {
-		// TODO refactor to be able to adjust map pane position after zoom
-		var worldWidth = this._worldWidth,
-		    halfWidth = Math.round(worldWidth / 2),
-		    dx = this._initialWorldOffset,
-		    x = this._draggable._newPos.x,
-		    newX1 = (x - halfWidth + dx) % worldWidth + halfWidth - dx,
-		    newX2 = (x + halfWidth + dx) % worldWidth - halfWidth - dx,
-		    newX = Math.abs(newX1 + dx) < Math.abs(newX2 + dx) ? newX1 : newX2;
+  _onPreDrag: function () {
+    // TODO refactor to be able to adjust map pane position after zoom
+    var worldWidth = this._worldWidth,
+        halfWidth = Math.round(worldWidth / 2),
+        dx = this._initialWorldOffset,
+        x = this._draggable._newPos.x,
+        newX1 = (x - halfWidth + dx) % worldWidth + halfWidth - dx,
+        newX2 = (x + halfWidth + dx) % worldWidth - halfWidth - dx,
+        newX = Math.abs(newX1 + dx) < Math.abs(newX2 + dx) ? newX1 : newX2;
 
-		this._draggable._newPos.x = newX;
-	},
+    this._draggable._newPos.x = newX;
+  },
 
-	_onDragEnd: function (e) {
-		var map = this._map,
-		    options = map.options,
-		    delay = +new Date() - this._lastTime,
+  _onDragEnd: function (e) {
+    var map = this._map,
+        options = map.options,
+        delay = +new Date() - this._lastTime,
 
-		    noInertia = !options.inertia || delay > options.inertiaThreshold || !this._positions[0];
+        noInertia = !options.inertia || delay > options.inertiaThreshold || !this._positions[0];
 
-		map.fire('dragend', e);
+    map.fire('dragend', e);
 
-		if (noInertia) {
-			map.fire('moveend');
+    if (noInertia) {
+      map.fire('moveend');
 
-		} else {
+    } else {
 
-			var direction = this._lastPos.subtract(this._positions[0]),
-			    duration = (this._lastTime + delay - this._times[0]) / 1000,
-			    ease = options.easeLinearity,
+      var direction = this._lastPos.subtract(this._positions[0]),
+          duration = (this._lastTime + delay - this._times[0]) / 1000,
+          ease = options.easeLinearity,
 
-			    speedVector = direction.multiplyBy(ease / duration),
-			    speed = speedVector.distanceTo([0, 0]),
+          speedVector = direction.multiplyBy(ease / duration),
+          speed = speedVector.distanceTo([0, 0]),
 
-			    limitedSpeed = Math.min(options.inertiaMaxSpeed, speed),
-			    limitedSpeedVector = speedVector.multiplyBy(limitedSpeed / speed),
+          limitedSpeed = Math.min(options.inertiaMaxSpeed, speed),
+          limitedSpeedVector = speedVector.multiplyBy(limitedSpeed / speed),
 
-			    decelerationDuration = limitedSpeed / (options.inertiaDeceleration * ease),
-			    offset = limitedSpeedVector.multiplyBy(-decelerationDuration / 2).round();
+          decelerationDuration = limitedSpeed / (options.inertiaDeceleration * ease),
+          offset = limitedSpeedVector.multiplyBy(-decelerationDuration / 2).round();
 
-			if (!offset.x || !offset.y) {
-				map.fire('moveend');
+      if (!offset.x || !offset.y) {
+        map.fire('moveend');
 
-			} else {
-				offset = map._limitOffset(offset, map.options.maxBounds);
+      } else {
+        offset = map._limitOffset(offset, map.options.maxBounds);
 
-				L.Util.requestAnimFrame(function () {
-					map.panBy(offset, {
-						duration: decelerationDuration,
-						easeLinearity: ease,
-						noMoveStart: true
-					});
-				});
-			}
-		}
-	}
+        L.Util.requestAnimFrame(function () {
+          map.panBy(offset, {
+            duration: decelerationDuration,
+            easeLinearity: ease,
+            noMoveStart: true
+          });
+        });
+      }
+    }
+  }
 });
 
 L.Map.addInitHook('addHandler', 'dragging', L.Map.Drag);
@@ -13985,28 +13985,28 @@ L.Map.addInitHook('addHandler', 'dragging', L.Map.Drag);
  */
 
 L.Map.mergeOptions({
-	doubleClickZoom: true
+  doubleClickZoom: true
 });
 
 L.Map.DoubleClickZoom = L.Handler.extend({
-	addHooks: function () {
-		this._map.on('dblclick', this._onDoubleClick, this);
-	},
+  addHooks: function () {
+    this._map.on('dblclick', this._onDoubleClick, this);
+  },
 
-	removeHooks: function () {
-		this._map.off('dblclick', this._onDoubleClick, this);
-	},
+  removeHooks: function () {
+    this._map.off('dblclick', this._onDoubleClick, this);
+  },
 
-	_onDoubleClick: function (e) {
-		var map = this._map,
-		    zoom = map.getZoom() + (e.originalEvent.shiftKey ? -1 : 1);
+  _onDoubleClick: function (e) {
+    var map = this._map,
+        zoom = map.getZoom() + (e.originalEvent.shiftKey ? -1 : 1);
 
-		if (map.options.doubleClickZoom === 'center') {
-			map.setZoom(zoom);
-		} else {
-			map.setZoomAround(e.containerPoint, zoom);
-		}
-	}
+    if (map.options.doubleClickZoom === 'center') {
+      map.setZoom(zoom);
+    } else {
+      map.setZoomAround(e.containerPoint, zoom);
+    }
+  }
 });
 
 L.Map.addInitHook('addHandler', 'doubleClickZoom', L.Map.DoubleClickZoom);
@@ -14021,60 +14021,60 @@ L.Map.addInitHook('addHandler', 'doubleClickZoom', L.Map.DoubleClickZoom);
  */
 
 L.Map.mergeOptions({
-	scrollWheelZoom: true
+  scrollWheelZoom: true
 });
 
 L.Map.ScrollWheelZoom = L.Handler.extend({
-	addHooks: function () {
-		L.DomEvent.on(this._map._container, 'mousewheel', this._onWheelScroll, this);
-		L.DomEvent.on(this._map._container, 'MozMousePixelScroll', L.DomEvent.preventDefault);
-		this._delta = 0;
-	},
+  addHooks: function () {
+    L.DomEvent.on(this._map._container, 'mousewheel', this._onWheelScroll, this);
+    L.DomEvent.on(this._map._container, 'MozMousePixelScroll', L.DomEvent.preventDefault);
+    this._delta = 0;
+  },
 
-	removeHooks: function () {
-		L.DomEvent.off(this._map._container, 'mousewheel', this._onWheelScroll);
-		L.DomEvent.off(this._map._container, 'MozMousePixelScroll', L.DomEvent.preventDefault);
-	},
+  removeHooks: function () {
+    L.DomEvent.off(this._map._container, 'mousewheel', this._onWheelScroll);
+    L.DomEvent.off(this._map._container, 'MozMousePixelScroll', L.DomEvent.preventDefault);
+  },
 
-	_onWheelScroll: function (e) {
-		var delta = L.DomEvent.getWheelDelta(e);
+  _onWheelScroll: function (e) {
+    var delta = L.DomEvent.getWheelDelta(e);
 
-		this._delta += delta;
-		this._lastMousePos = this._map.mouseEventToContainerPoint(e);
+    this._delta += delta;
+    this._lastMousePos = this._map.mouseEventToContainerPoint(e);
 
-		if (!this._startTime) {
-			this._startTime = +new Date();
-		}
+    if (!this._startTime) {
+      this._startTime = +new Date();
+    }
 
-		var left = Math.max(40 - (+new Date() - this._startTime), 0);
+    var left = Math.max(40 - (+new Date() - this._startTime), 0);
 
-		clearTimeout(this._timer);
-		this._timer = setTimeout(L.bind(this._performZoom, this), left);
+    clearTimeout(this._timer);
+    this._timer = setTimeout(L.bind(this._performZoom, this), left);
 
-		L.DomEvent.preventDefault(e);
-		L.DomEvent.stopPropagation(e);
-	},
+    L.DomEvent.preventDefault(e);
+    L.DomEvent.stopPropagation(e);
+  },
 
-	_performZoom: function () {
-		var map = this._map,
-		    delta = this._delta,
-		    zoom = map.getZoom();
+  _performZoom: function () {
+    var map = this._map,
+        delta = this._delta,
+        zoom = map.getZoom();
 
-		delta = delta > 0 ? Math.ceil(delta) : Math.floor(delta);
-		delta = Math.max(Math.min(delta, 4), -4);
-		delta = map._limitZoom(zoom + delta) - zoom;
+    delta = delta > 0 ? Math.ceil(delta) : Math.floor(delta);
+    delta = Math.max(Math.min(delta, 4), -4);
+    delta = map._limitZoom(zoom + delta) - zoom;
 
-		this._delta = 0;
-		this._startTime = null;
+    this._delta = 0;
+    this._startTime = null;
 
-		if (!delta) { return; }
+    if (!delta) { return; }
 
-		if (map.options.scrollWheelZoom === 'center') {
-			map.setZoom(zoom + delta);
-		} else {
-			map.setZoomAround(this._lastMousePos, zoom + delta);
-		}
-	}
+    if (map.options.scrollWheelZoom === 'center') {
+      map.setZoom(zoom + delta);
+    } else {
+      map.setZoomAround(this._lastMousePos, zoom + delta);
+    }
+  }
 });
 
 L.Map.addInitHook('addHandler', 'scrollWheelZoom', L.Map.ScrollWheelZoom);
@@ -14090,103 +14090,103 @@ L.Map.addInitHook('addHandler', 'scrollWheelZoom', L.Map.ScrollWheelZoom);
 
 L.extend(L.DomEvent, {
 
-	_touchstart: L.Browser.msPointer ? 'MSPointerDown' : L.Browser.pointer ? 'pointerdown' : 'touchstart',
-	_touchend: L.Browser.msPointer ? 'MSPointerUp' : L.Browser.pointer ? 'pointerup' : 'touchend',
+  _touchstart: L.Browser.msPointer ? 'MSPointerDown' : L.Browser.pointer ? 'pointerdown' : 'touchstart',
+  _touchend: L.Browser.msPointer ? 'MSPointerUp' : L.Browser.pointer ? 'pointerup' : 'touchend',
 
-	// inspired by Zepto touch code by Thomas Fuchs
-	addDoubleTapListener: function (obj, handler, id) {
-		var last,
-		    doubleTap = false,
-		    delay = 250,
-		    touch,
-		    pre = '_leaflet_',
-		    touchstart = this._touchstart,
-		    touchend = this._touchend,
-		    trackedTouches = [];
+  // inspired by Zepto touch code by Thomas Fuchs
+  addDoubleTapListener: function (obj, handler, id) {
+    var last,
+        doubleTap = false,
+        delay = 250,
+        touch,
+        pre = '_leaflet_',
+        touchstart = this._touchstart,
+        touchend = this._touchend,
+        trackedTouches = [];
 
-		function onTouchStart(e) {
-			var count;
+    function onTouchStart(e) {
+      var count;
 
-			if (L.Browser.pointer) {
-				trackedTouches.push(e.pointerId);
-				count = trackedTouches.length;
-			} else {
-				count = e.touches.length;
-			}
-			if (count > 1) {
-				return;
-			}
+      if (L.Browser.pointer) {
+        trackedTouches.push(e.pointerId);
+        count = trackedTouches.length;
+      } else {
+        count = e.touches.length;
+      }
+      if (count > 1) {
+        return;
+      }
 
-			var now = Date.now(),
-				delta = now - (last || now);
+      var now = Date.now(),
+        delta = now - (last || now);
 
-			touch = e.touches ? e.touches[0] : e;
-			doubleTap = (delta > 0 && delta <= delay);
-			last = now;
-		}
+      touch = e.touches ? e.touches[0] : e;
+      doubleTap = (delta > 0 && delta <= delay);
+      last = now;
+    }
 
-		function onTouchEnd(e) {
-			if (L.Browser.pointer) {
-				var idx = trackedTouches.indexOf(e.pointerId);
-				if (idx === -1) {
-					return;
-				}
-				trackedTouches.splice(idx, 1);
-			}
+    function onTouchEnd(e) {
+      if (L.Browser.pointer) {
+        var idx = trackedTouches.indexOf(e.pointerId);
+        if (idx === -1) {
+          return;
+        }
+        trackedTouches.splice(idx, 1);
+      }
 
-			if (doubleTap) {
-				if (L.Browser.pointer) {
-					// work around .type being readonly with MSPointer* events
-					var newTouch = { },
-						prop;
+      if (doubleTap) {
+        if (L.Browser.pointer) {
+          // work around .type being readonly with MSPointer* events
+          var newTouch = { },
+            prop;
 
-					// jshint forin:false
-					for (var i in touch) {
-						prop = touch[i];
-						if (typeof prop === 'function') {
-							newTouch[i] = prop.bind(touch);
-						} else {
-							newTouch[i] = prop;
-						}
-					}
-					touch = newTouch;
-				}
-				touch.type = 'dblclick';
-				handler(touch);
-				last = null;
-			}
-		}
-		obj[pre + touchstart + id] = onTouchStart;
-		obj[pre + touchend + id] = onTouchEnd;
+          // jshint forin:false
+          for (var i in touch) {
+            prop = touch[i];
+            if (typeof prop === 'function') {
+              newTouch[i] = prop.bind(touch);
+            } else {
+              newTouch[i] = prop;
+            }
+          }
+          touch = newTouch;
+        }
+        touch.type = 'dblclick';
+        handler(touch);
+        last = null;
+      }
+    }
+    obj[pre + touchstart + id] = onTouchStart;
+    obj[pre + touchend + id] = onTouchEnd;
 
-		// on pointer we need to listen on the document, otherwise a drag starting on the map and moving off screen
-		// will not come through to us, so we will lose track of how many touches are ongoing
-		var endElement = L.Browser.pointer ? document.documentElement : obj;
+    // on pointer we need to listen on the document, otherwise a drag starting on the map and moving off screen
+    // will not come through to us, so we will lose track of how many touches are ongoing
+    var endElement = L.Browser.pointer ? document.documentElement : obj;
 
-		obj.addEventListener(touchstart, onTouchStart, false);
-		endElement.addEventListener(touchend, onTouchEnd, false);
+    obj.addEventListener(touchstart, onTouchStart, false);
+    endElement.addEventListener(touchend, onTouchEnd, false);
 
-		if (L.Browser.pointer) {
-			endElement.addEventListener(L.DomEvent.POINTER_CANCEL, onTouchEnd, false);
-		}
+    if (L.Browser.pointer) {
+      endElement.addEventListener(L.DomEvent.POINTER_CANCEL, onTouchEnd, false);
+    }
 
-		return this;
-	},
+    return this;
+  },
 
-	removeDoubleTapListener: function (obj, id) {
-		var pre = '_leaflet_';
+  removeDoubleTapListener: function (obj, id) {
+    var pre = '_leaflet_';
 
-		obj.removeEventListener(this._touchstart, obj[pre + this._touchstart + id], false);
-		(L.Browser.pointer ? document.documentElement : obj).removeEventListener(
-		        this._touchend, obj[pre + this._touchend + id], false);
+    obj.removeEventListener(this._touchstart, obj[pre + this._touchstart + id], false);
+    (L.Browser.pointer ? document.documentElement : obj).removeEventListener(
+            this._touchend, obj[pre + this._touchend + id], false);
 
-		if (L.Browser.pointer) {
-			document.documentElement.removeEventListener(L.DomEvent.POINTER_CANCEL, obj[pre + this._touchend + id],
-				false);
-		}
+    if (L.Browser.pointer) {
+      document.documentElement.removeEventListener(L.DomEvent.POINTER_CANCEL, obj[pre + this._touchend + id],
+        false);
+    }
 
-		return this;
-	}
+    return this;
+  }
 });
 
 
@@ -14200,154 +14200,154 @@ L.extend(L.DomEvent, {
 
 L.extend(L.DomEvent, {
 
-	//static
-	POINTER_DOWN: L.Browser.msPointer ? 'MSPointerDown' : 'pointerdown',
-	POINTER_MOVE: L.Browser.msPointer ? 'MSPointerMove' : 'pointermove',
-	POINTER_UP: L.Browser.msPointer ? 'MSPointerUp' : 'pointerup',
-	POINTER_CANCEL: L.Browser.msPointer ? 'MSPointerCancel' : 'pointercancel',
+  //static
+  POINTER_DOWN: L.Browser.msPointer ? 'MSPointerDown' : 'pointerdown',
+  POINTER_MOVE: L.Browser.msPointer ? 'MSPointerMove' : 'pointermove',
+  POINTER_UP: L.Browser.msPointer ? 'MSPointerUp' : 'pointerup',
+  POINTER_CANCEL: L.Browser.msPointer ? 'MSPointerCancel' : 'pointercancel',
 
-	_pointers: [],
-	_pointerDocumentListener: false,
+  _pointers: [],
+  _pointerDocumentListener: false,
 
-	// Provides a touch events wrapper for (ms)pointer events.
-	// Based on changes by veproza https://github.com/CloudMade/Leaflet/pull/1019
-	//ref http://www.w3.org/TR/pointerevents/ https://www.w3.org/Bugs/Public/show_bug.cgi?id=22890
+  // Provides a touch events wrapper for (ms)pointer events.
+  // Based on changes by veproza https://github.com/CloudMade/Leaflet/pull/1019
+  //ref http://www.w3.org/TR/pointerevents/ https://www.w3.org/Bugs/Public/show_bug.cgi?id=22890
 
-	addPointerListener: function (obj, type, handler, id) {
+  addPointerListener: function (obj, type, handler, id) {
 
-		switch (type) {
-		case 'touchstart':
-			return this.addPointerListenerStart(obj, type, handler, id);
-		case 'touchend':
-			return this.addPointerListenerEnd(obj, type, handler, id);
-		case 'touchmove':
-			return this.addPointerListenerMove(obj, type, handler, id);
-		default:
-			throw 'Unknown touch event type';
-		}
-	},
+    switch (type) {
+    case 'touchstart':
+      return this.addPointerListenerStart(obj, type, handler, id);
+    case 'touchend':
+      return this.addPointerListenerEnd(obj, type, handler, id);
+    case 'touchmove':
+      return this.addPointerListenerMove(obj, type, handler, id);
+    default:
+      throw 'Unknown touch event type';
+    }
+  },
 
-	addPointerListenerStart: function (obj, type, handler, id) {
-		var pre = '_leaflet_',
-		    pointers = this._pointers;
+  addPointerListenerStart: function (obj, type, handler, id) {
+    var pre = '_leaflet_',
+        pointers = this._pointers;
 
-		var cb = function (e) {
+    var cb = function (e) {
 
-			L.DomEvent.preventDefault(e);
+      L.DomEvent.preventDefault(e);
 
-			var alreadyInArray = false;
-			for (var i = 0; i < pointers.length; i++) {
-				if (pointers[i].pointerId === e.pointerId) {
-					alreadyInArray = true;
-					break;
-				}
-			}
-			if (!alreadyInArray) {
-				pointers.push(e);
-			}
+      var alreadyInArray = false;
+      for (var i = 0; i < pointers.length; i++) {
+        if (pointers[i].pointerId === e.pointerId) {
+          alreadyInArray = true;
+          break;
+        }
+      }
+      if (!alreadyInArray) {
+        pointers.push(e);
+      }
 
-			e.touches = pointers.slice();
-			e.changedTouches = [e];
+      e.touches = pointers.slice();
+      e.changedTouches = [e];
 
-			handler(e);
-		};
+      handler(e);
+    };
 
-		obj[pre + 'touchstart' + id] = cb;
-		obj.addEventListener(this.POINTER_DOWN, cb, false);
+    obj[pre + 'touchstart' + id] = cb;
+    obj.addEventListener(this.POINTER_DOWN, cb, false);
 
-		// need to also listen for end events to keep the _pointers list accurate
-		// this needs to be on the body and never go away
-		if (!this._pointerDocumentListener) {
-			var internalCb = function (e) {
-				for (var i = 0; i < pointers.length; i++) {
-					if (pointers[i].pointerId === e.pointerId) {
-						pointers.splice(i, 1);
-						break;
-					}
-				}
-			};
-			//We listen on the documentElement as any drags that end by moving the touch off the screen get fired there
-			document.documentElement.addEventListener(this.POINTER_UP, internalCb, false);
-			document.documentElement.addEventListener(this.POINTER_CANCEL, internalCb, false);
+    // need to also listen for end events to keep the _pointers list accurate
+    // this needs to be on the body and never go away
+    if (!this._pointerDocumentListener) {
+      var internalCb = function (e) {
+        for (var i = 0; i < pointers.length; i++) {
+          if (pointers[i].pointerId === e.pointerId) {
+            pointers.splice(i, 1);
+            break;
+          }
+        }
+      };
+      //We listen on the documentElement as any drags that end by moving the touch off the screen get fired there
+      document.documentElement.addEventListener(this.POINTER_UP, internalCb, false);
+      document.documentElement.addEventListener(this.POINTER_CANCEL, internalCb, false);
 
-			this._pointerDocumentListener = true;
-		}
+      this._pointerDocumentListener = true;
+    }
 
-		return this;
-	},
+    return this;
+  },
 
-	addPointerListenerMove: function (obj, type, handler, id) {
-		var pre = '_leaflet_',
-		    touches = this._pointers;
+  addPointerListenerMove: function (obj, type, handler, id) {
+    var pre = '_leaflet_',
+        touches = this._pointers;
 
-		function cb(e) {
+    function cb(e) {
 
-			// don't fire touch moves when mouse isn't down
-			if ((e.pointerType === e.MSPOINTER_TYPE_MOUSE || e.pointerType === 'mouse') && e.buttons === 0) { return; }
+      // don't fire touch moves when mouse isn't down
+      if ((e.pointerType === e.MSPOINTER_TYPE_MOUSE || e.pointerType === 'mouse') && e.buttons === 0) { return; }
 
-			for (var i = 0; i < touches.length; i++) {
-				if (touches[i].pointerId === e.pointerId) {
-					touches[i] = e;
-					break;
-				}
-			}
+      for (var i = 0; i < touches.length; i++) {
+        if (touches[i].pointerId === e.pointerId) {
+          touches[i] = e;
+          break;
+        }
+      }
 
-			e.touches = touches.slice();
-			e.changedTouches = [e];
+      e.touches = touches.slice();
+      e.changedTouches = [e];
 
-			handler(e);
-		}
+      handler(e);
+    }
 
-		obj[pre + 'touchmove' + id] = cb;
-		obj.addEventListener(this.POINTER_MOVE, cb, false);
+    obj[pre + 'touchmove' + id] = cb;
+    obj.addEventListener(this.POINTER_MOVE, cb, false);
 
-		return this;
-	},
+    return this;
+  },
 
-	addPointerListenerEnd: function (obj, type, handler, id) {
-		var pre = '_leaflet_',
-		    touches = this._pointers;
+  addPointerListenerEnd: function (obj, type, handler, id) {
+    var pre = '_leaflet_',
+        touches = this._pointers;
 
-		var cb = function (e) {
-			for (var i = 0; i < touches.length; i++) {
-				if (touches[i].pointerId === e.pointerId) {
-					touches.splice(i, 1);
-					break;
-				}
-			}
+    var cb = function (e) {
+      for (var i = 0; i < touches.length; i++) {
+        if (touches[i].pointerId === e.pointerId) {
+          touches.splice(i, 1);
+          break;
+        }
+      }
 
-			e.touches = touches.slice();
-			e.changedTouches = [e];
+      e.touches = touches.slice();
+      e.changedTouches = [e];
 
-			handler(e);
-		};
+      handler(e);
+    };
 
-		obj[pre + 'touchend' + id] = cb;
-		obj.addEventListener(this.POINTER_UP, cb, false);
-		obj.addEventListener(this.POINTER_CANCEL, cb, false);
+    obj[pre + 'touchend' + id] = cb;
+    obj.addEventListener(this.POINTER_UP, cb, false);
+    obj.addEventListener(this.POINTER_CANCEL, cb, false);
 
-		return this;
-	},
+    return this;
+  },
 
-	removePointerListener: function (obj, type, id) {
-		var pre = '_leaflet_',
-		    cb = obj[pre + type + id];
+  removePointerListener: function (obj, type, id) {
+    var pre = '_leaflet_',
+        cb = obj[pre + type + id];
 
-		switch (type) {
-		case 'touchstart':
-			obj.removeEventListener(this.POINTER_DOWN, cb, false);
-			break;
-		case 'touchmove':
-			obj.removeEventListener(this.POINTER_MOVE, cb, false);
-			break;
-		case 'touchend':
-			obj.removeEventListener(this.POINTER_UP, cb, false);
-			obj.removeEventListener(this.POINTER_CANCEL, cb, false);
-			break;
-		}
+    switch (type) {
+    case 'touchstart':
+      obj.removeEventListener(this.POINTER_DOWN, cb, false);
+      break;
+    case 'touchmove':
+      obj.removeEventListener(this.POINTER_MOVE, cb, false);
+      break;
+    case 'touchend':
+      obj.removeEventListener(this.POINTER_UP, cb, false);
+      obj.removeEventListener(this.POINTER_CANCEL, cb, false);
+      break;
+    }
 
-		return this;
-	}
+    return this;
+  }
 });
 
 
@@ -14360,125 +14360,125 @@ L.extend(L.DomEvent, {
  */
 
 L.Map.mergeOptions({
-	touchZoom: L.Browser.touch && !L.Browser.android23,
-	bounceAtZoomLimits: true
+  touchZoom: L.Browser.touch && !L.Browser.android23,
+  bounceAtZoomLimits: true
 });
 
 L.Map.TouchZoom = L.Handler.extend({
-	addHooks: function () {
-		L.DomEvent.on(this._map._container, 'touchstart', this._onTouchStart, this);
-	},
+  addHooks: function () {
+    L.DomEvent.on(this._map._container, 'touchstart', this._onTouchStart, this);
+  },
 
-	removeHooks: function () {
-		L.DomEvent.off(this._map._container, 'touchstart', this._onTouchStart, this);
-	},
+  removeHooks: function () {
+    L.DomEvent.off(this._map._container, 'touchstart', this._onTouchStart, this);
+  },
 
-	_onTouchStart: function (e) {
-		var map = this._map;
+  _onTouchStart: function (e) {
+    var map = this._map;
 
-		if (!e.touches || e.touches.length !== 2 || map._animatingZoom || this._zooming) { return; }
+    if (!e.touches || e.touches.length !== 2 || map._animatingZoom || this._zooming) { return; }
 
-		var p1 = map.mouseEventToLayerPoint(e.touches[0]),
-		    p2 = map.mouseEventToLayerPoint(e.touches[1]),
-		    viewCenter = map._getCenterLayerPoint();
+    var p1 = map.mouseEventToLayerPoint(e.touches[0]),
+        p2 = map.mouseEventToLayerPoint(e.touches[1]),
+        viewCenter = map._getCenterLayerPoint();
 
-		this._startCenter = p1.add(p2)._divideBy(2);
-		this._startDist = p1.distanceTo(p2);
+    this._startCenter = p1.add(p2)._divideBy(2);
+    this._startDist = p1.distanceTo(p2);
 
-		this._moved = false;
-		this._zooming = true;
+    this._moved = false;
+    this._zooming = true;
 
-		this._centerOffset = viewCenter.subtract(this._startCenter);
+    this._centerOffset = viewCenter.subtract(this._startCenter);
 
-		if (map._panAnim) {
-			map._panAnim.stop();
-		}
+    if (map._panAnim) {
+      map._panAnim.stop();
+    }
 
-		L.DomEvent
-		    .on(document, 'touchmove', this._onTouchMove, this)
-		    .on(document, 'touchend', this._onTouchEnd, this);
+    L.DomEvent
+        .on(document, 'touchmove', this._onTouchMove, this)
+        .on(document, 'touchend', this._onTouchEnd, this);
 
-		L.DomEvent.preventDefault(e);
-	},
+    L.DomEvent.preventDefault(e);
+  },
 
-	_onTouchMove: function (e) {
-		var map = this._map;
+  _onTouchMove: function (e) {
+    var map = this._map;
 
-		if (!e.touches || e.touches.length !== 2 || !this._zooming) { return; }
+    if (!e.touches || e.touches.length !== 2 || !this._zooming) { return; }
 
-		var p1 = map.mouseEventToLayerPoint(e.touches[0]),
-		    p2 = map.mouseEventToLayerPoint(e.touches[1]);
+    var p1 = map.mouseEventToLayerPoint(e.touches[0]),
+        p2 = map.mouseEventToLayerPoint(e.touches[1]);
 
-		this._scale = p1.distanceTo(p2) / this._startDist;
-		this._delta = p1._add(p2)._divideBy(2)._subtract(this._startCenter);
+    this._scale = p1.distanceTo(p2) / this._startDist;
+    this._delta = p1._add(p2)._divideBy(2)._subtract(this._startCenter);
 
-		if (this._scale === 1) { return; }
+    if (this._scale === 1) { return; }
 
-		if (!map.options.bounceAtZoomLimits) {
-			if ((map.getZoom() === map.getMinZoom() && this._scale < 1) ||
-			    (map.getZoom() === map.getMaxZoom() && this._scale > 1)) { return; }
-		}
+    if (!map.options.bounceAtZoomLimits) {
+      if ((map.getZoom() === map.getMinZoom() && this._scale < 1) ||
+          (map.getZoom() === map.getMaxZoom() && this._scale > 1)) { return; }
+    }
 
-		if (!this._moved) {
-			L.DomUtil.addClass(map._mapPane, 'leaflet-touching');
+    if (!this._moved) {
+      L.DomUtil.addClass(map._mapPane, 'leaflet-touching');
 
-			map
-			    .fire('movestart')
-			    .fire('zoomstart');
+      map
+          .fire('movestart')
+          .fire('zoomstart');
 
-			this._moved = true;
-		}
+      this._moved = true;
+    }
 
-		L.Util.cancelAnimFrame(this._animRequest);
-		this._animRequest = L.Util.requestAnimFrame(
-		        this._updateOnMove, this, true, this._map._container);
+    L.Util.cancelAnimFrame(this._animRequest);
+    this._animRequest = L.Util.requestAnimFrame(
+            this._updateOnMove, this, true, this._map._container);
 
-		L.DomEvent.preventDefault(e);
-	},
+    L.DomEvent.preventDefault(e);
+  },
 
-	_updateOnMove: function () {
-		var map = this._map,
-		    origin = this._getScaleOrigin(),
-		    center = map.layerPointToLatLng(origin),
-		    zoom = map.getScaleZoom(this._scale);
+  _updateOnMove: function () {
+    var map = this._map,
+        origin = this._getScaleOrigin(),
+        center = map.layerPointToLatLng(origin),
+        zoom = map.getScaleZoom(this._scale);
 
-		map._animateZoom(center, zoom, this._startCenter, this._scale, this._delta);
-	},
+    map._animateZoom(center, zoom, this._startCenter, this._scale, this._delta);
+  },
 
-	_onTouchEnd: function () {
-		if (!this._moved || !this._zooming) {
-			this._zooming = false;
-			return;
-		}
+  _onTouchEnd: function () {
+    if (!this._moved || !this._zooming) {
+      this._zooming = false;
+      return;
+    }
 
-		var map = this._map;
+    var map = this._map;
 
-		this._zooming = false;
-		L.DomUtil.removeClass(map._mapPane, 'leaflet-touching');
-		L.Util.cancelAnimFrame(this._animRequest);
+    this._zooming = false;
+    L.DomUtil.removeClass(map._mapPane, 'leaflet-touching');
+    L.Util.cancelAnimFrame(this._animRequest);
 
-		L.DomEvent
-		    .off(document, 'touchmove', this._onTouchMove)
-		    .off(document, 'touchend', this._onTouchEnd);
+    L.DomEvent
+        .off(document, 'touchmove', this._onTouchMove)
+        .off(document, 'touchend', this._onTouchEnd);
 
-		var origin = this._getScaleOrigin(),
-		    center = map.layerPointToLatLng(origin),
+    var origin = this._getScaleOrigin(),
+        center = map.layerPointToLatLng(origin),
 
-		    oldZoom = map.getZoom(),
-		    floatZoomDelta = map.getScaleZoom(this._scale) - oldZoom,
-		    roundZoomDelta = (floatZoomDelta > 0 ?
-		            Math.ceil(floatZoomDelta) : Math.floor(floatZoomDelta)),
+        oldZoom = map.getZoom(),
+        floatZoomDelta = map.getScaleZoom(this._scale) - oldZoom,
+        roundZoomDelta = (floatZoomDelta > 0 ?
+                Math.ceil(floatZoomDelta) : Math.floor(floatZoomDelta)),
 
-		    zoom = map._limitZoom(oldZoom + roundZoomDelta),
-		    scale = map.getZoomScale(zoom) / this._scale;
+        zoom = map._limitZoom(oldZoom + roundZoomDelta),
+        scale = map.getZoomScale(zoom) / this._scale;
 
-		map._animateZoom(center, zoom, origin, scale);
-	},
+    map._animateZoom(center, zoom, origin, scale);
+  },
 
-	_getScaleOrigin: function () {
-		var centerOffset = this._centerOffset.subtract(this._delta).divideBy(this._scale);
-		return this._startCenter.add(centerOffset);
-	}
+  _getScaleOrigin: function () {
+    var centerOffset = this._centerOffset.subtract(this._delta).divideBy(this._scale);
+    return this._startCenter.add(centerOffset);
+  }
 });
 
 L.Map.addInitHook('addHandler', 'touchZoom', L.Map.TouchZoom);
@@ -14493,107 +14493,107 @@ L.Map.addInitHook('addHandler', 'touchZoom', L.Map.TouchZoom);
  */
 
 L.Map.mergeOptions({
-	tap: true,
-	tapTolerance: 15
+  tap: true,
+  tapTolerance: 15
 });
 
 L.Map.Tap = L.Handler.extend({
-	addHooks: function () {
-		L.DomEvent.on(this._map._container, 'touchstart', this._onDown, this);
-	},
+  addHooks: function () {
+    L.DomEvent.on(this._map._container, 'touchstart', this._onDown, this);
+  },
 
-	removeHooks: function () {
-		L.DomEvent.off(this._map._container, 'touchstart', this._onDown, this);
-	},
+  removeHooks: function () {
+    L.DomEvent.off(this._map._container, 'touchstart', this._onDown, this);
+  },
 
-	_onDown: function (e) {
-		if (!e.touches) { return; }
+  _onDown: function (e) {
+    if (!e.touches) { return; }
 
-		L.DomEvent.preventDefault(e);
+    L.DomEvent.preventDefault(e);
 
-		this._fireClick = true;
+    this._fireClick = true;
 
-		// don't simulate click or track longpress if more than 1 touch
-		if (e.touches.length > 1) {
-			this._fireClick = false;
-			clearTimeout(this._holdTimeout);
-			return;
-		}
+    // don't simulate click or track longpress if more than 1 touch
+    if (e.touches.length > 1) {
+      this._fireClick = false;
+      clearTimeout(this._holdTimeout);
+      return;
+    }
 
-		var first = e.touches[0],
-		    el = first.target;
+    var first = e.touches[0],
+        el = first.target;
 
-		this._startPos = this._newPos = new L.Point(first.clientX, first.clientY);
+    this._startPos = this._newPos = new L.Point(first.clientX, first.clientY);
 
-		// if touching a link, highlight it
-		if (el.tagName && el.tagName.toLowerCase() === 'a') {
-			L.DomUtil.addClass(el, 'leaflet-active');
-		}
+    // if touching a link, highlight it
+    if (el.tagName && el.tagName.toLowerCase() === 'a') {
+      L.DomUtil.addClass(el, 'leaflet-active');
+    }
 
-		// simulate long hold but setting a timeout
-		this._holdTimeout = setTimeout(L.bind(function () {
-			if (this._isTapValid()) {
-				this._fireClick = false;
-				this._onUp();
-				this._simulateEvent('contextmenu', first);
-			}
-		}, this), 1000);
+    // simulate long hold but setting a timeout
+    this._holdTimeout = setTimeout(L.bind(function () {
+      if (this._isTapValid()) {
+        this._fireClick = false;
+        this._onUp();
+        this._simulateEvent('contextmenu', first);
+      }
+    }, this), 1000);
 
-		L.DomEvent
-			.on(document, 'touchmove', this._onMove, this)
-			.on(document, 'touchend', this._onUp, this);
-	},
+    L.DomEvent
+      .on(document, 'touchmove', this._onMove, this)
+      .on(document, 'touchend', this._onUp, this);
+  },
 
-	_onUp: function (e) {
-		clearTimeout(this._holdTimeout);
+  _onUp: function (e) {
+    clearTimeout(this._holdTimeout);
 
-		L.DomEvent
-			.off(document, 'touchmove', this._onMove, this)
-			.off(document, 'touchend', this._onUp, this);
+    L.DomEvent
+      .off(document, 'touchmove', this._onMove, this)
+      .off(document, 'touchend', this._onUp, this);
 
-		if (this._fireClick && e && e.changedTouches) {
+    if (this._fireClick && e && e.changedTouches) {
 
-			var first = e.changedTouches[0],
-			    el = first.target;
+      var first = e.changedTouches[0],
+          el = first.target;
 
-			if (el && el.tagName && el.tagName.toLowerCase() === 'a') {
-				L.DomUtil.removeClass(el, 'leaflet-active');
-			}
+      if (el && el.tagName && el.tagName.toLowerCase() === 'a') {
+        L.DomUtil.removeClass(el, 'leaflet-active');
+      }
 
-			// simulate click if the touch didn't move too much
-			if (this._isTapValid()) {
-				this._simulateEvent('click', first);
-			}
-		}
-	},
+      // simulate click if the touch didn't move too much
+      if (this._isTapValid()) {
+        this._simulateEvent('click', first);
+      }
+    }
+  },
 
-	_isTapValid: function () {
-		return this._newPos.distanceTo(this._startPos) <= this._map.options.tapTolerance;
-	},
+  _isTapValid: function () {
+    return this._newPos.distanceTo(this._startPos) <= this._map.options.tapTolerance;
+  },
 
-	_onMove: function (e) {
-		var first = e.touches[0];
-		this._newPos = new L.Point(first.clientX, first.clientY);
-	},
+  _onMove: function (e) {
+    var first = e.touches[0];
+    this._newPos = new L.Point(first.clientX, first.clientY);
+  },
 
-	_simulateEvent: function (type, e) {
-		var simulatedEvent = document.createEvent('MouseEvents');
+  _simulateEvent: function (type, e) {
+    var simulatedEvent = document.createEvent('MouseEvents');
 
-		simulatedEvent._simulated = true;
-		e.target._simulatedClick = true;
+    simulatedEvent._simulated = true;
+    e.target._simulatedClick = true;
 
-		simulatedEvent.initMouseEvent(
-		        type, true, true, window, 1,
-		        e.screenX, e.screenY,
-		        e.clientX, e.clientY,
-		        false, false, false, false, 0, null);
+    simulatedEvent.initMouseEvent(
+            type, true, true, window, 1,
+            e.screenX, e.screenY,
+            e.clientX, e.clientY,
+            false, false, false, false, 0, null);
 
-		e.target.dispatchEvent(simulatedEvent);
-	}
+    e.target.dispatchEvent(simulatedEvent);
+  }
 });
 
 if (L.Browser.touch && !L.Browser.pointer) {
-	L.Map.addInitHook('addHandler', 'tap', L.Map.Tap);
+  L.Map.addInitHook('addHandler', 'tap', L.Map.Tap);
 }
 
 
@@ -14606,93 +14606,93 @@ if (L.Browser.touch && !L.Browser.pointer) {
  */
 
 L.Control.Zoom = L.Control.extend({
-	options: {
-		position: 'topleft',
-		zoomInText: '+',
-		zoomInTitle: 'Zoom in',
-		zoomOutText: '-',
-		zoomOutTitle: 'Zoom out'
-	},
+  options: {
+    position: 'topleft',
+    zoomInText: '+',
+    zoomInTitle: 'Zoom in',
+    zoomOutText: '-',
+    zoomOutTitle: 'Zoom out'
+  },
 
-	onAdd: function (map) {
-		var zoomName = 'leaflet-control-zoom',
-		    container = L.DomUtil.create('div', zoomName + ' leaflet-bar');
+  onAdd: function (map) {
+    var zoomName = 'leaflet-control-zoom',
+        container = L.DomUtil.create('div', zoomName + ' leaflet-bar');
 
-		this._map = map;
+    this._map = map;
 
-		this._zoomInButton  = this._createButton(
-		        this.options.zoomInText, this.options.zoomInTitle,
-		        zoomName + '-in',  container, this._zoomIn,  this);
-		this._zoomOutButton = this._createButton(
-		        this.options.zoomOutText, this.options.zoomOutTitle,
-		        zoomName + '-out', container, this._zoomOut, this);
+    this._zoomInButton  = this._createButton(
+            this.options.zoomInText, this.options.zoomInTitle,
+            zoomName + '-in',  container, this._zoomIn,  this);
+    this._zoomOutButton = this._createButton(
+            this.options.zoomOutText, this.options.zoomOutTitle,
+            zoomName + '-out', container, this._zoomOut, this);
 
-		this._updateDisabled();
-		map.on('zoomend zoomlevelschange', this._updateDisabled, this);
+    this._updateDisabled();
+    map.on('zoomend zoomlevelschange', this._updateDisabled, this);
 
-		return container;
-	},
+    return container;
+  },
 
-	onRemove: function (map) {
-		map.off('zoomend zoomlevelschange', this._updateDisabled, this);
-	},
+  onRemove: function (map) {
+    map.off('zoomend zoomlevelschange', this._updateDisabled, this);
+  },
 
-	_zoomIn: function (e) {
-		this._map.zoomIn(e.shiftKey ? 3 : 1);
-	},
+  _zoomIn: function (e) {
+    this._map.zoomIn(e.shiftKey ? 3 : 1);
+  },
 
-	_zoomOut: function (e) {
-		this._map.zoomOut(e.shiftKey ? 3 : 1);
-	},
+  _zoomOut: function (e) {
+    this._map.zoomOut(e.shiftKey ? 3 : 1);
+  },
 
-	_createButton: function (html, title, className, container, fn, context) {
-		var link = L.DomUtil.create('a', className, container);
-		link.innerHTML = html;
-		link.href = '#';
-		link.title = title;
+  _createButton: function (html, title, className, container, fn, context) {
+    var link = L.DomUtil.create('a', className, container);
+    link.innerHTML = html;
+    link.href = '#';
+    link.title = title;
 
-		var stop = L.DomEvent.stopPropagation;
+    var stop = L.DomEvent.stopPropagation;
 
-		L.DomEvent
-		    .on(link, 'click', stop)
-		    .on(link, 'mousedown', stop)
-		    .on(link, 'dblclick', stop)
-		    .on(link, 'click', L.DomEvent.preventDefault)
-		    .on(link, 'click', fn, context)
-		    .on(link, 'click', this._refocusOnMap, context);
+    L.DomEvent
+        .on(link, 'click', stop)
+        .on(link, 'mousedown', stop)
+        .on(link, 'dblclick', stop)
+        .on(link, 'click', L.DomEvent.preventDefault)
+        .on(link, 'click', fn, context)
+        .on(link, 'click', this._refocusOnMap, context);
 
-		return link;
-	},
+    return link;
+  },
 
-	_updateDisabled: function () {
-		var map = this._map,
-			className = 'leaflet-disabled';
+  _updateDisabled: function () {
+    var map = this._map,
+      className = 'leaflet-disabled';
 
-		L.DomUtil.removeClass(this._zoomInButton, className);
-		L.DomUtil.removeClass(this._zoomOutButton, className);
+    L.DomUtil.removeClass(this._zoomInButton, className);
+    L.DomUtil.removeClass(this._zoomOutButton, className);
 
-		if (map._zoom === map.getMinZoom()) {
-			L.DomUtil.addClass(this._zoomOutButton, className);
-		}
-		if (map._zoom === map.getMaxZoom()) {
-			L.DomUtil.addClass(this._zoomInButton, className);
-		}
-	}
+    if (map._zoom === map.getMinZoom()) {
+      L.DomUtil.addClass(this._zoomOutButton, className);
+    }
+    if (map._zoom === map.getMaxZoom()) {
+      L.DomUtil.addClass(this._zoomInButton, className);
+    }
+  }
 });
 
 L.Map.mergeOptions({
-	zoomControl: true
+  zoomControl: true
 });
 
 L.Map.addInitHook(function () {
-	if (this.options.zoomControl) {
-		this.zoomControl = new L.Control.Zoom();
-		this.addControl(this.zoomControl);
-	}
+  if (this.options.zoomControl) {
+    this.zoomControl = new L.Control.Zoom();
+    this.addControl(this.zoomControl);
+  }
 });
 
 L.control.zoom = function (options) {
-	return new L.Control.Zoom(options);
+  return new L.Control.Zoom(options);
 };
 
 
@@ -14706,121 +14706,121 @@ L.control.zoom = function (options) {
  */
 
 L.Control.Attribution = L.Control.extend({
-	options: {
-		position: 'bottomright',
-		prefix: '<a href="http://leafletjs.com" title="A JS library for interactive maps">Leaflet</a>'
-	},
+  options: {
+    position: 'bottomright',
+    prefix: '<a href="http://leafletjs.com" title="A JS library for interactive maps">Leaflet</a>'
+  },
 
-	initialize: function (options) {
-		L.setOptions(this, options);
+  initialize: function (options) {
+    L.setOptions(this, options);
 
-		this._attributions = {};
-	},
+    this._attributions = {};
+  },
 
-	onAdd: function (map) {
-		this._container = L.DomUtil.create('div', 'leaflet-control-attribution');
-		L.DomEvent.disableClickPropagation(this._container);
+  onAdd: function (map) {
+    this._container = L.DomUtil.create('div', 'leaflet-control-attribution');
+    L.DomEvent.disableClickPropagation(this._container);
 
-		for (var i in map._layers) {
-			if (map._layers[i].getAttribution) {
-				this.addAttribution(map._layers[i].getAttribution());
-			}
-		}
-		
-		map
-		    .on('layeradd', this._onLayerAdd, this)
-		    .on('layerremove', this._onLayerRemove, this);
+    for (var i in map._layers) {
+      if (map._layers[i].getAttribution) {
+        this.addAttribution(map._layers[i].getAttribution());
+      }
+    }
 
-		this._update();
+    map
+        .on('layeradd', this._onLayerAdd, this)
+        .on('layerremove', this._onLayerRemove, this);
 
-		return this._container;
-	},
+    this._update();
 
-	onRemove: function (map) {
-		map
-		    .off('layeradd', this._onLayerAdd)
-		    .off('layerremove', this._onLayerRemove);
+    return this._container;
+  },
 
-	},
+  onRemove: function (map) {
+    map
+        .off('layeradd', this._onLayerAdd)
+        .off('layerremove', this._onLayerRemove);
 
-	setPrefix: function (prefix) {
-		this.options.prefix = prefix;
-		this._update();
-		return this;
-	},
+  },
 
-	addAttribution: function (text) {
-		if (!text) { return; }
+  setPrefix: function (prefix) {
+    this.options.prefix = prefix;
+    this._update();
+    return this;
+  },
 
-		if (!this._attributions[text]) {
-			this._attributions[text] = 0;
-		}
-		this._attributions[text]++;
+  addAttribution: function (text) {
+    if (!text) { return; }
 
-		this._update();
+    if (!this._attributions[text]) {
+      this._attributions[text] = 0;
+    }
+    this._attributions[text]++;
 
-		return this;
-	},
+    this._update();
 
-	removeAttribution: function (text) {
-		if (!text) { return; }
+    return this;
+  },
 
-		if (this._attributions[text]) {
-			this._attributions[text]--;
-			this._update();
-		}
+  removeAttribution: function (text) {
+    if (!text) { return; }
 
-		return this;
-	},
+    if (this._attributions[text]) {
+      this._attributions[text]--;
+      this._update();
+    }
 
-	_update: function () {
-		if (!this._map) { return; }
+    return this;
+  },
 
-		var attribs = [];
+  _update: function () {
+    if (!this._map) { return; }
 
-		for (var i in this._attributions) {
-			if (this._attributions[i]) {
-				attribs.push(i);
-			}
-		}
+    var attribs = [];
 
-		var prefixAndAttribs = [];
+    for (var i in this._attributions) {
+      if (this._attributions[i]) {
+        attribs.push(i);
+      }
+    }
 
-		if (this.options.prefix) {
-			prefixAndAttribs.push(this.options.prefix);
-		}
-		if (attribs.length) {
-			prefixAndAttribs.push(attribs.join(', '));
-		}
+    var prefixAndAttribs = [];
 
-		this._container.innerHTML = prefixAndAttribs.join(' | ');
-	},
+    if (this.options.prefix) {
+      prefixAndAttribs.push(this.options.prefix);
+    }
+    if (attribs.length) {
+      prefixAndAttribs.push(attribs.join(', '));
+    }
 
-	_onLayerAdd: function (e) {
-		if (e.layer.getAttribution) {
-			this.addAttribution(e.layer.getAttribution());
-		}
-	},
+    this._container.innerHTML = prefixAndAttribs.join(' | ');
+  },
 
-	_onLayerRemove: function (e) {
-		if (e.layer.getAttribution) {
-			this.removeAttribution(e.layer.getAttribution());
-		}
-	}
+  _onLayerAdd: function (e) {
+    if (e.layer.getAttribution) {
+      this.addAttribution(e.layer.getAttribution());
+    }
+  },
+
+  _onLayerRemove: function (e) {
+    if (e.layer.getAttribution) {
+      this.removeAttribution(e.layer.getAttribution());
+    }
+  }
 });
 
 L.Map.mergeOptions({
-	attributionControl: true
+  attributionControl: true
 });
 
 L.Map.addInitHook(function () {
-	if (this.options.attributionControl) {
-		this.attributionControl = (new L.Control.Attribution()).addTo(this);
-	}
+  if (this.options.attributionControl) {
+    this.attributionControl = (new L.Control.Attribution()).addTo(this);
+  }
 });
 
 L.control.attribution = function (options) {
-	return new L.Control.Attribution(options);
+  return new L.Control.Attribution(options);
 };
 
 
@@ -14833,93 +14833,93 @@ L.control.attribution = function (options) {
  */
 
 L.PosAnimation = L.Class.extend({
-	includes: L.Mixin.Events,
+  includes: L.Mixin.Events,
 
-	run: function (el, newPos, duration, easeLinearity) { // (HTMLElement, Point[, Number, Number])
-		this.stop();
+  run: function (el, newPos, duration, easeLinearity) { // (HTMLElement, Point[, Number, Number])
+    this.stop();
 
-		this._el = el;
-		this._inProgress = true;
-		this._newPos = newPos;
+    this._el = el;
+    this._inProgress = true;
+    this._newPos = newPos;
 
-		this.fire('start');
+    this.fire('start');
 
-		el.style[L.DomUtil.TRANSITION] = 'all ' + (duration || 0.25) +
-		        's cubic-bezier(0,0,' + (easeLinearity || 0.5) + ',1)';
+    el.style[L.DomUtil.TRANSITION] = 'all ' + (duration || 0.25) +
+            's cubic-bezier(0,0,' + (easeLinearity || 0.5) + ',1)';
 
-		L.DomEvent.on(el, L.DomUtil.TRANSITION_END, this._onTransitionEnd, this);
-		L.DomUtil.setPosition(el, newPos);
+    L.DomEvent.on(el, L.DomUtil.TRANSITION_END, this._onTransitionEnd, this);
+    L.DomUtil.setPosition(el, newPos);
 
-		// toggle reflow, Chrome flickers for some reason if you don't do this
-		L.Util.falseFn(el.offsetWidth);
+    // toggle reflow, Chrome flickers for some reason if you don't do this
+    L.Util.falseFn(el.offsetWidth);
 
-		// there's no native way to track value updates of transitioned properties, so we imitate this
-		this._stepTimer = setInterval(L.bind(this._onStep, this), 50);
-	},
+    // there's no native way to track value updates of transitioned properties, so we imitate this
+    this._stepTimer = setInterval(L.bind(this._onStep, this), 50);
+  },
 
-	stop: function () {
-		if (!this._inProgress) { return; }
+  stop: function () {
+    if (!this._inProgress) { return; }
 
-		// if we just removed the transition property, the element would jump to its final position,
-		// so we need to make it stay at the current position
+    // if we just removed the transition property, the element would jump to its final position,
+    // so we need to make it stay at the current position
 
-		L.DomUtil.setPosition(this._el, this._getPos());
-		this._onTransitionEnd();
-		L.Util.falseFn(this._el.offsetWidth); // force reflow in case we are about to start a new animation
-	},
+    L.DomUtil.setPosition(this._el, this._getPos());
+    this._onTransitionEnd();
+    L.Util.falseFn(this._el.offsetWidth); // force reflow in case we are about to start a new animation
+  },
 
-	_onStep: function () {
-		var stepPos = this._getPos();
-		if (!stepPos) {
-			this._onTransitionEnd();
-			return;
-		}
-		// jshint camelcase: false
-		// make L.DomUtil.getPosition return intermediate position value during animation
-		this._el._leaflet_pos = stepPos;
+  _onStep: function () {
+    var stepPos = this._getPos();
+    if (!stepPos) {
+      this._onTransitionEnd();
+      return;
+    }
+    // jshint camelcase: false
+    // make L.DomUtil.getPosition return intermediate position value during animation
+    this._el._leaflet_pos = stepPos;
 
-		this.fire('step');
-	},
+    this.fire('step');
+  },
 
-	// you can't easily get intermediate values of properties animated with CSS3 Transitions,
-	// we need to parse computed style (in case of transform it returns matrix string)
+  // you can't easily get intermediate values of properties animated with CSS3 Transitions,
+  // we need to parse computed style (in case of transform it returns matrix string)
 
-	_transformRe: /([-+]?(?:\d*\.)?\d+)\D*, ([-+]?(?:\d*\.)?\d+)\D*\)/,
+  _transformRe: /([-+]?(?:\d*\.)?\d+)\D*, ([-+]?(?:\d*\.)?\d+)\D*\)/,
 
-	_getPos: function () {
-		var left, top, matches,
-		    el = this._el,
-		    style = window.getComputedStyle(el);
+  _getPos: function () {
+    var left, top, matches,
+        el = this._el,
+        style = window.getComputedStyle(el);
 
-		if (L.Browser.any3d) {
-			matches = style[L.DomUtil.TRANSFORM].match(this._transformRe);
-			if (!matches) { return; }
-			left = parseFloat(matches[1]);
-			top  = parseFloat(matches[2]);
-		} else {
-			left = parseFloat(style.left);
-			top  = parseFloat(style.top);
-		}
+    if (L.Browser.any3d) {
+      matches = style[L.DomUtil.TRANSFORM].match(this._transformRe);
+      if (!matches) { return; }
+      left = parseFloat(matches[1]);
+      top  = parseFloat(matches[2]);
+    } else {
+      left = parseFloat(style.left);
+      top  = parseFloat(style.top);
+    }
 
-		return new L.Point(left, top, true);
-	},
+    return new L.Point(left, top, true);
+  },
 
-	_onTransitionEnd: function () {
-		L.DomEvent.off(this._el, L.DomUtil.TRANSITION_END, this._onTransitionEnd, this);
+  _onTransitionEnd: function () {
+    L.DomEvent.off(this._el, L.DomUtil.TRANSITION_END, this._onTransitionEnd, this);
 
-		if (!this._inProgress) { return; }
-		this._inProgress = false;
+    if (!this._inProgress) { return; }
+    this._inProgress = false;
 
-		this._el.style[L.DomUtil.TRANSITION] = '';
+    this._el.style[L.DomUtil.TRANSITION] = '';
 
-		// jshint camelcase: false
-		// make sure L.DomUtil.getPosition returns the final position value after animation
-		this._el._leaflet_pos = this._newPos;
+    // jshint camelcase: false
+    // make sure L.DomUtil.getPosition returns the final position value after animation
+    this._el._leaflet_pos = this._newPos;
 
-		clearInterval(this._stepTimer);
+    clearInterval(this._stepTimer);
 
-		this.fire('step').fire('end');
-	}
+    this.fire('step').fire('end');
+  }
 
 });
 
@@ -14934,97 +14934,97 @@ L.PosAnimation = L.Class.extend({
 
 L.Map.include({
 
-	setView: function (center, zoom, options) {
+  setView: function (center, zoom, options) {
 
-		zoom = zoom === undefined ? this._zoom : this._limitZoom(zoom);
-		center = this._limitCenter(L.latLng(center), zoom, this.options.maxBounds);
-		options = options || {};
+    zoom = zoom === undefined ? this._zoom : this._limitZoom(zoom);
+    center = this._limitCenter(L.latLng(center), zoom, this.options.maxBounds);
+    options = options || {};
 
-		if (this._panAnim) {
-			this._panAnim.stop();
-		}
+    if (this._panAnim) {
+      this._panAnim.stop();
+    }
 
-		if (this._loaded && !options.reset && options !== true) {
+    if (this._loaded && !options.reset && options !== true) {
 
-			if (options.animate !== undefined) {
-				options.zoom = L.extend({animate: options.animate}, options.zoom);
-				options.pan = L.extend({animate: options.animate}, options.pan);
-			}
+      if (options.animate !== undefined) {
+        options.zoom = L.extend({animate: options.animate}, options.zoom);
+        options.pan = L.extend({animate: options.animate}, options.pan);
+      }
 
-			// try animating pan or zoom
-			var animated = (this._zoom !== zoom) ?
-				this._tryAnimatedZoom && this._tryAnimatedZoom(center, zoom, options.zoom) :
-				this._tryAnimatedPan(center, options.pan);
+      // try animating pan or zoom
+      var animated = (this._zoom !== zoom) ?
+        this._tryAnimatedZoom && this._tryAnimatedZoom(center, zoom, options.zoom) :
+        this._tryAnimatedPan(center, options.pan);
 
-			if (animated) {
-				// prevent resize handler call, the view will refresh after animation anyway
-				clearTimeout(this._sizeTimer);
-				return this;
-			}
-		}
+      if (animated) {
+        // prevent resize handler call, the view will refresh after animation anyway
+        clearTimeout(this._sizeTimer);
+        return this;
+      }
+    }
 
-		// animation didn't start, just reset the map view
-		this._resetView(center, zoom);
+    // animation didn't start, just reset the map view
+    this._resetView(center, zoom);
 
-		return this;
-	},
+    return this;
+  },
 
-	panBy: function (offset, options) {
-		offset = L.point(offset).round();
-		options = options || {};
+  panBy: function (offset, options) {
+    offset = L.point(offset).round();
+    options = options || {};
 
-		if (!offset.x && !offset.y) {
-			return this;
-		}
+    if (!offset.x && !offset.y) {
+      return this;
+    }
 
-		if (!this._panAnim) {
-			this._panAnim = new L.PosAnimation();
+    if (!this._panAnim) {
+      this._panAnim = new L.PosAnimation();
 
-			this._panAnim.on({
-				'step': this._onPanTransitionStep,
-				'end': this._onPanTransitionEnd
-			}, this);
-		}
+      this._panAnim.on({
+        'step': this._onPanTransitionStep,
+        'end': this._onPanTransitionEnd
+      }, this);
+    }
 
-		// don't fire movestart if animating inertia
-		if (!options.noMoveStart) {
-			this.fire('movestart');
-		}
+    // don't fire movestart if animating inertia
+    if (!options.noMoveStart) {
+      this.fire('movestart');
+    }
 
-		// animate pan unless animate: false specified
-		if (options.animate !== false) {
-			L.DomUtil.addClass(this._mapPane, 'leaflet-pan-anim');
+    // animate pan unless animate: false specified
+    if (options.animate !== false) {
+      L.DomUtil.addClass(this._mapPane, 'leaflet-pan-anim');
 
-			var newPos = this._getMapPanePos().subtract(offset);
-			this._panAnim.run(this._mapPane, newPos, options.duration || 0.25, options.easeLinearity);
-		} else {
-			this._rawPanBy(offset);
-			this.fire('move').fire('moveend');
-		}
+      var newPos = this._getMapPanePos().subtract(offset);
+      this._panAnim.run(this._mapPane, newPos, options.duration || 0.25, options.easeLinearity);
+    } else {
+      this._rawPanBy(offset);
+      this.fire('move').fire('moveend');
+    }
 
-		return this;
-	},
+    return this;
+  },
 
-	_onPanTransitionStep: function () {
-		this.fire('move');
-	},
+  _onPanTransitionStep: function () {
+    this.fire('move');
+  },
 
-	_onPanTransitionEnd: function () {
-		L.DomUtil.removeClass(this._mapPane, 'leaflet-pan-anim');
-		this.fire('moveend');
-	},
+  _onPanTransitionEnd: function () {
+    L.DomUtil.removeClass(this._mapPane, 'leaflet-pan-anim');
+    this.fire('moveend');
+  },
 
-	_tryAnimatedPan: function (center, options) {
-		// difference between the new and current centers in pixels
-		var offset = this._getCenterOffset(center)._floor();
+  _tryAnimatedPan: function (center, options) {
+    // difference between the new and current centers in pixels
+    var offset = this._getCenterOffset(center)._floor();
 
-		// don't animate too far unless animate: true specified in options
-		if ((options && options.animate) !== true && !this.getSize().contains(offset)) { return false; }
+    // don't animate too far unless animate: true specified in options
+    if ((options && options.animate) !== true && !this.getSize().contains(offset)) { return false; }
 
-		this.panBy(offset, options);
+    this.panBy(offset, options);
 
-		return true;
-	}
+    return true;
+  }
 });
 
 
@@ -15039,65 +15039,65 @@ L.Map.include({
 
 L.PosAnimation = L.DomUtil.TRANSITION ? L.PosAnimation : L.PosAnimation.extend({
 
-	run: function (el, newPos, duration, easeLinearity) { // (HTMLElement, Point[, Number, Number])
-		this.stop();
+  run: function (el, newPos, duration, easeLinearity) { // (HTMLElement, Point[, Number, Number])
+    this.stop();
 
-		this._el = el;
-		this._inProgress = true;
-		this._duration = duration || 0.25;
-		this._easeOutPower = 1 / Math.max(easeLinearity || 0.5, 0.2);
+    this._el = el;
+    this._inProgress = true;
+    this._duration = duration || 0.25;
+    this._easeOutPower = 1 / Math.max(easeLinearity || 0.5, 0.2);
 
-		this._startPos = L.DomUtil.getPosition(el);
-		this._offset = newPos.subtract(this._startPos);
-		this._startTime = +new Date();
+    this._startPos = L.DomUtil.getPosition(el);
+    this._offset = newPos.subtract(this._startPos);
+    this._startTime = +new Date();
 
-		this.fire('start');
+    this.fire('start');
 
-		this._animate();
-	},
+    this._animate();
+  },
 
-	stop: function () {
-		if (!this._inProgress) { return; }
+  stop: function () {
+    if (!this._inProgress) { return; }
 
-		this._step();
-		this._complete();
-	},
+    this._step();
+    this._complete();
+  },
 
-	_animate: function () {
-		// animation loop
-		this._animId = L.Util.requestAnimFrame(this._animate, this);
-		this._step();
-	},
+  _animate: function () {
+    // animation loop
+    this._animId = L.Util.requestAnimFrame(this._animate, this);
+    this._step();
+  },
 
-	_step: function () {
-		var elapsed = (+new Date()) - this._startTime,
-		    duration = this._duration * 1000;
+  _step: function () {
+    var elapsed = (+new Date()) - this._startTime,
+        duration = this._duration * 1000;
 
-		if (elapsed < duration) {
-			this._runFrame(this._easeOut(elapsed / duration));
-		} else {
-			this._runFrame(1);
-			this._complete();
-		}
-	},
+    if (elapsed < duration) {
+      this._runFrame(this._easeOut(elapsed / duration));
+    } else {
+      this._runFrame(1);
+      this._complete();
+    }
+  },
 
-	_runFrame: function (progress) {
-		var pos = this._startPos.add(this._offset.multiplyBy(progress));
-		L.DomUtil.setPosition(this._el, pos);
+  _runFrame: function (progress) {
+    var pos = this._startPos.add(this._offset.multiplyBy(progress));
+    L.DomUtil.setPosition(this._el, pos);
 
-		this.fire('step');
-	},
+    this.fire('step');
+  },
 
-	_complete: function () {
-		L.Util.cancelAnimFrame(this._animId);
+  _complete: function () {
+    L.Util.cancelAnimFrame(this._animId);
 
-		this._inProgress = false;
-		this.fire('end');
-	},
+    this._inProgress = false;
+    this.fire('end');
+  },
 
-	_easeOut: function (t) {
-		return 1 - Math.pow(1 - t, this._easeOutPower);
-	}
+  _easeOut: function (t) {
+    return 1 - Math.pow(1 - t, this._easeOutPower);
+  }
 });
 
 
@@ -15110,102 +15110,102 @@ L.PosAnimation = L.DomUtil.TRANSITION ? L.PosAnimation : L.PosAnimation.extend({
  */
 
 L.Map.mergeOptions({
-	zoomAnimation: true,
-	zoomAnimationThreshold: 4
+  zoomAnimation: true,
+  zoomAnimationThreshold: 4
 });
 
 if (L.DomUtil.TRANSITION) {
 
-	L.Map.addInitHook(function () {
-		// don't animate on browsers without hardware-accelerated transitions or old Android/Opera
-		this._zoomAnimated = this.options.zoomAnimation && L.DomUtil.TRANSITION &&
-				L.Browser.any3d && !L.Browser.android23 && !L.Browser.mobileOpera;
+  L.Map.addInitHook(function () {
+    // don't animate on browsers without hardware-accelerated transitions or old Android/Opera
+    this._zoomAnimated = this.options.zoomAnimation && L.DomUtil.TRANSITION &&
+        L.Browser.any3d && !L.Browser.android23 && !L.Browser.mobileOpera;
 
-		// zoom transitions run with the same duration for all layers, so if one of transitionend events
-		// happens after starting zoom animation (propagating to the map pane), we know that it ended globally
-		if (this._zoomAnimated) {
-			L.DomEvent.on(this._mapPane, L.DomUtil.TRANSITION_END, this._catchTransitionEnd, this);
-		}
-	});
+    // zoom transitions run with the same duration for all layers, so if one of transitionend events
+    // happens after starting zoom animation (propagating to the map pane), we know that it ended globally
+    if (this._zoomAnimated) {
+      L.DomEvent.on(this._mapPane, L.DomUtil.TRANSITION_END, this._catchTransitionEnd, this);
+    }
+  });
 }
 
 L.Map.include(!L.DomUtil.TRANSITION ? {} : {
 
-	_catchTransitionEnd: function (e) {
-		if (this._animatingZoom && e.propertyName.indexOf('transform') >= 0) {
-			this._onZoomTransitionEnd();
-		}
-	},
+  _catchTransitionEnd: function (e) {
+    if (this._animatingZoom && e.propertyName.indexOf('transform') >= 0) {
+      this._onZoomTransitionEnd();
+    }
+  },
 
-	_nothingToAnimate: function () {
-		return !this._container.getElementsByClassName('leaflet-zoom-animated').length;
-	},
+  _nothingToAnimate: function () {
+    return !this._container.getElementsByClassName('leaflet-zoom-animated').length;
+  },
 
-	_tryAnimatedZoom: function (center, zoom, options) {
+  _tryAnimatedZoom: function (center, zoom, options) {
 
-		if (this._animatingZoom) { return true; }
+    if (this._animatingZoom) { return true; }
 
-		options = options || {};
+    options = options || {};
 
-		// don't animate if disabled, not supported or zoom difference is too large
-		if (!this._zoomAnimated || options.animate === false || this._nothingToAnimate() ||
-		        Math.abs(zoom - this._zoom) > this.options.zoomAnimationThreshold) { return false; }
+    // don't animate if disabled, not supported or zoom difference is too large
+    if (!this._zoomAnimated || options.animate === false || this._nothingToAnimate() ||
+            Math.abs(zoom - this._zoom) > this.options.zoomAnimationThreshold) { return false; }
 
-		// offset is the pixel coords of the zoom origin relative to the current center
-		var scale = this.getZoomScale(zoom),
-		    offset = this._getCenterOffset(center)._divideBy(1 - 1 / scale),
-			origin = this._getCenterLayerPoint()._add(offset);
+    // offset is the pixel coords of the zoom origin relative to the current center
+    var scale = this.getZoomScale(zoom),
+        offset = this._getCenterOffset(center)._divideBy(1 - 1 / scale),
+      origin = this._getCenterLayerPoint()._add(offset);
 
-		// don't animate if the zoom origin isn't within one screen from the current center, unless forced
-		if (options.animate !== true && !this.getSize().contains(offset)) { return false; }
+    // don't animate if the zoom origin isn't within one screen from the current center, unless forced
+    if (options.animate !== true && !this.getSize().contains(offset)) { return false; }
 
-		this
-		    .fire('movestart')
-		    .fire('zoomstart');
+    this
+        .fire('movestart')
+        .fire('zoomstart');
 
-		this._animateZoom(center, zoom, origin, scale, null, true);
+    this._animateZoom(center, zoom, origin, scale, null, true);
 
-		return true;
-	},
+    return true;
+  },
 
-	_animateZoom: function (center, zoom, origin, scale, delta, backwards) {
+  _animateZoom: function (center, zoom, origin, scale, delta, backwards) {
 
-		this._animatingZoom = true;
+    this._animatingZoom = true;
 
-		// put transform transition on all layers with leaflet-zoom-animated class
-		L.DomUtil.addClass(this._mapPane, 'leaflet-zoom-anim');
+    // put transform transition on all layers with leaflet-zoom-animated class
+    L.DomUtil.addClass(this._mapPane, 'leaflet-zoom-anim');
 
-		// remember what center/zoom to set after animation
-		this._animateToCenter = center;
-		this._animateToZoom = zoom;
+    // remember what center/zoom to set after animation
+    this._animateToCenter = center;
+    this._animateToZoom = zoom;
 
-		// disable any dragging during animation
-		if (L.Draggable) {
-			L.Draggable._disabled = true;
-		}
+    // disable any dragging during animation
+    if (L.Draggable) {
+      L.Draggable._disabled = true;
+    }
 
-		this.fire('zoomanim', {
-			center: center,
-			zoom: zoom,
-			origin: origin,
-			scale: scale,
-			delta: delta,
-			backwards: backwards
-		});
-	},
+    this.fire('zoomanim', {
+      center: center,
+      zoom: zoom,
+      origin: origin,
+      scale: scale,
+      delta: delta,
+      backwards: backwards
+    });
+  },
 
-	_onZoomTransitionEnd: function () {
+  _onZoomTransitionEnd: function () {
 
-		this._animatingZoom = false;
+    this._animatingZoom = false;
 
-		L.DomUtil.removeClass(this._mapPane, 'leaflet-zoom-anim');
+    L.DomUtil.removeClass(this._mapPane, 'leaflet-zoom-anim');
 
-		this._resetView(this._animateToCenter, this._animateToZoom, true, true);
+    this._resetView(this._animateToCenter, this._animateToZoom, true, true);
 
-		if (L.Draggable) {
-			L.Draggable._disabled = false;
-		}
-	}
+    if (L.Draggable) {
+      L.Draggable._disabled = false;
+    }
+  }
 });
 
 
@@ -15214,109 +15214,109 @@ L.Map.include(!L.DomUtil.TRANSITION ? {} : {
 ********************************************** */
 
 /*
-	Zoom animation logic for L.TileLayer.
+  Zoom animation logic for L.TileLayer.
 */
 
 L.TileLayer.include({
-	_animateZoom: function (e) {
-		if (!this._animating) {
-			this._animating = true;
-			this._prepareBgBuffer();
-		}
+  _animateZoom: function (e) {
+    if (!this._animating) {
+      this._animating = true;
+      this._prepareBgBuffer();
+    }
 
-		var bg = this._bgBuffer,
-		    transform = L.DomUtil.TRANSFORM,
-		    initialTransform = e.delta ? L.DomUtil.getTranslateString(e.delta) : bg.style[transform],
-		    scaleStr = L.DomUtil.getScaleString(e.scale, e.origin);
+    var bg = this._bgBuffer,
+        transform = L.DomUtil.TRANSFORM,
+        initialTransform = e.delta ? L.DomUtil.getTranslateString(e.delta) : bg.style[transform],
+        scaleStr = L.DomUtil.getScaleString(e.scale, e.origin);
 
-		bg.style[transform] = e.backwards ?
-				scaleStr + ' ' + initialTransform :
-				initialTransform + ' ' + scaleStr;
-	},
+    bg.style[transform] = e.backwards ?
+        scaleStr + ' ' + initialTransform :
+        initialTransform + ' ' + scaleStr;
+  },
 
-	_endZoomAnim: function () {
-		var front = this._tileContainer,
-		    bg = this._bgBuffer;
+  _endZoomAnim: function () {
+    var front = this._tileContainer,
+        bg = this._bgBuffer;
 
-		front.style.visibility = '';
-		front.parentNode.appendChild(front); // Bring to fore
+    front.style.visibility = '';
+    front.parentNode.appendChild(front); // Bring to fore
 
-		// force reflow
-		L.Util.falseFn(bg.offsetWidth);
+    // force reflow
+    L.Util.falseFn(bg.offsetWidth);
 
-		this._animating = false;
-	},
+    this._animating = false;
+  },
 
-	_clearBgBuffer: function () {
-		var map = this._map;
+  _clearBgBuffer: function () {
+    var map = this._map;
 
-		if (map && !map._animatingZoom && !map.touchZoom._zooming) {
-			this._bgBuffer.innerHTML = '';
-			this._bgBuffer.style[L.DomUtil.TRANSFORM] = '';
-		}
-	},
+    if (map && !map._animatingZoom && !map.touchZoom._zooming) {
+      this._bgBuffer.innerHTML = '';
+      this._bgBuffer.style[L.DomUtil.TRANSFORM] = '';
+    }
+  },
 
-	_prepareBgBuffer: function () {
+  _prepareBgBuffer: function () {
 
-		var front = this._tileContainer,
-		    bg = this._bgBuffer;
+    var front = this._tileContainer,
+        bg = this._bgBuffer;
 
-		// if foreground layer doesn't have many tiles but bg layer does,
-		// keep the existing bg layer and just zoom it some more
+    // if foreground layer doesn't have many tiles but bg layer does,
+    // keep the existing bg layer and just zoom it some more
 
-		var bgLoaded = this._getLoadedTilesPercentage(bg),
-		    frontLoaded = this._getLoadedTilesPercentage(front);
+    var bgLoaded = this._getLoadedTilesPercentage(bg),
+        frontLoaded = this._getLoadedTilesPercentage(front);
 
-		if (bg && bgLoaded > 0.5 && frontLoaded < 0.5) {
+    if (bg && bgLoaded > 0.5 && frontLoaded < 0.5) {
 
-			front.style.visibility = 'hidden';
-			this._stopLoadingImages(front);
-			return;
-		}
+      front.style.visibility = 'hidden';
+      this._stopLoadingImages(front);
+      return;
+    }
 
-		// prepare the buffer to become the front tile pane
-		bg.style.visibility = 'hidden';
-		bg.style[L.DomUtil.TRANSFORM] = '';
+    // prepare the buffer to become the front tile pane
+    bg.style.visibility = 'hidden';
+    bg.style[L.DomUtil.TRANSFORM] = '';
 
-		// switch out the current layer to be the new bg layer (and vice-versa)
-		this._tileContainer = bg;
-		bg = this._bgBuffer = front;
+    // switch out the current layer to be the new bg layer (and vice-versa)
+    this._tileContainer = bg;
+    bg = this._bgBuffer = front;
 
-		this._stopLoadingImages(bg);
+    this._stopLoadingImages(bg);
 
-		//prevent bg buffer from clearing right after zoom
-		clearTimeout(this._clearBgBufferTimer);
-	},
+    //prevent bg buffer from clearing right after zoom
+    clearTimeout(this._clearBgBufferTimer);
+  },
 
-	_getLoadedTilesPercentage: function (container) {
-		var tiles = container.getElementsByTagName('img'),
-		    i, len, count = 0;
+  _getLoadedTilesPercentage: function (container) {
+    var tiles = container.getElementsByTagName('img'),
+        i, len, count = 0;
 
-		for (i = 0, len = tiles.length; i < len; i++) {
-			if (tiles[i].complete) {
-				count++;
-			}
-		}
-		return count / len;
-	},
+    for (i = 0, len = tiles.length; i < len; i++) {
+      if (tiles[i].complete) {
+        count++;
+      }
+    }
+    return count / len;
+  },
 
-	// stops loading all tiles in the background layer
-	_stopLoadingImages: function (container) {
-		var tiles = Array.prototype.slice.call(container.getElementsByTagName('img')),
-		    i, len, tile;
+  // stops loading all tiles in the background layer
+  _stopLoadingImages: function (container) {
+    var tiles = Array.prototype.slice.call(container.getElementsByTagName('img')),
+        i, len, tile;
 
-		for (i = 0, len = tiles.length; i < len; i++) {
-			tile = tiles[i];
+    for (i = 0, len = tiles.length; i < len; i++) {
+      tile = tiles[i];
 
-			if (!tile.complete) {
-				tile.onload = L.Util.falseFn;
-				tile.onerror = L.Util.falseFn;
-				tile.src = L.Util.emptyImageUrl;
+      if (!tile.complete) {
+        tile.onload = L.Util.falseFn;
+        tile.onerror = L.Util.falseFn;
+        tile.src = L.Util.emptyImageUrl;
 
-				tile.parentNode.removeChild(tile);
-			}
-		}
-	}
+        tile.parentNode.removeChild(tile);
+      }
+    }
+  }
 });
 
 
@@ -15330,149 +15330,149 @@ L.TileLayer.include({
  */
 
 L.TileLayer.Zoomify = L.TileLayer.extend({
-	options: {
-		continuousWorld: true,
-		tolerance: 0.8
-	},
+  options: {
+    continuousWorld: true,
+    tolerance: 0.8
+  },
 
-	initialize: function (url, options) {
-		options = L.setOptions(this, options);
-		this._url = url;
+  initialize: function (url, options) {
+    options = L.setOptions(this, options);
+    this._url = url;
 
-    	var imageSize = L.point(options.width, options.height),
-	    	tileSize = options.tileSize;
+      var imageSize = L.point(options.width, options.height),
+        tileSize = options.tileSize;
 
-    	this._imageSize = [imageSize];
-    	this._gridSize = [this._getGridSize(imageSize)];
+      this._imageSize = [imageSize];
+      this._gridSize = [this._getGridSize(imageSize)];
 
         while (imageSize.x > tileSize || imageSize.y > tileSize) {
-        	imageSize = imageSize.divideBy(2).floor();
-        	this._imageSize.push(imageSize);
-        	this._gridSize.push(this._getGridSize(imageSize));
+          imageSize = imageSize.divideBy(2).floor();
+          this._imageSize.push(imageSize);
+          this._gridSize.push(this._getGridSize(imageSize));
         }
 
-		this._imageSize.reverse();
-		this._gridSize.reverse();
+    this._imageSize.reverse();
+    this._gridSize.reverse();
 
         this.options.maxZoom = this._gridSize.length - 1;
-	},
+  },
 
-	onAdd: function (map) {
-		L.TileLayer.prototype.onAdd.call(this, map);
+  onAdd: function (map) {
+    L.TileLayer.prototype.onAdd.call(this, map);
 
-		var mapSize = map.getSize(),
-			zoom = this._getBestFitZoom(mapSize),
-			imageSize = this._imageSize[zoom],
-			center = map.options.crs.pointToLatLng(L.point(imageSize.x / 2, imageSize.y / 2), zoom);
+    var mapSize = map.getSize(),
+      zoom = this._getBestFitZoom(mapSize),
+      imageSize = this._imageSize[zoom],
+      center = map.options.crs.pointToLatLng(L.point(imageSize.x / 2, imageSize.y / 2), zoom);
 
-		//map.setView(center, zoom, true);
-	},
-	
-	getZoomifyBounds: function(map) {
-		//return "getZoomifyBounds";
-		var imageSize 	= this._imageSize[0],
-			topleft 	= map.options.crs.pointToLatLng(L.point(0, 0), 0),
-		    bottomright = map.options.crs.pointToLatLng(L.point(imageSize.x, imageSize.y), 0),
-		    bounds 		= L.latLngBounds(topleft, bottomright);
-			
-			
-		return bounds;
-		//[[75, -132], [-30, 128]]
-	},
-	
-	getCenterZoom: function(map) {
-		var mapSize = map.getSize(),
-			zoom = this._getBestFitZoom(mapSize),
-			imageSize = this._imageSize[zoom],
-			center = map.options.crs.pointToLatLng(L.point(imageSize.x / 2, imageSize.y / 2), zoom);
-			
-		return {
-			center: center,
-			lat: 	center.lat,
-			lon: 	center.lng,
-			zoom: 	zoom
-		};
-	},
+    //map.setView(center, zoom, true);
+  },
 
-	_getGridSize: function (imageSize) {
-		var tileSize = this.options.tileSize;
-		return L.point(Math.ceil(imageSize.x / tileSize), Math.ceil(imageSize.y / tileSize));
-	},
+  getZoomifyBounds: function(map) {
+    //return "getZoomifyBounds";
+    var imageSize   = this._imageSize[0],
+      topleft   = map.options.crs.pointToLatLng(L.point(0, 0), 0),
+        bottomright = map.options.crs.pointToLatLng(L.point(imageSize.x, imageSize.y), 0),
+        bounds    = L.latLngBounds(topleft, bottomright);
 
-	_getBestFitZoom: function (mapSize) {
-		var tolerance = this.options.tolerance,
-			zoom = this._imageSize.length - 1,
-			imageSize, zoom;
 
-		while (zoom) {
-			imageSize = this._imageSize[zoom];
-			if (imageSize.x * tolerance < mapSize.x && imageSize.y * tolerance < mapSize.y) {
-				return zoom;
-			}			
-			zoom--;
-		}
+    return bounds;
+    //[[75, -132], [-30, 128]]
+  },
 
-		return zoom;
-	},
+  getCenterZoom: function(map) {
+    var mapSize = map.getSize(),
+      zoom = this._getBestFitZoom(mapSize),
+      imageSize = this._imageSize[zoom],
+      center = map.options.crs.pointToLatLng(L.point(imageSize.x / 2, imageSize.y / 2), zoom);
 
-	_tileShouldBeLoaded: function (tilePoint) {
-		var gridSize = this._gridSize[this._map.getZoom()];
-		if (gridSize) {
-			return (tilePoint.x >= 0 && tilePoint.x < gridSize.x && tilePoint.y >= 0 && tilePoint.y < gridSize.y);
-		} else {
-			console.log("_tileShouldBeLoaded: No gridSize for " + this._map.getZoom());
-			return false;
-		}
-	},
+    return {
+      center: center,
+      lat:  center.lat,
+      lon:  center.lng,
+      zoom:   zoom
+    };
+  },
 
-	_addTile: function (tilePoint, container) {
-		var tilePos = this._getTilePos(tilePoint),
-			tile = this._getTile(),
-			zoom = this._map.getZoom(),
-			imageSize = this._imageSize[zoom],
-			gridSize = this._gridSize[zoom],
-			tileSize = this.options.tileSize;
+  _getGridSize: function (imageSize) {
+    var tileSize = this.options.tileSize;
+    return L.point(Math.ceil(imageSize.x / tileSize), Math.ceil(imageSize.y / tileSize));
+  },
 
-		if (tilePoint.x === gridSize.x - 1) {
-			tile.style.width = imageSize.x - (tileSize * (gridSize.x - 1)) + 'px';
-		} 
+  _getBestFitZoom: function (mapSize) {
+    var tolerance = this.options.tolerance,
+      zoom = this._imageSize.length - 1,
+      imageSize, zoom;
 
-		if (tilePoint.y === gridSize.y - 1) {
-			tile.style.height = imageSize.y - (tileSize * (gridSize.y - 1)) + 'px';			
-		} 
+    while (zoom) {
+      imageSize = this._imageSize[zoom];
+      if (imageSize.x * tolerance < mapSize.x && imageSize.y * tolerance < mapSize.y) {
+        return zoom;
+      }
+      zoom--;
+    }
 
-		L.DomUtil.setPosition(tile, tilePos, L.Browser.chrome || L.Browser.android23);
+    return zoom;
+  },
 
-		this._tiles[tilePoint.x + ':' + tilePoint.y] = tile;
-		this._loadTile(tile, tilePoint);
+  _tileShouldBeLoaded: function (tilePoint) {
+    var gridSize = this._gridSize[this._map.getZoom()];
+    if (gridSize) {
+      return (tilePoint.x >= 0 && tilePoint.x < gridSize.x && tilePoint.y >= 0 && tilePoint.y < gridSize.y);
+    } else {
+      console.log("_tileShouldBeLoaded: No gridSize for " + this._map.getZoom());
+      return false;
+    }
+  },
 
-		if (tile.parentNode !== this._tileContainer) {
-			container.appendChild(tile);
-		}
-	},
+  _addTile: function (tilePoint, container) {
+    var tilePos = this._getTilePos(tilePoint),
+      tile = this._getTile(),
+      zoom = this._map.getZoom(),
+      imageSize = this._imageSize[zoom],
+      gridSize = this._gridSize[zoom],
+      tileSize = this.options.tileSize;
 
-	getTileUrl: function (tilePoint) {
-		return this._url + 'TileGroup' + this._getTileGroup(tilePoint) + '/' + this._map.getZoom() + '-' + tilePoint.x + '-' + tilePoint.y + '.jpg';
-	},
+    if (tilePoint.x === gridSize.x - 1) {
+      tile.style.width = imageSize.x - (tileSize * (gridSize.x - 1)) + 'px';
+    }
 
-	_getTileGroup: function (tilePoint) {
-		var zoom = this._map.getZoom(),
-			num = 0,
-			gridSize;
+    if (tilePoint.y === gridSize.y - 1) {
+      tile.style.height = imageSize.y - (tileSize * (gridSize.y - 1)) + 'px';
+    }
 
-		for (z = 0; z < zoom; z++) {
-			gridSize = this._gridSize[z];
-			num += gridSize.x * gridSize.y; 
-		}	
+    L.DomUtil.setPosition(tile, tilePos, L.Browser.chrome || L.Browser.android23);
 
-		num += tilePoint.y * this._gridSize[zoom].x + tilePoint.x;
-      	return Math.floor(num / 256);;
-	}
+    this._tiles[tilePoint.x + ':' + tilePoint.y] = tile;
+    this._loadTile(tile, tilePoint);
+
+    if (tile.parentNode !== this._tileContainer) {
+      container.appendChild(tile);
+    }
+  },
+
+  getTileUrl: function (tilePoint) {
+    return this._url + 'TileGroup' + this._getTileGroup(tilePoint) + '/' + this._map.getZoom() + '-' + tilePoint.x + '-' + tilePoint.y + '.jpg';
+  },
+
+  _getTileGroup: function (tilePoint) {
+    var zoom = this._map.getZoom(),
+      num = 0,
+      gridSize;
+
+    for (z = 0; z < zoom; z++) {
+      gridSize = this._gridSize[z];
+      num += gridSize.x * gridSize.y;
+    }
+
+    num += tilePoint.y * this._gridSize[zoom].x + tilePoint.x;
+        return Math.floor(num / 256);;
+  }
 
 });
 
 L.tileLayer.zoomify = function (url, options) {
-	return new L.TileLayer.Zoomify(url, options);
+  return new L.TileLayer.Zoomify(url, options);
 };
 
 /* **********************************************
@@ -15480,8 +15480,8 @@ L.tileLayer.zoomify = function (url, options) {
 ********************************************** */
 
 /*
-	https://github.com/Norkart/Leaflet-MiniMap
-	
+  https://github.com/Norkart/Leaflet-MiniMap
+
 */
 
 L.Control.MiniMap = L.Control.extend({
@@ -15492,14 +15492,14 @@ L.Control.MiniMap = L.Control.extend({
         zoomLevelFixed: false,
         zoomAnimation: false,
         autoToggleDisplay: false,
-		show_view: true,
+    show_view: true,
         width: 150,
         height: 150,
         aimingRectOptions: {
             color: "#c34528",
             weight: 1,
             clickable: false,
-			stroke:true
+      stroke:true
         },
         shadowRectOptions: {
             color: "#000000",
@@ -15544,7 +15544,7 @@ L.Control.MiniMap = L.Control.extend({
             scrollWheelZoom: false,
             doubleClickZoom: false,
             boxZoom: false,
-			dragging:false,
+      dragging:false,
             crs: map.options.crs
         });
 
@@ -15565,44 +15565,44 @@ L.Control.MiniMap = L.Control.extend({
         this._miniMap.whenReady(L.Util.bind(function() {
             this._aimingRect = L.rectangle(this._mainMap.getBounds(), this.options.aimingRectOptions).addTo(this._miniMap);
             this._shadowRect = L.rectangle(this._mainMap.getBounds(), this.options.shadowRectOptions).addTo(this._miniMap);
-			
-			this._locationCircle = L.circleMarker(this._mainMap.getCenter(), {
-				fillColor: "#c34528",
-				color: "#FFFFFF",
-				weight:2,
-				radius: 10,
-				fill:true,
-				fillOpacity: 1,
-				stroke:true,
-				clickable: false
-			}).addTo(this._miniMap);
-			this._locationCircle.setRadius(5);
-			
+
+      this._locationCircle = L.circleMarker(this._mainMap.getCenter(), {
+        fillColor: "#c34528",
+        color: "#FFFFFF",
+        weight:2,
+        radius: 10,
+        fill:true,
+        fillOpacity: 1,
+        stroke:true,
+        clickable: false
+      }).addTo(this._miniMap);
+      this._locationCircle.setRadius(5);
+
             this._mainMap.on('moveend', this._onMainMapMoved, this);
             this._mainMap.on('move', this._onMainMapMoving, this);
             //this._miniMap.on('movestart', this._onMiniMapMoveStarted, this);
             //this._miniMap.on('move', this._onMiniMapMoving, this);
             //this._miniMap.on('moveend', this._onMiniMapMoved, this);
-			if (this.options.bounds_array) {
-				this._miniMap.fitBounds(this.options.bounds_array, {padding:[15,15]});
-			}
+      if (this.options.bounds_array) {
+        this._miniMap.fitBounds(this.options.bounds_array, {padding:[15,15]});
+      }
         }, this));
 
         return this._container;
     },
-	
-	minimize: function(hide_completely) {
-		if (!this._minimized) {
-			this._minimize();
-		}
-	},
-	
-	restore: function() {
-		if (this._minimized) {
-			this._restore();
-			this._miniMap.fitBounds(this.options.bounds_array, {padding:[15,15]});
-		}
-	},
+
+  minimize: function(hide_completely) {
+    if (!this._minimized) {
+      this._minimize();
+    }
+  },
+
+  restore: function() {
+    if (this._minimized) {
+      this._restore();
+      this._miniMap.fitBounds(this.options.bounds_array, {padding:[15,15]});
+    }
+  },
 
     addTo: function(map) {
         L.Control.prototype.addTo.call(this, map);
@@ -15675,29 +15675,29 @@ L.Control.MiniMap = L.Control.extend({
 
     _onMainMapMoved: function(e) {
         if (!this._miniMapMoving) {
-			var zoom = this._decideZoom(true);
-			if (zoom != 0) {
-				//this._miniMap.setView(this._mainMap.getCenter(), this._decideZoom(true));
-				//this._miniMap.setView(this._mainMap.getCenter());
-			}
+      var zoom = this._decideZoom(true);
+      if (zoom != 0) {
+        //this._miniMap.setView(this._mainMap.getCenter(), this._decideZoom(true));
+        //this._miniMap.setView(this._mainMap.getCenter());
+      }
             this._mainMapMoving = true;
 
             this._setDisplay(this._decideMinimized());
         } else {
             this._miniMapMoving = false;
         }
-		if (this.options.show_view) {
-			this._aimingRect.setBounds(this._mainMap.getBounds());
-		}
-		this._locationCircle.setLatLng(this._mainMap.getCenter());
-        
+    if (this.options.show_view) {
+      this._aimingRect.setBounds(this._mainMap.getBounds());
+    }
+    this._locationCircle.setLatLng(this._mainMap.getCenter());
+
     },
 
     _onMainMapMoving: function(e) {
-		if (this.options.show_view) {
-			this._aimingRect.setBounds(this._mainMap.getBounds());
-		}
-		this._locationCircle.setLatLng(this._mainMap.getCenter());
+    if (this.options.show_view) {
+      this._aimingRect.setBounds(this._mainMap.getBounds());
+    }
+    this._locationCircle.setLatLng(this._mainMap.getCenter());
     },
 
     _onMiniMapMoveStarted: function(e) {
@@ -15736,38 +15736,38 @@ L.Control.MiniMap = L.Control.extend({
     _decideZoom: function(fromMaintoMini) {
         if (!this.options.zoomLevelFixed && this.options.zoomLevelFixed != 0) {
             if (fromMaintoMini) {
-				return this._mainMap.getZoom() + this.options.zoomLevelOffset;
-			} else {
-				var currentDiff = this._miniMap.getZoom() - this._mainMap.getZoom();
-				var proposedZoom = this._miniMap.getZoom() - this.options.zoomLevelOffset;
-				var toRet;
+        return this._mainMap.getZoom() + this.options.zoomLevelOffset;
+      } else {
+        var currentDiff = this._miniMap.getZoom() - this._mainMap.getZoom();
+        var proposedZoom = this._miniMap.getZoom() - this.options.zoomLevelOffset;
+        var toRet;
 
-				if (currentDiff > this.options.zoomLevelOffset && this._mainMap.getZoom() < this._miniMap.getMinZoom() - this.options.zoomLevelOffset) {
-				    //This means the miniMap is zoomed out to the minimum zoom level and can't zoom any more.
-				    if (this._miniMap.getZoom() > this._lastMiniMapZoom) {
-				        //This means the user is trying to zoom in by using the minimap, zoom the main map.
-				        toRet = this._mainMap.getZoom() + 1;
-				        //Also we cheat and zoom the minimap out again to keep it visually consistent.
-				        this._miniMap.setZoom(this._miniMap.getZoom() - 1);
-				    } else {
-				        //Either the user is trying to zoom out past the mini map's min zoom or has just panned using it, we can't tell the difference.
-				        //Therefore, we ignore it!
-				        toRet = this._mainMap.getZoom();
-				    }
-				} else {
-				    //This is what happens in the majority of cases, and always if you configure the min levels + offset in a sane fashion.
-				    toRet = proposedZoom;
-				}
-				this._lastMiniMapZoom = this._miniMap.getZoom();
-				return toRet;
+        if (currentDiff > this.options.zoomLevelOffset && this._mainMap.getZoom() < this._miniMap.getMinZoom() - this.options.zoomLevelOffset) {
+            //This means the miniMap is zoomed out to the minimum zoom level and can't zoom any more.
+            if (this._miniMap.getZoom() > this._lastMiniMapZoom) {
+                //This means the user is trying to zoom in by using the minimap, zoom the main map.
+                toRet = this._mainMap.getZoom() + 1;
+                //Also we cheat and zoom the minimap out again to keep it visually consistent.
+                this._miniMap.setZoom(this._miniMap.getZoom() - 1);
+            } else {
+                //Either the user is trying to zoom out past the mini map's min zoom or has just panned using it, we can't tell the difference.
+                //Therefore, we ignore it!
+                toRet = this._mainMap.getZoom();
+            }
+        } else {
+            //This is what happens in the majority of cases, and always if you configure the min levels + offset in a sane fashion.
+            toRet = proposedZoom;
+        }
+        this._lastMiniMapZoom = this._miniMap.getZoom();
+        return toRet;
             }
         } else {
             if (fromMaintoMini) {
-				return this.options.zoomLevelFixed;
-			} else {
-				return this._mainMap.getZoom();
-			}
-             
+        return this.options.zoomLevelFixed;
+      } else {
+        return this._mainMap.getZoom();
+      }
+
         }
     },
 
@@ -15806,186 +15806,186 @@ L.control.minimap = function(options) {
      Begin VCO.TileLayer.Stamen.js
 ********************************************** */
 
-/*	VCO.TyleLayer.Stamen
-	Makes Stamen Map tiles available
-	http://maps.stamen.com/
+/*  VCO.TyleLayer.Stamen
+  Makes Stamen Map tiles available
+  http://maps.stamen.com/
 ================================================== */
 
 (function(exports) {
 
-	/*	tile.stamen.js v1.2.3
-	================================================== */
-	var SUBDOMAINS = "a b c d".split(" "),
-		MAKE_PROVIDER = function(layer, type, minZoom, maxZoom) {
-			return {
-				"url":          ["http://stamen-tiles-{S}.a.ssl.fastly.net/", layer, "/{Z}/{X}/{Y}.", type].join(""),
-				"type":         type,
-				"subdomains":   SUBDOMAINS.slice(),
-				"minZoom":      minZoom,
-	            "maxZoom":      maxZoom,
-	            "attribution":  [
-					"<a href='http://leafletjs.com' title='A JS library for interactive maps'>Leaflet</a> | ",
-	                'Map tiles by <a href="http://stamen.com">Stamen Design</a>, ',
-	                'under <a href="http://creativecommons.org/licenses/by/3.0">CC BY 3.0</a>. ',
-	                'Data by <a href="http://openstreetmap.org">OpenStreetMap</a>, ',
-	                'under <a href="http://creativecommons.org/licenses/by-sa/3.0">CC BY SA</a>.'
-	            ].join("")
-	        };
-	    },
-	    PROVIDERS =  {
-	        "toner":        MAKE_PROVIDER("toner", "png", 0, 20),
-	        "terrain":      MAKE_PROVIDER("terrain", "jpg", 4, 18),
-	        "watercolor":   MAKE_PROVIDER("watercolor", "jpg", 1, 16),
-	        "trees-cabs-crime": {
-	            "url": "http://{S}.tiles.mapbox.com/v3/stamen.trees-cabs-crime/{Z}/{X}/{Y}.png",
-	            "type": "png",
-	            "subdomains": "a b c d".split(" "),
-	            "minZoom": 11,
-	            "maxZoom": 18,
-	            "extent": [
-	                {"lat": 37.853, "lon": -122.577},
-	                {"lat": 37.684, "lon": -122.313}
-	            ],
-	            "attribution": [
-	                'Design by Shawn Allen at <a href="http://stamen.com">Stamen</a>.',
-	                'Data courtesy of <a href="http://fuf.net">FuF</a>,',
-	                '<a href="http://www.yellowcabsf.com">Yellow Cab</a>',
-	                '&amp; <a href="http://sf-police.org">SFPD</a>.'
-	            ].join(" ")
-	        }
-	    };
+  /*  tile.stamen.js v1.2.3
+  ================================================== */
+  var SUBDOMAINS = "a b c d".split(" "),
+    MAKE_PROVIDER = function(layer, type, minZoom, maxZoom) {
+      return {
+        "url":          ["//stamen-tiles-{S}.a.ssl.fastly.net/", layer, "/{Z}/{X}/{Y}.", type].join(""),
+        "type":         type,
+        "subdomains":   SUBDOMAINS.slice(),
+        "minZoom":      minZoom,
+              "maxZoom":      maxZoom,
+              "attribution":  [
+          "<a href='http://leafletjs.com' title='A JS library for interactive maps'>Leaflet</a> | ",
+                  'Map tiles by <a href="http://stamen.com">Stamen Design</a>, ',
+                  'under <a href="http://creativecommons.org/licenses/by/3.0">CC BY 3.0</a>. ',
+                  'Data by <a href="http://openstreetmap.org">OpenStreetMap</a>, ',
+                  'under <a href="http://creativecommons.org/licenses/by-sa/3.0">CC BY SA</a>.'
+              ].join("")
+          };
+      },
+      PROVIDERS =  {
+          "toner":        MAKE_PROVIDER("toner", "png", 0, 20),
+          "terrain":      MAKE_PROVIDER("terrain", "jpg", 4, 18),
+          "watercolor":   MAKE_PROVIDER("watercolor", "jpg", 1, 16),
+          "trees-cabs-crime": {
+              "url": "http://{S}.tiles.mapbox.com/v3/stamen.trees-cabs-crime/{Z}/{X}/{Y}.png",
+              "type": "png",
+              "subdomains": "a b c d".split(" "),
+              "minZoom": 11,
+              "maxZoom": 18,
+              "extent": [
+                  {"lat": 37.853, "lon": -122.577},
+                  {"lat": 37.684, "lon": -122.313}
+              ],
+              "attribution": [
+                  'Design by Shawn Allen at <a href="http://stamen.com">Stamen</a>.',
+                  'Data courtesy of <a href="http://fuf.net">FuF</a>,',
+                  '<a href="http://www.yellowcabsf.com">Yellow Cab</a>',
+                  '&amp; <a href="http://sf-police.org">SFPD</a>.'
+              ].join(" ")
+          }
+      };
 
-	// set up toner and terrain flavors
-	setupFlavors("toner", ["hybrid", "labels", "lines", "background", "lite"]);
-	// toner 2010
-	setupFlavors("toner", ["2010"]);
-	// toner 2011 flavors
-	setupFlavors("toner", ["2011", "2011-lines", "2011-labels", "2011-lite"]);
-	setupFlavors("terrain", ["background"]);
-	setupFlavors("terrain", ["labels", "lines"], "png");
-
-
-	/*	Export stamen.tile to the provided namespace.
-	================================================== */
-	exports.stamen = exports.stamen || {};
-	exports.stamen.tile = exports.stamen.tile || {};
-	exports.stamen.tile.providers = PROVIDERS;
-	exports.stamen.tile.getProvider = getProvider;
+  // set up toner and terrain flavors
+  setupFlavors("toner", ["hybrid", "labels", "lines", "background", "lite"]);
+  // toner 2010
+  setupFlavors("toner", ["2010"]);
+  // toner 2011 flavors
+  setupFlavors("toner", ["2011", "2011-lines", "2011-labels", "2011-lite"]);
+  setupFlavors("terrain", ["background"]);
+  setupFlavors("terrain", ["labels", "lines"], "png");
 
 
-	/*	A shortcut for specifying "flavors" of a style, which are assumed to have the
-		same type and zoom range.
-	================================================== */
-	function setupFlavors(base, flavors, type) {
-	    var provider = getProvider(base);
-	    for (var i = 0; i < flavors.length; i++) {
-	        var flavor = [base, flavors[i]].join("-");
-	        PROVIDERS[flavor] = MAKE_PROVIDER(flavor, type || provider.type, provider.minZoom, provider.maxZoom);
-	    }
-	}
+  /*  Export stamen.tile to the provided namespace.
+  ================================================== */
+  exports.stamen = exports.stamen || {};
+  exports.stamen.tile = exports.stamen.tile || {};
+  exports.stamen.tile.providers = PROVIDERS;
+  exports.stamen.tile.getProvider = getProvider;
 
-	/*	Get the named provider, or throw an exception 
-		if it doesn't exist.
-	================================================== */
-	function getProvider(name) {
-	    if (name in PROVIDERS) {
-	        return PROVIDERS[name];
-	    } else {
-	        throw 'No such provider (' + name + ')';
-	    }
-	}
 
-	/*	StamenTileLayer for modestmaps-js
-		<https://github.com/modestmaps/modestmaps-js/>
-		Works with both 1.x and 2.x by checking for the existence of MM.Template.
-	================================================== */
-	if (typeof MM === "object") {
-	    var ModestTemplate = (typeof MM.Template === "function")
-	        ? MM.Template
-	        : MM.TemplatedMapProvider;
-	    MM.StamenTileLayer = function(name) {
-	        var provider = getProvider(name);
-	        this._provider = provider;
-	        MM.Layer.call(this, new ModestTemplate(provider.url, provider.subdomains));
-	        this.provider.setZoomRange(provider.minZoom, provider.maxZoom);
-	        this.attribution = provider.attribution;
-	    };
+  /*  A shortcut for specifying "flavors" of a style, which are assumed to have the
+    same type and zoom range.
+  ================================================== */
+  function setupFlavors(base, flavors, type) {
+      var provider = getProvider(base);
+      for (var i = 0; i < flavors.length; i++) {
+          var flavor = [base, flavors[i]].join("-");
+          PROVIDERS[flavor] = MAKE_PROVIDER(flavor, type || provider.type, provider.minZoom, provider.maxZoom);
+      }
+  }
 
-	    MM.StamenTileLayer.prototype = {
-	        setCoordLimits: function(map) {
-	            var provider = this._provider;
-	            if (provider.extent) {
-	                map.coordLimits = [
-	                    map.locationCoordinate(provider.extent[0]).zoomTo(provider.minZoom),
-	                    map.locationCoordinate(provider.extent[1]).zoomTo(provider.maxZoom)
-	                ];
-	                return true;
-	            } else {
-	                return false;
-	            }
-	        }
-	    };
+  /*  Get the named provider, or throw an exception
+    if it doesn't exist.
+  ================================================== */
+  function getProvider(name) {
+      if (name in PROVIDERS) {
+          return PROVIDERS[name];
+      } else {
+          throw 'No such provider (' + name + ')';
+      }
+  }
 
-	    MM.extend(MM.StamenTileLayer, MM.Layer);
-	}
+  /*  StamenTileLayer for modestmaps-js
+    <https://github.com/modestmaps/modestmaps-js/>
+    Works with both 1.x and 2.x by checking for the existence of MM.Template.
+  ================================================== */
+  if (typeof MM === "object") {
+      var ModestTemplate = (typeof MM.Template === "function")
+          ? MM.Template
+          : MM.TemplatedMapProvider;
+      MM.StamenTileLayer = function(name) {
+          var provider = getProvider(name);
+          this._provider = provider;
+          MM.Layer.call(this, new ModestTemplate(provider.url, provider.subdomains));
+          this.provider.setZoomRange(provider.minZoom, provider.maxZoom);
+          this.attribution = provider.attribution;
+      };
 
-	/*	StamenTileLayer for Leaflet
-		<http://leaflet.cloudmade.com/>
-		Tested with version 0.3 and 0.4, but should work on all 0.x releases.
-	================================================== */
-	if (typeof L === "object") {
-	    L.StamenTileLayer = L.TileLayer.extend({
-	        initialize: function(name, options) {
-	            var provider = getProvider(name),
-	                url = provider.url.replace(/({[A-Z]})/g, function(s) {
-	                    return s.toLowerCase();
-	                }), 
-					_options = {
-						minZoom: 		provider.minZoom,
-						maxZoom: 		provider.maxZoom,
-						subdomains: 	provider.subdomains,
-						scheme: 		"xyz",
-						attribution: 	provider.attribution
-					};
-					
-				if (options) {
-					VCO.Util.mergeData(_options, options);
-				}
-				
-	            L.TileLayer.prototype.initialize.call(this, url, _options);
-	        }
-	    });
-	}
+      MM.StamenTileLayer.prototype = {
+          setCoordLimits: function(map) {
+              var provider = this._provider;
+              if (provider.extent) {
+                  map.coordLimits = [
+                      map.locationCoordinate(provider.extent[0]).zoomTo(provider.minZoom),
+                      map.locationCoordinate(provider.extent[1]).zoomTo(provider.maxZoom)
+                  ];
+                  return true;
+              } else {
+                  return false;
+              }
+          }
+      };
 
-	/*	 StamenMapType for Google Maps API V3
-		<https://developers.google.com/maps/documentation/javascript/>
-	================================================== */
-	if (typeof google === "object" && typeof google.maps === "object") {
-	    google.maps.StamenMapType = function(name) {
-	        var provider = getProvider(name),
-	            subdomains = provider.subdomains;
-	        return google.maps.ImageMapType.call(this, {
-	            "getTileUrl": function(coord, zoom) {
-	                var numTiles = 1 << zoom,
-	                    wx = coord.x % numTiles,
-	                    x = (wx < 0) ? wx + numTiles : wx,
-	                    y = coord.y,
-	                    index = (zoom + x + y) % subdomains.length;
-	                return provider.url
-	                    .replace("{S}", subdomains[index])
-	                    .replace("{Z}", zoom)
-	                    .replace("{X}", x)
-	                    .replace("{Y}", y);
-	            },
-	            "tileSize": new google.maps.Size(256, 256),
-	            "name":     name,
-	            "minZoom":  provider.minZoom,
-	            "maxZoom":  provider.maxZoom
-	        });
-	    };
-	    // FIXME: is there a better way to extend classes in Google land?
-	    google.maps.StamenMapType.prototype = new google.maps.ImageMapType("_");
-	}
+      MM.extend(MM.StamenTileLayer, MM.Layer);
+  }
+
+  /*  StamenTileLayer for Leaflet
+    <http://leaflet.cloudmade.com/>
+    Tested with version 0.3 and 0.4, but should work on all 0.x releases.
+  ================================================== */
+  if (typeof L === "object") {
+      L.StamenTileLayer = L.TileLayer.extend({
+          initialize: function(name, options) {
+              var provider = getProvider(name),
+                  url = provider.url.replace(/({[A-Z]})/g, function(s) {
+                      return s.toLowerCase();
+                  }),
+          _options = {
+            minZoom:    provider.minZoom,
+            maxZoom:    provider.maxZoom,
+            subdomains:   provider.subdomains,
+            scheme:     "xyz",
+            attribution:  provider.attribution
+          };
+
+        if (options) {
+          VCO.Util.mergeData(_options, options);
+        }
+
+              L.TileLayer.prototype.initialize.call(this, url, _options);
+          }
+      });
+  }
+
+  /*   StamenMapType for Google Maps API V3
+    <https://developers.google.com/maps/documentation/javascript/>
+  ================================================== */
+  if (typeof google === "object" && typeof google.maps === "object") {
+      google.maps.StamenMapType = function(name) {
+          var provider = getProvider(name),
+              subdomains = provider.subdomains;
+          return google.maps.ImageMapType.call(this, {
+              "getTileUrl": function(coord, zoom) {
+                  var numTiles = 1 << zoom,
+                      wx = coord.x % numTiles,
+                      x = (wx < 0) ? wx + numTiles : wx,
+                      y = coord.y,
+                      index = (zoom + x + y) % subdomains.length;
+                  return provider.url
+                      .replace("{S}", subdomains[index])
+                      .replace("{Z}", zoom)
+                      .replace("{X}", x)
+                      .replace("{Y}", y);
+              },
+              "tileSize": new google.maps.Size(256, 256),
+              "name":     name,
+              "minZoom":  provider.minZoom,
+              "maxZoom":  provider.maxZoom
+          });
+      };
+      // FIXME: is there a better way to extend classes in Google land?
+      google.maps.StamenMapType.prototype = new google.maps.ImageMapType("_");
+  }
 
 })(typeof exports === "undefined" ? this : exports);
 
@@ -15994,153 +15994,153 @@ L.control.minimap = function(options) {
      Begin VCO.MapMarker.js
 ********************************************** */
 
-/*	VCO.MapMarker
-	Creates a marker. Takes a data object and
-	populates the marker with content.
+/*  VCO.MapMarker
+  Creates a marker. Takes a data object and
+  populates the marker with content.
 ================================================== */
 
 VCO.MapMarker = VCO.Class.extend({
-	
-	includes: [VCO.Events],
-	
-	/*	Constructor
-	================================================== */
-	initialize: function(data, options) {
-		
-		// DOM Elements
-		this._el = {
-			container: {},
-			content_container: {},
-			content: {}
-		};
-	
-		// Components
-		this._marker = {};
-		
-		// Icon
-		this._icon = {};
-		this._custom_icon = false;
-		this._custom_icon_url = "";
-		this._custom_image_icon = false;
-		
-		// Marker Number
-		this.marker_number = 0;
-		
-		// Media Icon
-		this.media_icon_class = "";
-		
-		// Timer
-		this.timer = {};
-	
-		// Data
-		this.data = {};
-	
-		// Options
-		this.options = {
-			// animation
-			duration: 			1000,
-			ease: 				VCO.Ease.easeInSpline,
-			width: 				600,
-			height: 			600,
-			map_popup: 			false,
-			use_custom_markers: false
-		};
-		
-		
-		// Animation Object
-		this.animator = null;
-		
-		// Merge Data and Options
-		VCO.Util.mergeData(this.options, options);
-		VCO.Util.mergeData(this.data, data);
-		
-		this._initLayout();
-		
-		
-	},
-	
-	/*	Public
-	================================================== */
-	show: function() {
-		
-	},
-	
-	hide: function() {
-		
-	},
-	
-	addTo: function(m) {
-		this._addTo(m);
-	},
-	
-	removeFrom: function(m) {
-		this._removeFrom(m)
-	},
-	
-	updateDisplay: function(w, h, a) {
-		this._updateDisplay(w, h, a);
-	},
-	
-	createMarker: function(d, o) {
-		this._createMarker(d, o);
-	},
-	
-	createPopup: function(d, o) {
-		this._createPopup(d, o);
-	},
-	
-	active: function(a) {
-		this._active(a);
-	},
-	
-	location: function() {
-		return this._location();
-	},
-	
-	/*	Marker Specific
-		Specific to Map API
-	================================================== */
-		_createMarker: function(d, o) {
-			
-		},
-		
-		_addTo: function(m) {
-			
-		},
-		
-		_removeFrom: function(m) {
-			
-		},
-		
-		_createPopup: function(d, o) {
-		
-		},
-		
-		_active: function(a) {
-			
-		},
-		
-		_location: function() {
-			return {lat:0, lng:0}
-		},
-	
-	/*	Events
-	================================================== */
-	_onMarkerClick: function(e) {
-		this.fire("markerclick", {marker_number: this.marker_number});
-	},
-	
-	/*	Private Methods
-	================================================== */
-	_initLayout: function () {
-		this._createMarker(this.data, this.options);
-	},
-	
-	// Update Display
-	_updateDisplay: function(width, height, animate) {
-		
-	}
-	
+
+  includes: [VCO.Events],
+
+  /*  Constructor
+  ================================================== */
+  initialize: function(data, options) {
+
+    // DOM Elements
+    this._el = {
+      container: {},
+      content_container: {},
+      content: {}
+    };
+
+    // Components
+    this._marker = {};
+
+    // Icon
+    this._icon = {};
+    this._custom_icon = false;
+    this._custom_icon_url = "";
+    this._custom_image_icon = false;
+
+    // Marker Number
+    this.marker_number = 0;
+
+    // Media Icon
+    this.media_icon_class = "";
+
+    // Timer
+    this.timer = {};
+
+    // Data
+    this.data = {};
+
+    // Options
+    this.options = {
+      // animation
+      duration:       1000,
+      ease:         VCO.Ease.easeInSpline,
+      width:        600,
+      height:       600,
+      map_popup:      false,
+      use_custom_markers: false
+    };
+
+
+    // Animation Object
+    this.animator = null;
+
+    // Merge Data and Options
+    VCO.Util.mergeData(this.options, options);
+    VCO.Util.mergeData(this.data, data);
+
+    this._initLayout();
+
+
+  },
+
+  /*  Public
+  ================================================== */
+  show: function() {
+
+  },
+
+  hide: function() {
+
+  },
+
+  addTo: function(m) {
+    this._addTo(m);
+  },
+
+  removeFrom: function(m) {
+    this._removeFrom(m)
+  },
+
+  updateDisplay: function(w, h, a) {
+    this._updateDisplay(w, h, a);
+  },
+
+  createMarker: function(d, o) {
+    this._createMarker(d, o);
+  },
+
+  createPopup: function(d, o) {
+    this._createPopup(d, o);
+  },
+
+  active: function(a) {
+    this._active(a);
+  },
+
+  location: function() {
+    return this._location();
+  },
+
+  /*  Marker Specific
+    Specific to Map API
+  ================================================== */
+    _createMarker: function(d, o) {
+
+    },
+
+    _addTo: function(m) {
+
+    },
+
+    _removeFrom: function(m) {
+
+    },
+
+    _createPopup: function(d, o) {
+
+    },
+
+    _active: function(a) {
+
+    },
+
+    _location: function() {
+      return {lat:0, lng:0}
+    },
+
+  /*  Events
+  ================================================== */
+  _onMarkerClick: function(e) {
+    this.fire("markerclick", {marker_number: this.marker_number});
+  },
+
+  /*  Private Methods
+  ================================================== */
+  _initLayout: function () {
+    this._createMarker(this.data, this.options);
+  },
+
+  // Update Display
+  _updateDisplay: function(width, height, animate) {
+
+  }
+
 });
 
 
@@ -16148,745 +16148,745 @@ VCO.MapMarker = VCO.Class.extend({
      Begin VCO.Map.js
 ********************************************** */
 
-/*	VCO.Map
-	Makes a Map
+/*  VCO.Map
+  Makes a Map
 
-	Events:
-	markerAdded
-	markerRemoved
+  Events:
+  markerAdded
+  markerRemoved
 
 
 ================================================== */
- 
-VCO.Map = VCO.Class.extend({
-	
-	includes: [VCO.Events, VCO.DomMixins],
-	
-	_el: {},
-	
-	/*	Constructor
-	================================================== */
-	initialize: function(elem, data, options) {
-		// DOM ELEMENTS
-		this._el = {
-			container: {},
-			map: {},
-			map_mask: {}
-		};
-		
-		if (typeof elem === 'object') {
-			this._el.container = elem;
-		} else {
-			this._el.container = VCO.Dom.get(elem);
-		}
-		
-		// LOADED
-		this._loaded = {
-			data: 	false,
-			map: 	false
-		};
-		
-		// MAP
-		this._map = null;
-		
-		// MINI MAP
-		this._mini_map = null;
-		
-		// Markers
-		this._markers = [];
-		
-		// Marker Zoom Miniumum and Maximum
-		this.zoom_min_max = {
-			min: null,
-			max: null
-		};
-		
-		// Line
-		this._line = null;
-		this._line_active = null;
-		
-		// Current Marker
-		this.current_marker = 0;
-		
-		// Markers Bounds Array
-		this.bounds_array = null;
-		
-		// Map Tiles Layer
-		this._tile_layer = null;
-		
-		// Map Tiles Layer for Mini Map
-		this._tile_layer_mini = null;
-		
-		// Image Layer (for zoomify)
-		this._image_layer = null;
-	
-		// Data
-		this.data = {
-			uniqueid: 			"",
-			slides: 				[{test:"yes"}, {test:"yes"}, {test:"yes"}]
-		};
-	
-		//Options
-		this.options = {
-			map_type: 			"stamen:toner-lite",
-			map_as_image: 		false,
-			map_mini: 			false,
-			map_background_color: "#d9d9d9",
-			map_subdomains: 	"",
-			zoomify: {
-				path: 			"",
-				width: 			"",
-				height: 		"",
-				tolerance: 		0.8,
-				attribution: 	""
-			},
-			skinny_size: 		650,
-			less_bounce: 		true,
-			path_gfx: 			"gfx",
-			start_at_slide: 	0,
-			map_popup: 			false, 
-			zoom_distance: 		100,
-			calculate_zoom: 	true,  // Allow map to determine best zoom level between markers (recommended)
-			line_follows_path: 	true,  // Map history path follows default line, if false it will connect previous and current only
-			line_color: 		"#333",
-			line_color_inactive: "#000", 
-			line_weight: 		5,
-			line_opacity: 		0.20,
-			line_dash: 			"5,5",
-			line_join: 			"miter",
-			show_lines: 		true,
-			show_history_line: 	true,
-			use_custom_markers: false,
-			map_center_offset:  null // takes object {top:0,left:0}
-		};
-		
-		// Animation
-		this.animator = null;
-		
-		// Timer
-		this.timer = null;
-		
-		// Touchpad Events
-		this.touch_scale = 1;
-		this.scroll = {
-			start_time: null
-		};
-		
-		// Merge Data and Options
-		VCO.Util.mergeData(this.options, options);
-		VCO.Util.mergeData(this.data, data);
-		
-		this._initLayout();
-		this._initEvents();
-		this._createMap();
-		this._initData();
-		
-		
-	},
-	
-	/*	Public
-	================================================== */
-	updateDisplay: function(w, h, animate, d, offset) {
-		this._updateDisplay(w, h, animate, d, offset);
-	},
-	
-	goTo: function(n, change) {
-		if (n < this._markers.length && n >= 0) {
-			var zoom = 0,
-				previous_marker = this.current_marker;
-				
-			this.current_marker = n;
-			
-			var marker = this._markers[this.current_marker];
-			
-			// Stop animation
-			if (this.animator) {
-				this.animator.stop();
-			}
-			
-			// Reset Active Markers
-			this._resetMarkersActive();
-			
-			// Check to see if it's an overview
-			if (marker.data.type && marker.data.type == "overview") {
-				this._markerOverview();
-				if (!change) {
-					this._onMarkerChange();
-				}
-			} else {
-				// Make marker active
-				marker.active(true);
-				
-				if (change) {
-					// Set Map View
-					if (marker.data.location) {
-						this._viewTo(marker.data.location);
-					} else {
-						
-					}
-					
-					
-				} else {
-					if (marker.data.location && marker.data.location.lat) {
-						
-						// Calculate Zoom
-						zoom = this._calculateZoomChange(this._getMapCenter(true), marker.location());
-						
-						// Set Map View
-						this._viewTo(marker.data.location, {calculate_zoom: this.options.calculate_zoom, zoom:zoom});
-					
-						// Show Line
-						if (this.options.line_follows_path) {
-							if (this.options.show_history_line && marker.data.real_marker && this._markers[previous_marker].data.real_marker) {
-								var lines_array = [],
-									line_num = previous_marker,
-									point;
-							
-								if (line_num < this.current_marker) {
-									while (line_num < this.current_marker) {
-										if (this._markers[line_num].data.location && this._markers[line_num].data.location.lat) {
-											point = {
-												lat:this._markers[line_num].data.location.lat,
-												lon:this._markers[line_num].data.location.lon
-											}
-											lines_array.push(point);
-										}
-										
-										line_num++;
-									}
-								} else if (line_num > this.current_marker) {
-									while (line_num > this.current_marker) {
-										if (this._markers[line_num].data.location && this._markers[line_num].data.location.lat) {
-											point = {
-												lat:this._markers[line_num].data.location.lat,
-												lon:this._markers[line_num].data.location.lon
-											}
-											lines_array.push(point);
-										}
-										
-										line_num--;
-									}
-								}
-						
-								lines_array.push({
-									lat:marker.data.location.lat,
-									lon:marker.data.location.lon
-								});
-						
-								this._replaceLines(this._line_active, lines_array);
-							}
-						} else {
-							// Show Line
-							if (this.options.show_history_line && marker.data.real_marker && this._markers[previous_marker].data.real_marker) {
-								this._replaceLines(this._line_active, [
-									{
-										lat:marker.data.location.lat,
-										lon:marker.data.location.lon
-									}, 
-									{
-										lat:this._markers[previous_marker].data.location.lat,
-										lon:this._markers[previous_marker].data.location.lon
-									}
-								])
-							}
-						
-						}
-					} else {
-						this._markerOverview();
-						if (!change) {
-							this._onMarkerChange();
-						}
-						
-					}
 
-					// Fire Event
-					this._onMarkerChange();
-					
-				}
-				
-			}
-			
-		}
-	},
-	
-	panTo: function(loc, animate) {
-		this._panTo(loc, animate);
-	},
-	
-	zoomTo: function(z, animate) {
-		this._zoomTo(z, animate);
-	},
-	
-	viewTo: function(loc, opts) {
-		this._viewTo(loc, opts);
-	},
-	
-	getBoundsZoom: function(m1, m2, inside, padding) {
-		this.__getBoundsZoom(m1, m2, inside, padding); // (LatLngBounds[, Boolean, Point]) -> Number
-	},
-	
-	markerOverview: function() {
-		this._markerOverview();
-	},
-	
-	calculateMarkerZooms: function() {
-		this._calculateMarkerZooms();
-	},
-	
-	createMiniMap: function() {
-		this._createMiniMap();
-	},
-	
-	setMapOffset: function(left, top) {
-		// Update Component Displays
-		this.options.map_center_offset.left = left;
-		this.options.map_center_offset.top 	= top;
-	},
-	
-	calculateMinMaxZoom: function() {
-		for (var i = 0; i < this._markers.length; i++) {
-			
-			if (this._markers[i].data.location && this._markers[i].data.location.zoom) {
-				this.updateMinMaxZoom(this._markers[i].data.location.zoom);
-			}
-			
-		}
-		trace("MAX ZOOM: " + this.zoom_min_max.max + " MIN ZOOM: " + this.zoom_min_max.min);
-	},
-	
-	updateMinMaxZoom: function(zoom) {
-		if (!this.zoom_min_max.max) {
-			this.zoom_min_max.max = zoom;
-		}
-		
-		if (!this.zoom_min_max.min) {
-			this.zoom_min_max.min = zoom;
-		}
-		
-		if (this.zoom_min_max.max < zoom) {
-			this.zoom_min_max.max = zoom;
-		}
-		if (this.zoom_min_max.min > zoom) {
-			this.zoom_min_max.min = zoom;
-		}
-	},
-	
-	initialMapLocation: function() {
-		if (this._loaded.data && this._loaded.map) {
-			this.goTo(this.options.start_at_slide, true);
-			this._initialMapLocation();
-		}
-	},
-	
-	/*	Adding, Hiding, Showing etc
-	================================================== */
-	show: function() {
-		
-	},
-	
-	hide: function() {
-		
-	},
-	
-	addTo: function(container) {
-		container.appendChild(this._el.container);
-		this.onAdd();
-	},
-	
-	removeFrom: function(container) {
-		container.removeChild(this._el.container);
-		this.onRemove();
-	},
-	
-	/*	Adding and Removing Markers
-	================================================== */
-	createMarkers: function(array) {
-		this._createMarkers(array)
-	},
-	
-	createMarker: function(d) {
-		this._createMarker(d);
-	},
-	
-	_destroyMarker: function(marker) {
-		this._removeMarker(marker);
-		for (var i = 0; i < this._markers.length; i++) {
-			if (this._markers[i] == marker) {
-				this._markers.splice(i, 1);
-			}
-		}
-		this.fire("markerRemoved", marker);
-	},
-	
-	_createMarkers: function(array) {
-		for (var i = 0; i < array.length; i++) {
-			this._createMarker(array[i]);
-			if (array[i].location && array[i].location.lat && this.options.show_lines) {
-				this._addToLine(this._line, array[i]);
-			}
-		};
-		
-	},
-	
-	_createLines: function(array) {
-		
-	},
-	
-	
-	/*	Map Specific
-	================================================== */
-	
-		/*	Map Specific Create
-		================================================== */
-		// Extend this map class and use this to create the map using preferred API
-		_createMap: function() {
-			
-		},
-		
-		/*	Mini Map Specific Create
-		================================================== */
-		// Extend this map class and use this to create the map using preferred API
-		_createMiniMap: function() {
-			
-		},
-	
-		/*	Map Specific Marker
-		================================================== */
-		
-		// Specific Marker Methods based on preferred Map API
-		_createMarker: function(d) {
-			var marker = {};
-			marker.on("markerclick", this._onMarkerClick);
-			this._addMarker(marker);
-			this._markers.push(marker);
-			marker.marker_number = this._markers.length - 1;
-			this.fire("markerAdded", marker);
-		},
-	
-		_addMarker: function(marker) {
-		
-		},
-	
-		_removeMarker: function(marker) {
-		
-		},
-		
-		_resetMarkersActive: function() {
-			for (var i = 0; i < this._markers.length; i++) {
-				this._markers[i].active(false);
-			};
-		},
-		
-		_calculateMarkerZooms: function() {
-			
-		},
-		
-		/*	Map Specific Line
-		================================================== */
-		
-		_createLine: function(d) {
-			return {data: d};
-		},
-		
-		_addToLine: function(line, d) {
-			
-		},
-		
-		_replaceLines: function(line, d) {
-		
-		},
-		
-		_addLineToMap: function(line) {
-			
-		},
-		
-		
-		/*	Map Specific Methods
-		================================================== */
-		
-		_panTo: function(loc, animate) {
-			
-		},
-		
-		_zoomTo: function(z, animate) {
-		
-		},
-		
-		_viewTo: function(loc, opts) {
-		
-		},
-		
-		_updateMapDisplay: function(animate, d) {
-			
-		},
-		
-		_refreshMap: function() {
-			
-		},
-		
-		_getMapLocation: function(m) {
-			return {x:0, y:0};
-		},
-		
-		_getMapZoom: function() {
-			return 1;
-		},
-		
-		_getMapCenter: function() {
-			return {lat:0, lng:0};
-		},
-		
-		_getBoundsZoom: function(m1, m2, inside, padding) {
-		
-		},
-		
-		_markerOverview: function() {
-			
-		},
-	
-		_initialMapLocation: function() {
-			
-		},
-	
-	/*	Events
-	================================================== */
-	_onMarkerChange: function(e) {
-		this.fire("change", {current_marker:this.current_marker});
-	},
-	
-	_onMarkerClick: function(e) {
-		if (this.current_marker != e.marker_number) {
-			this.goTo(e.marker_number);
-		}
-	},
-	
-	_onMapLoaded: function(e) {
-		this._loaded.map = true;
-		
-		
-		if (this.options.calculate_zoom) {
-			this.calculateMarkerZooms();
-		}
-		
-		this.calculateMinMaxZoom();
-		
-		if (this.options.map_mini && !VCO.Browser.touch) {
-			this.createMiniMap();
-		}
-		
-		this.initialMapLocation();
-		this.fire("loaded", this.data);
-	},
-	
-	_onWheel: function(e) {
-		// borrowed from http://jsbin.com/qiyaseza/5/edit
-		var self = this;
-		
-		if (e.ctrlKey) {
-			var s = Math.exp(-e.deltaY/100);
-			this.touch_scale *= s;
-			e.preventDefault();
-			e.stopPropagation(e);
-		} 
-		
-		if (!this.scroll.start_time) {
-			this.scroll.start_time = +new Date();
-		};
-		
-		var time_left = Math.max(40 - (+new Date() - this.scroll.start_time), 0);
-		
-		clearTimeout(this.scroll.timer);
-		
-		this.scroll.timer = setTimeout(function() {
-			self._scollZoom();
-			//e.preventDefault();
-			//e.stopPropagation(e);
-		}, time_left);
-		
-		
-	},
-	
-	_scollZoom: function(e) {
-		var self = this,
-			current_zoom = this._getMapZoom();
-			
-		this.scroll.start_time = null;
-		//VCO.DomUtil.addClass(this._el.container, 'vco-map-touch-zoom');
-		clearTimeout(this.scroll.timer);
-		clearTimeout(this.scroll.timer_done);
-		
-		this.scroll.timer_done = setTimeout(function() {
-			self._scollZoomDone();
-		}, 1000);
-		
-		this.zoomTo(Math.round(current_zoom * this.touch_scale));
-	},
-	
-	_scollZoomDone: function(e) {
-		//VCO.DomUtil.removeClass(this._el.container, 'vco-map-touch-zoom');
-		this.touch_scale = 1;
-	},
-	
-	/*	Private Methods
-	================================================== */
-	
-	_calculateZoomChange: function(origin, destination, correct_for_center) {
-		return this._getBoundsZoom(origin, destination, correct_for_center);
-	},
-	
-	_updateDisplay: function(w, h, animate, d) {
-		
-		// Update Map Display
-		this._updateMapDisplay(animate, d);
-	},
-	
-	_initLayout: function() {
-		
-		// Create Layout
-		this._el.map_mask 	= VCO.Dom.create("div", "vco-map-mask", this._el.container);
-		
-		if (this.options.map_as_image) {
-			this._el.map 	= VCO.Dom.create("div", "vco-map-display vco-mapimage-display", this._el.map_mask);
-		} else {
-			this._el.map 	= VCO.Dom.create("div", "vco-map-display", this._el.map_mask);
-		}
-		
-		
-	},
-	
-	_initData: function() {
-		if (this.data.slides) {
-			this._createMarkers(this.data.slides);
-			this._resetMarkersActive();
-			this._markers[this.current_marker].active(true);
-			this._loaded.data = true;
-			this._initialMapLocation();
-			
-		}
-	},
-	
-	_initEvents: function() {
-		var self = this;
-		
-		this._el.map.addEventListener('wheel', function(e) {
-			self._onWheel(e);
-		});
-		
-		//this.on("wheel", this._onWheel, this);
-	}
-	
+VCO.Map = VCO.Class.extend({
+
+  includes: [VCO.Events, VCO.DomMixins],
+
+  _el: {},
+
+  /*  Constructor
+  ================================================== */
+  initialize: function(elem, data, options) {
+    // DOM ELEMENTS
+    this._el = {
+      container: {},
+      map: {},
+      map_mask: {}
+    };
+
+    if (typeof elem === 'object') {
+      this._el.container = elem;
+    } else {
+      this._el.container = VCO.Dom.get(elem);
+    }
+
+    // LOADED
+    this._loaded = {
+      data:   false,
+      map:  false
+    };
+
+    // MAP
+    this._map = null;
+
+    // MINI MAP
+    this._mini_map = null;
+
+    // Markers
+    this._markers = [];
+
+    // Marker Zoom Miniumum and Maximum
+    this.zoom_min_max = {
+      min: null,
+      max: null
+    };
+
+    // Line
+    this._line = null;
+    this._line_active = null;
+
+    // Current Marker
+    this.current_marker = 0;
+
+    // Markers Bounds Array
+    this.bounds_array = null;
+
+    // Map Tiles Layer
+    this._tile_layer = null;
+
+    // Map Tiles Layer for Mini Map
+    this._tile_layer_mini = null;
+
+    // Image Layer (for zoomify)
+    this._image_layer = null;
+
+    // Data
+    this.data = {
+      uniqueid:       "",
+      slides:         [{test:"yes"}, {test:"yes"}, {test:"yes"}]
+    };
+
+    //Options
+    this.options = {
+      map_type:       "stamen:toner-lite",
+      map_as_image:     false,
+      map_mini:       false,
+      map_background_color: "#d9d9d9",
+      map_subdomains:   "",
+      zoomify: {
+        path:       "",
+        width:      "",
+        height:     "",
+        tolerance:    0.8,
+        attribution:  ""
+      },
+      skinny_size:    650,
+      less_bounce:    true,
+      path_gfx:       "gfx",
+      start_at_slide:   0,
+      map_popup:      false,
+      zoom_distance:    100,
+      calculate_zoom:   true,  // Allow map to determine best zoom level between markers (recommended)
+      line_follows_path:  true,  // Map history path follows default line, if false it will connect previous and current only
+      line_color:     "#333",
+      line_color_inactive: "#000",
+      line_weight:    5,
+      line_opacity:     0.20,
+      line_dash:      "5,5",
+      line_join:      "miter",
+      show_lines:     true,
+      show_history_line:  true,
+      use_custom_markers: false,
+      map_center_offset:  null // takes object {top:0,left:0}
+    };
+
+    // Animation
+    this.animator = null;
+
+    // Timer
+    this.timer = null;
+
+    // Touchpad Events
+    this.touch_scale = 1;
+    this.scroll = {
+      start_time: null
+    };
+
+    // Merge Data and Options
+    VCO.Util.mergeData(this.options, options);
+    VCO.Util.mergeData(this.data, data);
+
+    this._initLayout();
+    this._initEvents();
+    this._createMap();
+    this._initData();
+
+
+  },
+
+  /*  Public
+  ================================================== */
+  updateDisplay: function(w, h, animate, d, offset) {
+    this._updateDisplay(w, h, animate, d, offset);
+  },
+
+  goTo: function(n, change) {
+    if (n < this._markers.length && n >= 0) {
+      var zoom = 0,
+        previous_marker = this.current_marker;
+
+      this.current_marker = n;
+
+      var marker = this._markers[this.current_marker];
+
+      // Stop animation
+      if (this.animator) {
+        this.animator.stop();
+      }
+
+      // Reset Active Markers
+      this._resetMarkersActive();
+
+      // Check to see if it's an overview
+      if (marker.data.type && marker.data.type == "overview") {
+        this._markerOverview();
+        if (!change) {
+          this._onMarkerChange();
+        }
+      } else {
+        // Make marker active
+        marker.active(true);
+
+        if (change) {
+          // Set Map View
+          if (marker.data.location) {
+            this._viewTo(marker.data.location);
+          } else {
+
+          }
+
+
+        } else {
+          if (marker.data.location && marker.data.location.lat) {
+
+            // Calculate Zoom
+            zoom = this._calculateZoomChange(this._getMapCenter(true), marker.location());
+
+            // Set Map View
+            this._viewTo(marker.data.location, {calculate_zoom: this.options.calculate_zoom, zoom:zoom});
+
+            // Show Line
+            if (this.options.line_follows_path) {
+              if (this.options.show_history_line && marker.data.real_marker && this._markers[previous_marker].data.real_marker) {
+                var lines_array = [],
+                  line_num = previous_marker,
+                  point;
+
+                if (line_num < this.current_marker) {
+                  while (line_num < this.current_marker) {
+                    if (this._markers[line_num].data.location && this._markers[line_num].data.location.lat) {
+                      point = {
+                        lat:this._markers[line_num].data.location.lat,
+                        lon:this._markers[line_num].data.location.lon
+                      }
+                      lines_array.push(point);
+                    }
+
+                    line_num++;
+                  }
+                } else if (line_num > this.current_marker) {
+                  while (line_num > this.current_marker) {
+                    if (this._markers[line_num].data.location && this._markers[line_num].data.location.lat) {
+                      point = {
+                        lat:this._markers[line_num].data.location.lat,
+                        lon:this._markers[line_num].data.location.lon
+                      }
+                      lines_array.push(point);
+                    }
+
+                    line_num--;
+                  }
+                }
+
+                lines_array.push({
+                  lat:marker.data.location.lat,
+                  lon:marker.data.location.lon
+                });
+
+                this._replaceLines(this._line_active, lines_array);
+              }
+            } else {
+              // Show Line
+              if (this.options.show_history_line && marker.data.real_marker && this._markers[previous_marker].data.real_marker) {
+                this._replaceLines(this._line_active, [
+                  {
+                    lat:marker.data.location.lat,
+                    lon:marker.data.location.lon
+                  },
+                  {
+                    lat:this._markers[previous_marker].data.location.lat,
+                    lon:this._markers[previous_marker].data.location.lon
+                  }
+                ])
+              }
+
+            }
+          } else {
+            this._markerOverview();
+            if (!change) {
+              this._onMarkerChange();
+            }
+
+          }
+
+          // Fire Event
+          this._onMarkerChange();
+
+        }
+
+      }
+
+    }
+  },
+
+  panTo: function(loc, animate) {
+    this._panTo(loc, animate);
+  },
+
+  zoomTo: function(z, animate) {
+    this._zoomTo(z, animate);
+  },
+
+  viewTo: function(loc, opts) {
+    this._viewTo(loc, opts);
+  },
+
+  getBoundsZoom: function(m1, m2, inside, padding) {
+    this.__getBoundsZoom(m1, m2, inside, padding); // (LatLngBounds[, Boolean, Point]) -> Number
+  },
+
+  markerOverview: function() {
+    this._markerOverview();
+  },
+
+  calculateMarkerZooms: function() {
+    this._calculateMarkerZooms();
+  },
+
+  createMiniMap: function() {
+    this._createMiniMap();
+  },
+
+  setMapOffset: function(left, top) {
+    // Update Component Displays
+    this.options.map_center_offset.left = left;
+    this.options.map_center_offset.top  = top;
+  },
+
+  calculateMinMaxZoom: function() {
+    for (var i = 0; i < this._markers.length; i++) {
+
+      if (this._markers[i].data.location && this._markers[i].data.location.zoom) {
+        this.updateMinMaxZoom(this._markers[i].data.location.zoom);
+      }
+
+    }
+    trace("MAX ZOOM: " + this.zoom_min_max.max + " MIN ZOOM: " + this.zoom_min_max.min);
+  },
+
+  updateMinMaxZoom: function(zoom) {
+    if (!this.zoom_min_max.max) {
+      this.zoom_min_max.max = zoom;
+    }
+
+    if (!this.zoom_min_max.min) {
+      this.zoom_min_max.min = zoom;
+    }
+
+    if (this.zoom_min_max.max < zoom) {
+      this.zoom_min_max.max = zoom;
+    }
+    if (this.zoom_min_max.min > zoom) {
+      this.zoom_min_max.min = zoom;
+    }
+  },
+
+  initialMapLocation: function() {
+    if (this._loaded.data && this._loaded.map) {
+      this.goTo(this.options.start_at_slide, true);
+      this._initialMapLocation();
+    }
+  },
+
+  /*  Adding, Hiding, Showing etc
+  ================================================== */
+  show: function() {
+
+  },
+
+  hide: function() {
+
+  },
+
+  addTo: function(container) {
+    container.appendChild(this._el.container);
+    this.onAdd();
+  },
+
+  removeFrom: function(container) {
+    container.removeChild(this._el.container);
+    this.onRemove();
+  },
+
+  /*  Adding and Removing Markers
+  ================================================== */
+  createMarkers: function(array) {
+    this._createMarkers(array)
+  },
+
+  createMarker: function(d) {
+    this._createMarker(d);
+  },
+
+  _destroyMarker: function(marker) {
+    this._removeMarker(marker);
+    for (var i = 0; i < this._markers.length; i++) {
+      if (this._markers[i] == marker) {
+        this._markers.splice(i, 1);
+      }
+    }
+    this.fire("markerRemoved", marker);
+  },
+
+  _createMarkers: function(array) {
+    for (var i = 0; i < array.length; i++) {
+      this._createMarker(array[i]);
+      if (array[i].location && array[i].location.lat && this.options.show_lines) {
+        this._addToLine(this._line, array[i]);
+      }
+    };
+
+  },
+
+  _createLines: function(array) {
+
+  },
+
+
+  /*  Map Specific
+  ================================================== */
+
+    /*  Map Specific Create
+    ================================================== */
+    // Extend this map class and use this to create the map using preferred API
+    _createMap: function() {
+
+    },
+
+    /*  Mini Map Specific Create
+    ================================================== */
+    // Extend this map class and use this to create the map using preferred API
+    _createMiniMap: function() {
+
+    },
+
+    /*  Map Specific Marker
+    ================================================== */
+
+    // Specific Marker Methods based on preferred Map API
+    _createMarker: function(d) {
+      var marker = {};
+      marker.on("markerclick", this._onMarkerClick);
+      this._addMarker(marker);
+      this._markers.push(marker);
+      marker.marker_number = this._markers.length - 1;
+      this.fire("markerAdded", marker);
+    },
+
+    _addMarker: function(marker) {
+
+    },
+
+    _removeMarker: function(marker) {
+
+    },
+
+    _resetMarkersActive: function() {
+      for (var i = 0; i < this._markers.length; i++) {
+        this._markers[i].active(false);
+      };
+    },
+
+    _calculateMarkerZooms: function() {
+
+    },
+
+    /*  Map Specific Line
+    ================================================== */
+
+    _createLine: function(d) {
+      return {data: d};
+    },
+
+    _addToLine: function(line, d) {
+
+    },
+
+    _replaceLines: function(line, d) {
+
+    },
+
+    _addLineToMap: function(line) {
+
+    },
+
+
+    /*  Map Specific Methods
+    ================================================== */
+
+    _panTo: function(loc, animate) {
+
+    },
+
+    _zoomTo: function(z, animate) {
+
+    },
+
+    _viewTo: function(loc, opts) {
+
+    },
+
+    _updateMapDisplay: function(animate, d) {
+
+    },
+
+    _refreshMap: function() {
+
+    },
+
+    _getMapLocation: function(m) {
+      return {x:0, y:0};
+    },
+
+    _getMapZoom: function() {
+      return 1;
+    },
+
+    _getMapCenter: function() {
+      return {lat:0, lng:0};
+    },
+
+    _getBoundsZoom: function(m1, m2, inside, padding) {
+
+    },
+
+    _markerOverview: function() {
+
+    },
+
+    _initialMapLocation: function() {
+
+    },
+
+  /*  Events
+  ================================================== */
+  _onMarkerChange: function(e) {
+    this.fire("change", {current_marker:this.current_marker});
+  },
+
+  _onMarkerClick: function(e) {
+    if (this.current_marker != e.marker_number) {
+      this.goTo(e.marker_number);
+    }
+  },
+
+  _onMapLoaded: function(e) {
+    this._loaded.map = true;
+
+
+    if (this.options.calculate_zoom) {
+      this.calculateMarkerZooms();
+    }
+
+    this.calculateMinMaxZoom();
+
+    if (this.options.map_mini && !VCO.Browser.touch) {
+      this.createMiniMap();
+    }
+
+    this.initialMapLocation();
+    this.fire("loaded", this.data);
+  },
+
+  _onWheel: function(e) {
+    // borrowed from http://jsbin.com/qiyaseza/5/edit
+    var self = this;
+
+    if (e.ctrlKey) {
+      var s = Math.exp(-e.deltaY/100);
+      this.touch_scale *= s;
+      e.preventDefault();
+      e.stopPropagation(e);
+    }
+
+    if (!this.scroll.start_time) {
+      this.scroll.start_time = +new Date();
+    };
+
+    var time_left = Math.max(40 - (+new Date() - this.scroll.start_time), 0);
+
+    clearTimeout(this.scroll.timer);
+
+    this.scroll.timer = setTimeout(function() {
+      self._scollZoom();
+      //e.preventDefault();
+      //e.stopPropagation(e);
+    }, time_left);
+
+
+  },
+
+  _scollZoom: function(e) {
+    var self = this,
+      current_zoom = this._getMapZoom();
+
+    this.scroll.start_time = null;
+    //VCO.DomUtil.addClass(this._el.container, 'vco-map-touch-zoom');
+    clearTimeout(this.scroll.timer);
+    clearTimeout(this.scroll.timer_done);
+
+    this.scroll.timer_done = setTimeout(function() {
+      self._scollZoomDone();
+    }, 1000);
+
+    this.zoomTo(Math.round(current_zoom * this.touch_scale));
+  },
+
+  _scollZoomDone: function(e) {
+    //VCO.DomUtil.removeClass(this._el.container, 'vco-map-touch-zoom');
+    this.touch_scale = 1;
+  },
+
+  /*  Private Methods
+  ================================================== */
+
+  _calculateZoomChange: function(origin, destination, correct_for_center) {
+    return this._getBoundsZoom(origin, destination, correct_for_center);
+  },
+
+  _updateDisplay: function(w, h, animate, d) {
+
+    // Update Map Display
+    this._updateMapDisplay(animate, d);
+  },
+
+  _initLayout: function() {
+
+    // Create Layout
+    this._el.map_mask   = VCO.Dom.create("div", "vco-map-mask", this._el.container);
+
+    if (this.options.map_as_image) {
+      this._el.map  = VCO.Dom.create("div", "vco-map-display vco-mapimage-display", this._el.map_mask);
+    } else {
+      this._el.map  = VCO.Dom.create("div", "vco-map-display", this._el.map_mask);
+    }
+
+
+  },
+
+  _initData: function() {
+    if (this.data.slides) {
+      this._createMarkers(this.data.slides);
+      this._resetMarkersActive();
+      this._markers[this.current_marker].active(true);
+      this._loaded.data = true;
+      this._initialMapLocation();
+
+    }
+  },
+
+  _initEvents: function() {
+    var self = this;
+
+    this._el.map.addEventListener('wheel', function(e) {
+      self._onWheel(e);
+    });
+
+    //this.on("wheel", this._onWheel, this);
+  }
+
 });
 
 /* **********************************************
      Begin VCO.MapMarker.Leaflet.js
 ********************************************** */
 
-/*	VCO.MapMarker.Leaflet
-	Produces a marker for Leaflet Maps
+/*  VCO.MapMarker.Leaflet
+  Produces a marker for Leaflet Maps
 ================================================== */
 
 VCO.MapMarker.Leaflet = VCO.MapMarker.extend({
-	
-	
-	/*	Create Marker
-	================================================== */
-	_createMarker: function(d, o) {
-		
-		var icon = {}; //new L.Icon.Default();
-		
-		if (d.location && d.location.lat && d.location.lon) {
-			this.data.real_marker = true;
-			if (o.use_custom_markers && d.location.icon && d.location.icon != "") {
-				this._custom_icon = true;
-				this._custom_icon_url = d.location.icon;
-				this._icon = new L.icon({iconUrl: this._custom_icon_url, iconSize: [48], iconAnchor:[24, 48]});
-			
-			} else if (o.use_custom_markers && d.location.image && d.location.image != "") {
-				this._custom_image_icon = true;
-				this._custom_icon_url = d.location.image;
-				this._icon = new L.icon({iconUrl: this._custom_icon_url, iconSize: [48], iconAnchor:[24, 48], shadowSize: [68, 95], shadowAnchor: [22, 94], className:"vco-mapmarker-image-icon"});
-			} else {
-				this._icon = new L.divIcon({className: 'vco-mapmarker ' + this.media_icon_class, iconAnchor:[10, 10]});
-			}
-			
-			this._marker = new L.marker([d.location.lat, d.location.lon], {
-				title: 		d.text.headline,
-				icon: 		this._icon
-			});
-		
-			this._marker.on("click", this._onMarkerClick, this); 
-			
-			if (o.map_popup) {
-				this._createPopup(d, o);
-			}
-		}
-	},
-	
-	_addTo: function(m) {
-		if (this.data.real_marker) {
-			this._marker.addTo(m);
-		}
-	},
-	
-	_createPopup: function(d, o) {
-		/*
-		var html = "";
-		html += "<h4>" + this.data.text.headline + "</h4>";
-		this._marker.bindPopup(html, {closeButton:false, offset:[0, 43]});
-		*/
-	},
-	
-	_active: function(a) {
-		var self = this;
-		
-		if (this.data.media && this.data.media.mediatype) {
-			this.media_icon_class = "vco-mapmarker-icon vco-icon-" + this.data.media.mediatype.type;
-		} else {
-			this.media_icon_class = "vco-mapmarker-icon vco-icon-plaintext";
-		}
-		
-		if (this.data.real_marker) {
-			if (a) {
-				this._marker.setZIndexOffset(100);
-				if (this._custom_image_icon) {
-					this._icon = new L.icon({iconUrl: this._custom_icon_url, iconSize: [48], iconAnchor:[24, 48], shadowSize: [68, 95], shadowAnchor: [22, 94], className:"vco-mapmarker-image-icon-active"});
-				} else {
-					this._icon = new L.divIcon({className: 'vco-mapmarker-active ' + this.media_icon_class, iconAnchor:[10, 10]});
-				}
-				
-				//this.timer = setTimeout(function() {self._openPopup();}, this.options.duration + 200);
-				this._setIcon();
-			} else {
-				//this._marker.closePopup();
-				clearTimeout(this.timer);
-				this._marker.setZIndexOffset(0);
-				if (this._custom_image_icon) {
-					this._icon = new L.icon({iconUrl: this._custom_icon_url, iconSize: [48], iconAnchor:[24, 48], shadowSize: [68, 95], shadowAnchor: [22, 94], className:"vco-mapmarker-image-icon"});
-				} else {
-					this._icon = new L.divIcon({className: 'vco-mapmarker ' + this.media_icon_class, iconAnchor:[10, 10]});
-				}
-				
-				this._setIcon();
-			}
-		}
-	},
-	
-	_openPopup: function() {
-		this._marker.openPopup();
-	},
-	
-	_setIcon: function() {
-		this._marker.setIcon(this._icon);
-	},
-	
-	_location: function() {
-		if (this.data.real_marker) {
-			return this._marker.getLatLng();
-		} else {
-			return {};
-		}
-	}
-	
+
+
+  /*  Create Marker
+  ================================================== */
+  _createMarker: function(d, o) {
+
+    var icon = {}; //new L.Icon.Default();
+
+    if (d.location && d.location.lat && d.location.lon) {
+      this.data.real_marker = true;
+      if (o.use_custom_markers && d.location.icon && d.location.icon != "") {
+        this._custom_icon = true;
+        this._custom_icon_url = d.location.icon;
+        this._icon = new L.icon({iconUrl: this._custom_icon_url, iconSize: [48], iconAnchor:[24, 48]});
+
+      } else if (o.use_custom_markers && d.location.image && d.location.image != "") {
+        this._custom_image_icon = true;
+        this._custom_icon_url = d.location.image;
+        this._icon = new L.icon({iconUrl: this._custom_icon_url, iconSize: [48], iconAnchor:[24, 48], shadowSize: [68, 95], shadowAnchor: [22, 94], className:"vco-mapmarker-image-icon"});
+      } else {
+        this._icon = new L.divIcon({className: 'vco-mapmarker ' + this.media_icon_class, iconAnchor:[10, 10]});
+      }
+
+      this._marker = new L.marker([d.location.lat, d.location.lon], {
+        title:    d.text.headline,
+        icon:     this._icon
+      });
+
+      this._marker.on("click", this._onMarkerClick, this);
+
+      if (o.map_popup) {
+        this._createPopup(d, o);
+      }
+    }
+  },
+
+  _addTo: function(m) {
+    if (this.data.real_marker) {
+      this._marker.addTo(m);
+    }
+  },
+
+  _createPopup: function(d, o) {
+    /*
+    var html = "";
+    html += "<h4>" + this.data.text.headline + "</h4>";
+    this._marker.bindPopup(html, {closeButton:false, offset:[0, 43]});
+    */
+  },
+
+  _active: function(a) {
+    var self = this;
+
+    if (this.data.media && this.data.media.mediatype) {
+      this.media_icon_class = "vco-mapmarker-icon vco-icon-" + this.data.media.mediatype.type;
+    } else {
+      this.media_icon_class = "vco-mapmarker-icon vco-icon-plaintext";
+    }
+
+    if (this.data.real_marker) {
+      if (a) {
+        this._marker.setZIndexOffset(100);
+        if (this._custom_image_icon) {
+          this._icon = new L.icon({iconUrl: this._custom_icon_url, iconSize: [48], iconAnchor:[24, 48], shadowSize: [68, 95], shadowAnchor: [22, 94], className:"vco-mapmarker-image-icon-active"});
+        } else {
+          this._icon = new L.divIcon({className: 'vco-mapmarker-active ' + this.media_icon_class, iconAnchor:[10, 10]});
+        }
+
+        //this.timer = setTimeout(function() {self._openPopup();}, this.options.duration + 200);
+        this._setIcon();
+      } else {
+        //this._marker.closePopup();
+        clearTimeout(this.timer);
+        this._marker.setZIndexOffset(0);
+        if (this._custom_image_icon) {
+          this._icon = new L.icon({iconUrl: this._custom_icon_url, iconSize: [48], iconAnchor:[24, 48], shadowSize: [68, 95], shadowAnchor: [22, 94], className:"vco-mapmarker-image-icon"});
+        } else {
+          this._icon = new L.divIcon({className: 'vco-mapmarker ' + this.media_icon_class, iconAnchor:[10, 10]});
+        }
+
+        this._setIcon();
+      }
+    }
+  },
+
+  _openPopup: function() {
+    this._marker.openPopup();
+  },
+
+  _setIcon: function() {
+    this._marker.setIcon(this._icon);
+  },
+
+  _location: function() {
+    if (this.data.real_marker) {
+      return this._marker.getLatLng();
+    } else {
+      return {};
+    }
+  }
+
 });
 
 
@@ -16894,1463 +16894,1463 @@ VCO.MapMarker.Leaflet = VCO.MapMarker.extend({
      Begin VCO.Map.Leaflet.js
 ********************************************** */
 
-/*	VCO.Map.Leaflet
-	Creates a Map using Leaflet
+/*  VCO.Map.Leaflet
+  Creates a Map using Leaflet
 ================================================== */
 
 VCO.Map.Leaflet = VCO.Map.extend({
-	
-	includes: [VCO.Events],
-	
-	/*	Create the Map
-	================================================== */
-	_createMap: function() {
-		
-		
-		this._map = new L.map(this._el.map, {scrollWheelZoom:false, zoomControl:!this.options.map_mini});
-		this._map.on("load", this._onMapLoaded, this);
-		
-		
-		this._map.on("moveend", this._onMapMoveEnd, this);
-		this._map.attributionControl.setPrefix("<a href='http://storymap.knightlab.com/' target='_blank' class='vco-knightlab-brand'><span>&#x25a0;</span> StoryMapJS</a>");
-			
-		var map_type_arr = this.options.map_type.split(':');		
 
-		// Create Tile Layer
-		this._tile_layer = this._createTileLayer(this.options.map_type);
-		this._tile_layer.on("load", this._onTilesLoaded, this);
-		
-		// Add Tile Layer
-		this._map.addLayer(this._tile_layer);
-		
-		// Add Zoomify Image Layer
-		if (this._image_layer) {
-			this._map.addLayer(this._image_layer);
-		}
-		// Create Overall Connection Line
-		this._line = this._createLine(this._line);
-		this._line.setStyle({color:this.options.line_color_inactive});
-		this._addLineToMap(this._line);
-		
-		// Create Active Line
-		this._line_active = this._createLine(this._line_active);
-		this._line_active.setStyle({opacity:1});
-		this._addLineToMap(this._line_active);
-		
-		if (this.options.map_as_image) {
-			this._line_active.setStyle({opacity:0});
-			this._line.setStyle({opacity:0});
-		}
+  includes: [VCO.Events],
 
-		
-		
-	},
-	
-	/*	Create Mini Map
-	================================================== */
-	_createMiniMap: function() {
-		if (this.options.map_as_image) {
-			this.zoom_min_max.min = 0;
-		}
-		
-		if (!this.bounds_array) {
-			this.bounds_array = this._getAllMarkersBounds(this._markers);
-		} 
-		
-		this._tile_layer_mini = this._createTileLayer(this.options.map_type);
-		this._mini_map = new L.Control.MiniMap(this._tile_layer_mini, {
-			width: 				150,
-			height: 			100,
-			position: 			"topleft",
-			bounds_array: 		this.bounds_array,
-			zoomLevelFixed: 	this.zoom_min_max.min,
-			zoomAnimation: 		true,
-			aimingRectOptions: 	{
-				fillColor: 		"#FFFFFF",
-				color: 			"#FFFFFF",
-				opacity: 		0.4,
-				weight: 		1,
-				stroke: 		true
-			}
-		}).addTo(this._map);
-		
-		this._mini_map.getContainer().style.backgroundColor = this.options.map_background_color;
-		
-	},
-	
-	/*	Create Background Map
-	================================================== */
-	_createBackgroundMap: function(tiles) {
-		
-		// TODO Check width and height 
-		trace("CREATE BACKGROUND MAP");
-		if (!this._image_layer) {
-			// Make Image Layer a Group
-			this._image_layer = new L.layerGroup();
-			// Add Layer Group to Map
-			this._map.addLayer(this._image_layer);
-			
-		} else {
-			this._image_layer.clearLayers();
-		}
-		
-		if (tiles) {
-			// Create Image Overlay for each tile in the group
-			for (x in tiles) {
-				var target_tile = tiles[x],
-					image = {},
-					tile = {
-						x: 			0,
-						y: 			0,
-						url: 		target_tile.src,
-						height: 	parseInt(target_tile.style.height.split("px")[0]),
-						width: 		parseInt(target_tile.style.width.split("px")[0]),
-						pos: {
-							start: 	0,
-							end: 	0
-						}
-					};
-					
-				if (target_tile.style.left || target_tile.style.top) {
-					if (target_tile.style.left) {
-						tile.x = parseInt(target_tile.style.left.split("px")[0]);
-					}
-					if (target_tile.style.top) {
-						tile.y = parseInt(target_tile.style.top.split("px")[0]);
-					}
-				} else if (target_tile.style["-webkit-transform"] || target_tile.style["transform"] || target_tile.style["-ms-transform"]) {
-					var t_array;
-					
-					if (target_tile.style["-webkit-transform"]) {
-						t_array = target_tile.style["-webkit-transform"].split("3d(")[1].split(", 0)")[0].split(", ");
-					} else if (target_tile.style["transform"]) {
-						t_array = target_tile.style["transform"].split("3d(")[1].split(", 0)")[0].split(", ");
-					} else if (target_tile.style["-ms-transform"]) {
-						t_array = target_tile.style["-ms-transform"].split("3d(")[1].split(", 0)")[0].split(", ");
-					}
-					
-					tile.x = parseInt(t_array[0].split("px")[0]);
-					tile.y = parseInt(t_array[1].split("px")[0]);
-				}
-				
-				
-				// If using toner, switch to toner lines
-				if (tile.url.match("toner")) {
-					//tile.url = tile.url.replace("/toner-lite/","/toner-lines/");
-					tile.url = tile.url.replace("/toner-hybrid/","/toner-lines/");
-					tile.url = tile.url.replace("/toner/","/toner-background/");
-				}
+  /*  Create the Map
+  ================================================== */
+  _createMap: function() {
 
-				tile.pos.start 	= this._map.containerPointToLatLng([tile.x, tile.y]);
-				tile.pos.end 	= this._map.containerPointToLatLng([tile.x + tile.width, tile.y + tile.height]);
-				
-				image = new L.imageOverlay(tile.url, [tile.pos.start, tile.pos.end]);
-				this._image_layer.addLayer(image);
-				
-			}
-		}
-		
-	},
-	
-	/*	Create Tile Layer
-	================================================== */
-	_createTileLayer: function(map_type, options) {
-		var _tilelayer = null,
-			_map_type_arr = map_type.split(':'),
-			_options = {},
-			_attribution_knightlab = "<a href='http://leafletjs.com' title='A JS library for interactive maps'>Leaflet</a> | "
-		
-		if (options) {
-			_options = options;
-		}
-		
-		// Set Tiles
-		switch(_map_type_arr[0]) {
-			case 'mapbox':
-				var mapbox_name = _map_type_arr[1] || 'nuknightlab.hif6ioi4';
-				_options.subdomains 	= 'abcd';
-				_options.attribution 	= _attribution_knightlab + "<div class='mapbox-maplogo'></div><a href='https://www.mapbox.com/about/maps/' target='_blank'>© Mapbox © OpenStreetMap</a>";
-				_tilelayer = new L.TileLayer("https://api.tiles.mapbox.com/v4/" + mapbox_name + "/{z}/{x}/{y}.png?access_token=pk.eyJ1IjoibnVrbmlnaHRsYWIiLCJhIjoiczFmd0hPZyJ9.Y_afrZdAjo3u8sz_r8m2Yw", _options);
-				break;
-			case 'stamen':
-				_tilelayer = new L.StamenTileLayer(_map_type_arr[1] || 'toner-lite', _options);
-				this._map.getContainer().style.backgroundColor = "#FFFFFF";
-				break;
-			case 'zoomify':
-				_options.width			= this.options.zoomify.width;
-				_options.height 		= this.options.zoomify.height;
-				_options.tolerance 		= this.options.zoomify.tolerance;
-				_options.attribution 	= _attribution_knightlab + this.options.zoomify.attribution;
-				
-				_tilelayer = new L.tileLayer.zoomify(this.options.zoomify.path, _options);
-				//this._image_layer = new L.imageOverlay(this.options.zoomify.path + "TileGroup0/0-0-0.jpg", _tilelayer.getZoomifyBounds(this._map));
-				break;
-			case 'osm':
-				_options.subdomains = 'ab';
-				_options.attribution = _attribution_knightlab + "© <a target='_blank' href='http://www.openstreetmap.org'>OpenStreetMap</a> and contributors, under an <a target='_blank' href='http://www.openstreetmap.org/copyright'>open license</a>";
-				_tilelayer = new L.TileLayer('http://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', _options); 
-				break;
-		    
-			case 'http':
-			case 'https':
-				_options.subdomains = this.options.map_subdomains;
-				_tilelayer = new L.TileLayer(this.options.map_type, _options);
-				break;
-		        
-			default:
-				_tilelayer = new L.StamenTileLayer('toner', _options);
-				break;		
-		}
-		
-		return _tilelayer;
-	},
-	
-	/*	Events
-	================================================== */
-	_onMapMoveEnd: function(e) {
-		
-	},
-	
-	_onTilesLoaded: function(e) {
-		this._createBackgroundMap(e.target._tiles);
-		this._tile_layer.off("load", this._onTilesLoaded, this);
-	},
-	
-	_onMapZoomed:function(e) {
-		trace("FIRST ZOOM");
-		this._map.off("zoomend", this._onMapZoomed, this);
-		
-	},
-	
-	_onMapZoom:function(e) {
-		
-	},
-	
-	/*	Marker
-	================================================== */
-	_createMarker: function(d) {
-		var marker = new VCO.MapMarker.Leaflet(d, this.options);
-		marker.on('markerclick', this._onMarkerClick, this);
-		this._addMarker(marker);
-		this._markers.push(marker);
-		marker.marker_number = this._markers.length - 1;
-		this.fire("markerAdded", marker);
-		
-	},
 
-	_addMarker: function(marker) {
-		marker.addTo(this._map);
-	},
+    this._map = new L.map(this._el.map, {scrollWheelZoom:false, zoomControl:!this.options.map_mini});
+    this._map.on("load", this._onMapLoaded, this);
 
-	_removeMarker: function(marker) {
-	
-	},
-	
-	_markerOverview: function() {
-		var _location, _zoom;
-		// Hide Active Line
-		this._line_active.setStyle({opacity:0});
-		
-		if (this.options.map_type == "zoomify" && this.options.map_as_image) {
-			
-			var _center_zoom 	= this._tile_layer.getCenterZoom(this._map);
-			
-			_location = _center_zoom.center;
-			
-			if (this.options.map_center_offset && this.options.map_center_offset.left != 0 || this.options.map_center_offset.top != 0) {
-				_center_zoom.zoom = _center_zoom.zoom - 1;
-				_location = this._getMapCenterOffset(_location, _center_zoom.zoom);
-			}
-			
-			this._map.setView(_location, _center_zoom.zoom, {
-				pan:{animate: true, duration: this.options.duration/1000, easeLinearity:.10},
-				zoom:{animate: true, duration: this.options.duration/1000, easeLinearity:.10}
-			});
-			
-			
-			
-		} else {
-			this.bounds_array = this._getAllMarkersBounds(this._markers);
-			
-			if (this.options.map_center_offset && this.options.map_center_offset.left != 0 || this.options.map_center_offset.top != 0) {
-				var the_bounds 	= new L.latLngBounds(this.bounds_array);
-				_location 		= the_bounds.getCenter();
-				_zoom 			= this._map.getBoundsZoom(the_bounds)
-				
-				_location = this._getMapCenterOffset(_location, _zoom - 1);
-				
-				this._map.setView(_location, _zoom -1, {
-					pan:{animate: true, duration: this.options.duration/1000, easeLinearity:.10},
-					zoom:{animate: true, duration: this.options.duration/1000, easeLinearity:.10}
-				});
-				
-				
-			} else {
-				this._map.fitBounds(this.bounds_array, {padding:[15,15]});
-			}
-			
-		}
-		
-		if (this._mini_map) {
-			this._mini_map.minimize();
-		}
-		
-	},
-	
-	_getAllMarkersBounds: function(markers_array) {
-		var bounds_array = [];
-		for (var i = 0; i < markers_array.length; i++) {
-			if (markers_array[i].data.real_marker) {
-				bounds_array.push( [markers_array[i].data.location.lat, markers_array[i].data.location.lon]);
-			}
-		};
-		return bounds_array;
-	},
-	
-	_calculateMarkerZooms: function() {
-		for (var i = 0; i < this._markers.length; i++) {
-			
-			if (this._markers[i].data.location) {
-				var marker = this._markers[i],
-					prev_marker,
-					next_marker,
-					marker_location,
-					prev_marker_zoom,
-					next_marker_zoom,
-					calculated_zoom;
-				
-				
-				// MARKER LOCATION
-				if (marker.data.type && marker.data.type == "overview") {
-					marker_location = this._getMapCenter(true);
-				} else {
-					marker_location = marker.location();
-				}
-				// PREVIOUS MARKER ZOOM
-				if (i > 0 ) {
-					prev_marker = this._markers[i-1].location();
-				} else {
-					prev_marker = this._getMapCenter(true);
-				}
-				prev_marker_zoom = this._calculateZoomChange(prev_marker, marker_location);
-			
-				// NEXT MARKER ZOOM
-				if (i < (this._markers.length - 1)) {
-					next_marker = this._markers[i+1].location();
-				} else {
-					next_marker = this._getMapCenter(true);
-				}
-				next_marker_zoom = this._calculateZoomChange(next_marker, marker_location);
-			
-			
-				if (prev_marker_zoom && prev_marker_zoom < next_marker_zoom) {
-					calculated_zoom = prev_marker_zoom;
-				} else if (next_marker_zoom){
-					calculated_zoom = next_marker_zoom;
-					
-				} else {
-					calculated_zoom = prev_marker_zoom;
-				}
-				
-				if (this.options.map_center_offset && this.options.map_center_offset.left != 0 || this.options.map_center_offset.top != 0) {
-					calculated_zoom = calculated_zoom -1;
-				}
-			
-				marker.data.location.zoom = calculated_zoom;
-			}
-			
 
-		};
-		
-		
-	},
-	
-	
-	
-	/*	Line
-	================================================== */
-	
-	_createLine: function(d) {
-		return new L.Polyline([], {
-			clickable: false,
-			color: 		this.options.line_color,
-			weight: 	this.options.line_weight,
-			opacity: 	this.options.line_opacity,
-			dashArray: 	this.options.line_dash,
-			lineJoin: 	this.options.line_join,
-			className: 	"vco-map-line"
-		} );
-		
-	},
-	
-	_addLineToMap: function(line) {
-		this._map.addLayer(line);
-	},
-	
-	_addToLine: function(line, d) {
-		line.addLatLng({lon: d.location.lon, lat: d.location.lat});
-	},
-	
-	_replaceLines: function(line, array) {
-		line.setLatLngs(array);
-	},
-	
-	/*	Map
-	================================================== */
-	_panTo: function(loc, animate) {
-		this._map.panTo({lat:loc.lat, lon:loc.lon}, {animate: true, duration: this.options.duration/1000, easeLinearity:.10});
-	},
-	
-	_zoomTo: function(z, animate) {
-		this._map.setZoom(z);
-	},
-	
-	_viewTo: function(loc, opts) {
-		var _animate 	= true,
-			_duration 	= this.options.duration/1000,
-			_zoom 		= this._getMapZoom(),
-			_location 	= {lat:loc.lat, lon:loc.lon};
-			
-		// Show Active Line
-		if (!this.options.map_as_image) {
-			this._line_active.setStyle({opacity:1});
-		}
-			
-		if (loc.zoom) {
-			_zoom = loc.zoom;
-		}
-		
-		// Options
-		if (opts) {
-			if (opts.duration) {
-				if (opts.duration == 0) {
-					_animate = false;
-				} else {
-					_duration = duration;
-				}
-			}
-			
-			if (opts.zoom && this.options.calculate_zoom) {
-				_zoom = opts.zoom;
-			}
-		}	
-		
-		// OFFSET
-		if (this.options.map_center_offset) {
-			_location = this._getMapCenterOffset(_location, _zoom);
-		}
-		
-		this._map.setView(
-			_location, 
-			_zoom,
-			{
-				pan:{animate: _animate, duration: _duration, easeLinearity:.10},
-				zoom:{animate: _animate, duration: _duration, easeLinearity:.10}
-			}
-		)
-		
-		if (this._mini_map && this.options.width > this.options.skinny_size) {
-			if ((_zoom - 1) <= this.zoom_min_max.min ) {
-				this._mini_map.minimize();
-			} else {
-				this._mini_map.restore();
-				//this._mini_map.updateDisplay(_location, _zoom, _duration);
-			}
-		} 
-		
-	},
-	
-	_getMapLocation: function(m) {
-		return this._map.latLngToContainerPoint(m);
-	},
-	
-	_getMapZoom: function() {
-		return this._map.getZoom();
-	},
-	
-	_getMapCenter: function(offset) {
-		if (offset) {
-			
-		}
-		return this._map.getCenter();
-	},
-	
-	_getMapCenterOffset: function(location, zoom) {
-		var target_point,
-			target_latlng;
-		
-		target_point 	= this._map.project(location, zoom).subtract([this.options.map_center_offset.left, this.options.map_center_offset.top]);
-		target_latlng 	= this._map.unproject(target_point, zoom);
-		
-		return target_latlng;
+    this._map.on("moveend", this._onMapMoveEnd, this);
+    this._map.attributionControl.setPrefix("<a href='http://storymap.knightlab.com/' target='_blank' class='vco-knightlab-brand'><span>&#x25a0;</span> StoryMapJS</a>");
 
-	},
-	
-	_getBoundsZoom: function(origin, destination, correct_for_center) {
-		var _origin = origin,
-			_padding = [(Math.abs(this.options.map_center_offset.left)*3),(Math.abs(this.options.map_center_offset.top)*3)];
-			
-		
-		//_padding = [0,0];
-		//_padding = [0,0];
-		if (correct_for_center) {
-			var _lat = _origin.lat + (_origin.lat - destination.lat)/2,
-				_lng = _origin.lng + (_origin.lng - destination.lng)/2;
-			_origin = new L.LatLng(_lat, _lng);
-		}
-		
-		var bounds = new L.LatLngBounds([_origin, destination]);
-		if (this.options.less_bounce) {
-			return this._map.getBoundsZoom(bounds, false, _padding);
-		} else {
-			return this._map.getBoundsZoom(bounds, true, _padding);
-		}
-	},
-	
-	_getZoomifyZoom: function() {
+    var map_type_arr = this.options.map_type.split(':');
 
-	},
-	
-	_initialMapLocation: function() {
-		this._map.on("zoomend", this._onMapZoomed, this);
-	},
-	
-	/*	Display
-	================================================== */
-	_updateMapDisplay: function(animate, d) {
-		if (animate) {
-			var duration = this.options.duration,
-				self = this;
-				
-			if (d) {duration = d };
-			if (this.timer) {clearTimeout(this.timer)};
-			
-			this.timer = setTimeout(function() {
-				self._refreshMap();
-			}, duration);
-			
-		} else {
-			if (!this.timer) {
-				this._refreshMap();
-			};
-		}
-		
-		if (this._mini_map && this._el.container.offsetWidth < this.options.skinny_size ) {
-			this._mini_map.true_hide = true;
-			//this._mini_map.minimize();
-		} else if (this._mini_map) {
-			this._mini_map.true_hide = false;
-		}
-	},
-	
-	_refreshMap: function() {
-		if (this._map) {
-			if (this.timer) {
-				clearTimeout(this.timer);
-				this.timer = null;
-			};
-			
-			this._map.invalidateSize();
-			
-			// Check to see if it's an overview
-			if (this._markers[this.current_marker].data.type && this._markers[this.current_marker].data.type == "overview") {
-				this._markerOverview();
-			} else {
-				this._viewTo(this._markers[this.current_marker].data.location, {zoom:this._getMapZoom()});
-			}
-		};
-	}
-	
-	
+    // Create Tile Layer
+    this._tile_layer = this._createTileLayer(this.options.map_type);
+    this._tile_layer.on("load", this._onTilesLoaded, this);
+
+    // Add Tile Layer
+    this._map.addLayer(this._tile_layer);
+
+    // Add Zoomify Image Layer
+    if (this._image_layer) {
+      this._map.addLayer(this._image_layer);
+    }
+    // Create Overall Connection Line
+    this._line = this._createLine(this._line);
+    this._line.setStyle({color:this.options.line_color_inactive});
+    this._addLineToMap(this._line);
+
+    // Create Active Line
+    this._line_active = this._createLine(this._line_active);
+    this._line_active.setStyle({opacity:1});
+    this._addLineToMap(this._line_active);
+
+    if (this.options.map_as_image) {
+      this._line_active.setStyle({opacity:0});
+      this._line.setStyle({opacity:0});
+    }
+
+
+
+  },
+
+  /*  Create Mini Map
+  ================================================== */
+  _createMiniMap: function() {
+    if (this.options.map_as_image) {
+      this.zoom_min_max.min = 0;
+    }
+
+    if (!this.bounds_array) {
+      this.bounds_array = this._getAllMarkersBounds(this._markers);
+    }
+
+    this._tile_layer_mini = this._createTileLayer(this.options.map_type);
+    this._mini_map = new L.Control.MiniMap(this._tile_layer_mini, {
+      width:        150,
+      height:       100,
+      position:       "topleft",
+      bounds_array:     this.bounds_array,
+      zoomLevelFixed:   this.zoom_min_max.min,
+      zoomAnimation:    true,
+      aimingRectOptions:  {
+        fillColor:    "#FFFFFF",
+        color:      "#FFFFFF",
+        opacity:    0.4,
+        weight:     1,
+        stroke:     true
+      }
+    }).addTo(this._map);
+
+    this._mini_map.getContainer().style.backgroundColor = this.options.map_background_color;
+
+  },
+
+  /*  Create Background Map
+  ================================================== */
+  _createBackgroundMap: function(tiles) {
+
+    // TODO Check width and height
+    trace("CREATE BACKGROUND MAP");
+    if (!this._image_layer) {
+      // Make Image Layer a Group
+      this._image_layer = new L.layerGroup();
+      // Add Layer Group to Map
+      this._map.addLayer(this._image_layer);
+
+    } else {
+      this._image_layer.clearLayers();
+    }
+
+    if (tiles) {
+      // Create Image Overlay for each tile in the group
+      for (x in tiles) {
+        var target_tile = tiles[x],
+          image = {},
+          tile = {
+            x:      0,
+            y:      0,
+            url:    target_tile.src,
+            height:   parseInt(target_tile.style.height.split("px")[0]),
+            width:    parseInt(target_tile.style.width.split("px")[0]),
+            pos: {
+              start:  0,
+              end:  0
+            }
+          };
+
+        if (target_tile.style.left || target_tile.style.top) {
+          if (target_tile.style.left) {
+            tile.x = parseInt(target_tile.style.left.split("px")[0]);
+          }
+          if (target_tile.style.top) {
+            tile.y = parseInt(target_tile.style.top.split("px")[0]);
+          }
+        } else if (target_tile.style["-webkit-transform"] || target_tile.style["transform"] || target_tile.style["-ms-transform"]) {
+          var t_array;
+
+          if (target_tile.style["-webkit-transform"]) {
+            t_array = target_tile.style["-webkit-transform"].split("3d(")[1].split(", 0)")[0].split(", ");
+          } else if (target_tile.style["transform"]) {
+            t_array = target_tile.style["transform"].split("3d(")[1].split(", 0)")[0].split(", ");
+          } else if (target_tile.style["-ms-transform"]) {
+            t_array = target_tile.style["-ms-transform"].split("3d(")[1].split(", 0)")[0].split(", ");
+          }
+
+          tile.x = parseInt(t_array[0].split("px")[0]);
+          tile.y = parseInt(t_array[1].split("px")[0]);
+        }
+
+
+        // If using toner, switch to toner lines
+        if (tile.url.match("toner")) {
+          //tile.url = tile.url.replace("/toner-lite/","/toner-lines/");
+          tile.url = tile.url.replace("/toner-hybrid/","/toner-lines/");
+          tile.url = tile.url.replace("/toner/","/toner-background/");
+        }
+
+        tile.pos.start  = this._map.containerPointToLatLng([tile.x, tile.y]);
+        tile.pos.end  = this._map.containerPointToLatLng([tile.x + tile.width, tile.y + tile.height]);
+
+        image = new L.imageOverlay(tile.url, [tile.pos.start, tile.pos.end]);
+        this._image_layer.addLayer(image);
+
+      }
+    }
+
+  },
+
+  /*  Create Tile Layer
+  ================================================== */
+  _createTileLayer: function(map_type, options) {
+    var _tilelayer = null,
+      _map_type_arr = map_type.split(':'),
+      _options = {},
+      _attribution_knightlab = "<a href='http://leafletjs.com' title='A JS library for interactive maps'>Leaflet</a> | "
+
+    if (options) {
+      _options = options;
+    }
+
+    // Set Tiles
+    switch(_map_type_arr[0]) {
+      case 'mapbox':
+        var mapbox_name = _map_type_arr[1] || 'nuknightlab.hif6ioi4';
+        _options.subdomains   = 'abcd';
+        _options.attribution  = _attribution_knightlab + "<div class='mapbox-maplogo'></div><a href='https://www.mapbox.com/about/maps/' target='_blank'>© Mapbox © OpenStreetMap</a>";
+        _tilelayer = new L.TileLayer("https://api.tiles.mapbox.com/v4/" + mapbox_name + "/{z}/{x}/{y}.png?access_token=pk.eyJ1IjoibnVrbmlnaHRsYWIiLCJhIjoiczFmd0hPZyJ9.Y_afrZdAjo3u8sz_r8m2Yw", _options);
+        break;
+      case 'stamen':
+        _tilelayer = new L.StamenTileLayer(_map_type_arr[1] || 'toner-lite', _options);
+        this._map.getContainer().style.backgroundColor = "#FFFFFF";
+        break;
+      case 'zoomify':
+        _options.width      = this.options.zoomify.width;
+        _options.height     = this.options.zoomify.height;
+        _options.tolerance    = this.options.zoomify.tolerance;
+        _options.attribution  = _attribution_knightlab + this.options.zoomify.attribution;
+
+        _tilelayer = new L.tileLayer.zoomify(this.options.zoomify.path, _options);
+        //this._image_layer = new L.imageOverlay(this.options.zoomify.path + "TileGroup0/0-0-0.jpg", _tilelayer.getZoomifyBounds(this._map));
+        break;
+      case 'osm':
+        _options.subdomains = 'ab';
+        _options.attribution = _attribution_knightlab + "© <a target='_blank' href='http://www.openstreetmap.org'>OpenStreetMap</a> and contributors, under an <a target='_blank' href='http://www.openstreetmap.org/copyright'>open license</a>";
+        _tilelayer = new L.TileLayer('//{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', _options);
+        break;
+
+      case 'http':
+      case 'https':
+        _options.subdomains = this.options.map_subdomains;
+        _tilelayer = new L.TileLayer(this.options.map_type, _options);
+        break;
+
+      default:
+        _tilelayer = new L.StamenTileLayer('toner', _options);
+        break;
+    }
+
+    return _tilelayer;
+  },
+
+  /*  Events
+  ================================================== */
+  _onMapMoveEnd: function(e) {
+
+  },
+
+  _onTilesLoaded: function(e) {
+    this._createBackgroundMap(e.target._tiles);
+    this._tile_layer.off("load", this._onTilesLoaded, this);
+  },
+
+  _onMapZoomed:function(e) {
+    trace("FIRST ZOOM");
+    this._map.off("zoomend", this._onMapZoomed, this);
+
+  },
+
+  _onMapZoom:function(e) {
+
+  },
+
+  /*  Marker
+  ================================================== */
+  _createMarker: function(d) {
+    var marker = new VCO.MapMarker.Leaflet(d, this.options);
+    marker.on('markerclick', this._onMarkerClick, this);
+    this._addMarker(marker);
+    this._markers.push(marker);
+    marker.marker_number = this._markers.length - 1;
+    this.fire("markerAdded", marker);
+
+  },
+
+  _addMarker: function(marker) {
+    marker.addTo(this._map);
+  },
+
+  _removeMarker: function(marker) {
+
+  },
+
+  _markerOverview: function() {
+    var _location, _zoom;
+    // Hide Active Line
+    this._line_active.setStyle({opacity:0});
+
+    if (this.options.map_type == "zoomify" && this.options.map_as_image) {
+
+      var _center_zoom  = this._tile_layer.getCenterZoom(this._map);
+
+      _location = _center_zoom.center;
+
+      if (this.options.map_center_offset && this.options.map_center_offset.left != 0 || this.options.map_center_offset.top != 0) {
+        _center_zoom.zoom = _center_zoom.zoom - 1;
+        _location = this._getMapCenterOffset(_location, _center_zoom.zoom);
+      }
+
+      this._map.setView(_location, _center_zoom.zoom, {
+        pan:{animate: true, duration: this.options.duration/1000, easeLinearity:.10},
+        zoom:{animate: true, duration: this.options.duration/1000, easeLinearity:.10}
+      });
+
+
+
+    } else {
+      this.bounds_array = this._getAllMarkersBounds(this._markers);
+
+      if (this.options.map_center_offset && this.options.map_center_offset.left != 0 || this.options.map_center_offset.top != 0) {
+        var the_bounds  = new L.latLngBounds(this.bounds_array);
+        _location     = the_bounds.getCenter();
+        _zoom       = this._map.getBoundsZoom(the_bounds)
+
+        _location = this._getMapCenterOffset(_location, _zoom - 1);
+
+        this._map.setView(_location, _zoom -1, {
+          pan:{animate: true, duration: this.options.duration/1000, easeLinearity:.10},
+          zoom:{animate: true, duration: this.options.duration/1000, easeLinearity:.10}
+        });
+
+
+      } else {
+        this._map.fitBounds(this.bounds_array, {padding:[15,15]});
+      }
+
+    }
+
+    if (this._mini_map) {
+      this._mini_map.minimize();
+    }
+
+  },
+
+  _getAllMarkersBounds: function(markers_array) {
+    var bounds_array = [];
+    for (var i = 0; i < markers_array.length; i++) {
+      if (markers_array[i].data.real_marker) {
+        bounds_array.push( [markers_array[i].data.location.lat, markers_array[i].data.location.lon]);
+      }
+    };
+    return bounds_array;
+  },
+
+  _calculateMarkerZooms: function() {
+    for (var i = 0; i < this._markers.length; i++) {
+
+      if (this._markers[i].data.location) {
+        var marker = this._markers[i],
+          prev_marker,
+          next_marker,
+          marker_location,
+          prev_marker_zoom,
+          next_marker_zoom,
+          calculated_zoom;
+
+
+        // MARKER LOCATION
+        if (marker.data.type && marker.data.type == "overview") {
+          marker_location = this._getMapCenter(true);
+        } else {
+          marker_location = marker.location();
+        }
+        // PREVIOUS MARKER ZOOM
+        if (i > 0 ) {
+          prev_marker = this._markers[i-1].location();
+        } else {
+          prev_marker = this._getMapCenter(true);
+        }
+        prev_marker_zoom = this._calculateZoomChange(prev_marker, marker_location);
+
+        // NEXT MARKER ZOOM
+        if (i < (this._markers.length - 1)) {
+          next_marker = this._markers[i+1].location();
+        } else {
+          next_marker = this._getMapCenter(true);
+        }
+        next_marker_zoom = this._calculateZoomChange(next_marker, marker_location);
+
+
+        if (prev_marker_zoom && prev_marker_zoom < next_marker_zoom) {
+          calculated_zoom = prev_marker_zoom;
+        } else if (next_marker_zoom){
+          calculated_zoom = next_marker_zoom;
+
+        } else {
+          calculated_zoom = prev_marker_zoom;
+        }
+
+        if (this.options.map_center_offset && this.options.map_center_offset.left != 0 || this.options.map_center_offset.top != 0) {
+          calculated_zoom = calculated_zoom -1;
+        }
+
+        marker.data.location.zoom = calculated_zoom;
+      }
+
+
+    };
+
+
+  },
+
+
+
+  /*  Line
+  ================================================== */
+
+  _createLine: function(d) {
+    return new L.Polyline([], {
+      clickable: false,
+      color:    this.options.line_color,
+      weight:   this.options.line_weight,
+      opacity:  this.options.line_opacity,
+      dashArray:  this.options.line_dash,
+      lineJoin:   this.options.line_join,
+      className:  "vco-map-line"
+    } );
+
+  },
+
+  _addLineToMap: function(line) {
+    this._map.addLayer(line);
+  },
+
+  _addToLine: function(line, d) {
+    line.addLatLng({lon: d.location.lon, lat: d.location.lat});
+  },
+
+  _replaceLines: function(line, array) {
+    line.setLatLngs(array);
+  },
+
+  /*  Map
+  ================================================== */
+  _panTo: function(loc, animate) {
+    this._map.panTo({lat:loc.lat, lon:loc.lon}, {animate: true, duration: this.options.duration/1000, easeLinearity:.10});
+  },
+
+  _zoomTo: function(z, animate) {
+    this._map.setZoom(z);
+  },
+
+  _viewTo: function(loc, opts) {
+    var _animate  = true,
+      _duration   = this.options.duration/1000,
+      _zoom     = this._getMapZoom(),
+      _location   = {lat:loc.lat, lon:loc.lon};
+
+    // Show Active Line
+    if (!this.options.map_as_image) {
+      this._line_active.setStyle({opacity:1});
+    }
+
+    if (loc.zoom) {
+      _zoom = loc.zoom;
+    }
+
+    // Options
+    if (opts) {
+      if (opts.duration) {
+        if (opts.duration == 0) {
+          _animate = false;
+        } else {
+          _duration = duration;
+        }
+      }
+
+      if (opts.zoom && this.options.calculate_zoom) {
+        _zoom = opts.zoom;
+      }
+    }
+
+    // OFFSET
+    if (this.options.map_center_offset) {
+      _location = this._getMapCenterOffset(_location, _zoom);
+    }
+
+    this._map.setView(
+      _location,
+      _zoom,
+      {
+        pan:{animate: _animate, duration: _duration, easeLinearity:.10},
+        zoom:{animate: _animate, duration: _duration, easeLinearity:.10}
+      }
+    )
+
+    if (this._mini_map && this.options.width > this.options.skinny_size) {
+      if ((_zoom - 1) <= this.zoom_min_max.min ) {
+        this._mini_map.minimize();
+      } else {
+        this._mini_map.restore();
+        //this._mini_map.updateDisplay(_location, _zoom, _duration);
+      }
+    }
+
+  },
+
+  _getMapLocation: function(m) {
+    return this._map.latLngToContainerPoint(m);
+  },
+
+  _getMapZoom: function() {
+    return this._map.getZoom();
+  },
+
+  _getMapCenter: function(offset) {
+    if (offset) {
+
+    }
+    return this._map.getCenter();
+  },
+
+  _getMapCenterOffset: function(location, zoom) {
+    var target_point,
+      target_latlng;
+
+    target_point  = this._map.project(location, zoom).subtract([this.options.map_center_offset.left, this.options.map_center_offset.top]);
+    target_latlng   = this._map.unproject(target_point, zoom);
+
+    return target_latlng;
+
+  },
+
+  _getBoundsZoom: function(origin, destination, correct_for_center) {
+    var _origin = origin,
+      _padding = [(Math.abs(this.options.map_center_offset.left)*3),(Math.abs(this.options.map_center_offset.top)*3)];
+
+
+    //_padding = [0,0];
+    //_padding = [0,0];
+    if (correct_for_center) {
+      var _lat = _origin.lat + (_origin.lat - destination.lat)/2,
+        _lng = _origin.lng + (_origin.lng - destination.lng)/2;
+      _origin = new L.LatLng(_lat, _lng);
+    }
+
+    var bounds = new L.LatLngBounds([_origin, destination]);
+    if (this.options.less_bounce) {
+      return this._map.getBoundsZoom(bounds, false, _padding);
+    } else {
+      return this._map.getBoundsZoom(bounds, true, _padding);
+    }
+  },
+
+  _getZoomifyZoom: function() {
+
+  },
+
+  _initialMapLocation: function() {
+    this._map.on("zoomend", this._onMapZoomed, this);
+  },
+
+  /*  Display
+  ================================================== */
+  _updateMapDisplay: function(animate, d) {
+    if (animate) {
+      var duration = this.options.duration,
+        self = this;
+
+      if (d) {duration = d };
+      if (this.timer) {clearTimeout(this.timer)};
+
+      this.timer = setTimeout(function() {
+        self._refreshMap();
+      }, duration);
+
+    } else {
+      if (!this.timer) {
+        this._refreshMap();
+      };
+    }
+
+    if (this._mini_map && this._el.container.offsetWidth < this.options.skinny_size ) {
+      this._mini_map.true_hide = true;
+      //this._mini_map.minimize();
+    } else if (this._mini_map) {
+      this._mini_map.true_hide = false;
+    }
+  },
+
+  _refreshMap: function() {
+    if (this._map) {
+      if (this.timer) {
+        clearTimeout(this.timer);
+        this.timer = null;
+      };
+
+      this._map.invalidateSize();
+
+      // Check to see if it's an overview
+      if (this._markers[this.current_marker].data.type && this._markers[this.current_marker].data.type == "overview") {
+        this._markerOverview();
+      } else {
+        this._viewTo(this._markers[this.current_marker].data.location, {zoom:this._getMapZoom()});
+      }
+    };
+  }
+
+
 });
 
-/*	Overwrite and customize Leaflet functions
+/*  Overwrite and customize Leaflet functions
 ================================================== */
 L.Map.include({
-	_tryAnimatedPan: function (center, options) {
-		var offset = this._getCenterOffset(center)._floor();
+  _tryAnimatedPan: function (center, options) {
+    var offset = this._getCenterOffset(center)._floor();
 
-		this.panBy(offset, options);
+    this.panBy(offset, options);
 
-		return true;
-	},
-	
-	_tryAnimatedZoom: function (center, zoom, options) {
-		if (typeof this._animateZoom == "undefined") {
-			return false;
-		}
-		if (this._animatingZoom) { return true; }
+    return true;
+  },
 
-		options = options || {};
+  _tryAnimatedZoom: function (center, zoom, options) {
+    if (typeof this._animateZoom == "undefined") {
+      return false;
+    }
+    if (this._animatingZoom) { return true; }
 
-		// offset is the pixel coords of the zoom origin relative to the current center
-		var scale = this.getZoomScale(zoom),
-		    offset = this._getCenterOffset(center)._divideBy(1 - 1 / scale),
-			origin = this._getCenterLayerPoint()._add(offset);
+    options = options || {};
 
-		this
-		    .fire('movestart')
-		    .fire('zoomstart');
+    // offset is the pixel coords of the zoom origin relative to the current center
+    var scale = this.getZoomScale(zoom),
+        offset = this._getCenterOffset(center)._divideBy(1 - 1 / scale),
+      origin = this._getCenterLayerPoint()._add(offset);
 
-		this._animateZoom(center, zoom, origin, scale, null, true);
+    this
+        .fire('movestart')
+        .fire('zoomstart');
 
-		return true;
-	},
+    this._animateZoom(center, zoom, origin, scale, null, true);
 
-	getBoundsZoom: function (bounds, inside, padding) { // (LatLngBounds[, Boolean, Point]) -> Number
-		bounds = L.latLngBounds(bounds);
+    return true;
+  },
 
-		var zoom = this.getMinZoom() - (inside ? 1 : 0),
-		    minZoom = this.getMinZoom(),
-			maxZoom = this.getMaxZoom(),
-		    size = this.getSize(),
+  getBoundsZoom: function (bounds, inside, padding) { // (LatLngBounds[, Boolean, Point]) -> Number
+    bounds = L.latLngBounds(bounds);
 
-		    nw = bounds.getNorthWest(),
-		    se = bounds.getSouthEast(),
+    var zoom = this.getMinZoom() - (inside ? 1 : 0),
+        minZoom = this.getMinZoom(),
+      maxZoom = this.getMaxZoom(),
+        size = this.getSize(),
 
-		    zoomNotFound = true,
-		    boundsSize,
-			zoom_array = [],
-			best_zoom = {x:0,y:0},
-			smallest_zoom = {},
-			final_zoom = 0;
+        nw = bounds.getNorthWest(),
+        se = bounds.getSouthEast(),
 
-		padding = L.point(padding || [0, 0]);
-		size = this.getSize();
-		
-		
-		// Calculate Zoom Level Differences
-		for (var i = 0; i < maxZoom; i++) {
-			zoom++;
-			boundsSize = this.project(se, zoom).subtract(this.project(nw, zoom)).add(padding);
-			zoom_array.push({
-				x:Math.abs(size.x - boundsSize.x),
-				y:Math.abs(size.y - boundsSize.y)
-			})
-		}
-		
-		// Determine closest match
-		smallest_zoom = zoom_array[0];
-		for (var j = 0; j < zoom_array.length; j++) {
-			if (zoom_array[j].y <= smallest_zoom.y) {
-				smallest_zoom.y = zoom_array[j].y;
-				best_zoom.y = j;
-			}
-			if (zoom_array[j].x <= smallest_zoom.x) {
-				smallest_zoom.x = zoom_array[j].x;
-				best_zoom.x = j; 
-			}
-			
-		}
-		final_zoom = Math.round((best_zoom.y + best_zoom.x) / 2)
-		return final_zoom;
+        zoomNotFound = true,
+        boundsSize,
+      zoom_array = [],
+      best_zoom = {x:0,y:0},
+      smallest_zoom = {},
+      final_zoom = 0;
 
-	}
-	
+    padding = L.point(padding || [0, 0]);
+    size = this.getSize();
+
+
+    // Calculate Zoom Level Differences
+    for (var i = 0; i < maxZoom; i++) {
+      zoom++;
+      boundsSize = this.project(se, zoom).subtract(this.project(nw, zoom)).add(padding);
+      zoom_array.push({
+        x:Math.abs(size.x - boundsSize.x),
+        y:Math.abs(size.y - boundsSize.y)
+      })
+    }
+
+    // Determine closest match
+    smallest_zoom = zoom_array[0];
+    for (var j = 0; j < zoom_array.length; j++) {
+      if (zoom_array[j].y <= smallest_zoom.y) {
+        smallest_zoom.y = zoom_array[j].y;
+        best_zoom.y = j;
+      }
+      if (zoom_array[j].x <= smallest_zoom.x) {
+        smallest_zoom.x = zoom_array[j].x;
+        best_zoom.x = j;
+      }
+
+    }
+    final_zoom = Math.round((best_zoom.y + best_zoom.x) / 2)
+    return final_zoom;
+
+  }
+
 });
 
 L.TileLayer.include({
-	getTiles: function() {
-		return this._tiles;
-	}
+  getTiles: function() {
+    return this._tiles;
+  }
 });
 
 /* **********************************************
      Begin VCO.StoryMap.js
 ********************************************** */
 
-/*	StoryMap
-	Designed and built by Zach Wise at VéritéCo
+/*  StoryMap
+  Designed and built by Zach Wise at VéritéCo
 
-	This Source Code Form is subject to the terms of the Mozilla Public
-	License, v. 2.0. If a copy of the MPL was not distributed with this
-	file, You can obtain one at http://mozilla.org/MPL/2.0/.
-	
+  This Source Code Form is subject to the terms of the Mozilla Public
+  License, v. 2.0. If a copy of the MPL was not distributed with this
+  file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 ================================================== */
-/* 
-	TODO
-	Message for Data Loading
-*/ 
+/*
+  TODO
+  Message for Data Loading
+*/
 
-/*	Required Files
-	CodeKit Import
-	http://incident57.com/codekit/
+/*  Required Files
+  CodeKit Import
+  http://incident57.com/codekit/
 ================================================== */
 
 // CORE
-	// @codekit-prepend "core/VCO.js";
-	// @codekit-prepend "core/VCO.Util.js";
-	// @codekit-prepend "data/VCO.Data.js";
-	// @codekit-prepend "core/VCO.Class.js";
-	// @codekit-prepend "core/VCO.Events.js";
-	// @codekit-prepend "core/VCO.Browser.js";
-	// @codekit-prepend "core/VCO.Load.js";
+  // @codekit-prepend "core/VCO.js";
+  // @codekit-prepend "core/VCO.Util.js";
+  // @codekit-prepend "data/VCO.Data.js";
+  // @codekit-prepend "core/VCO.Class.js";
+  // @codekit-prepend "core/VCO.Events.js";
+  // @codekit-prepend "core/VCO.Browser.js";
+  // @codekit-prepend "core/VCO.Load.js";
 
 // LANGUAGE
-	// @codekit-prepend "language/VCO.Language.js";
-	
+  // @codekit-prepend "language/VCO.Language.js";
+
 // LIBRARY
-	// @codekit-prepend "library/VCO.Emoji.js";
+  // @codekit-prepend "library/VCO.Emoji.js";
 
 // ANIMATION
-	// @codekit-prepend "animation/VCO.Ease.js";
-	// @codekit-prepend "animation/VCO.Animate.js";
+  // @codekit-prepend "animation/VCO.Ease.js";
+  // @codekit-prepend "animation/VCO.Animate.js";
 
 // DOM
-	// @codekit-prepend "dom/VCO.Point.js";
-	// @codekit-prepend "dom/VCO.DomMixins.js";
-	// @codekit-prepend "dom/VCO.Dom.js";
-	// @codekit-prepend "dom/VCO.DomUtil.js";
-	// @codekit-prepend "dom/VCO.DomEvent.js";
+  // @codekit-prepend "dom/VCO.Point.js";
+  // @codekit-prepend "dom/VCO.DomMixins.js";
+  // @codekit-prepend "dom/VCO.Dom.js";
+  // @codekit-prepend "dom/VCO.DomUtil.js";
+  // @codekit-prepend "dom/VCO.DomEvent.js";
 
 // UI
-	// @codekit-prepend "ui/VCO.Draggable.js";
-	// @codekit-prepend "ui/VCO.Swipable.js";
-	// @codekit-prepend "ui/VCO.MenuBar.js";
-	// @codekit-prepend "ui/VCO.Message.js";
+  // @codekit-prepend "ui/VCO.Draggable.js";
+  // @codekit-prepend "ui/VCO.Swipable.js";
+  // @codekit-prepend "ui/VCO.MenuBar.js";
+  // @codekit-prepend "ui/VCO.Message.js";
 
 // MEDIA
-	// @codekit-prepend "media/VCO.MediaType.js";
-	// @codekit-prepend "media/VCO.Media.js";
+  // @codekit-prepend "media/VCO.MediaType.js";
+  // @codekit-prepend "media/VCO.Media.js";
 
 // MEDIA TYPES
-	// @codekit-prepend "media/types/VCO.Media.Blockquote.js";
-	// @codekit-prepend "media/types/VCO.Media.Flickr.js";
-	// @codekit-prepend "media/types/VCO.Media.Instagram.js";
-	// @codekit-prepend "media/types/VCO.Media.Profile.js";
-	// @codekit-prepend "media/types/VCO.Media.GoogleDoc.js";
-	// @codekit-prepend "media/types/VCO.Media.GooglePlus.js";
-	// @codekit-prepend "media/types/VCO.Media.IFrame.js";
-	// @codekit-prepend "media/types/VCO.Media.Image.js";
-	// @codekit-prepend "media/types/VCO.Media.SoundCloud.js";
-	// @codekit-prepend "media/types/VCO.Media.Storify.js";
-	// @codekit-prepend "media/types/VCO.Media.Text.js";
-	// @codekit-prepend "media/types/VCO.Media.Twitter.js";
-	// @codekit-prepend "media/types/VCO.Media.Vimeo.js";
-	// @codekit-prepend "media/types/VCO.Media.DailyMotion.js";
-	// @codekit-prepend "media/types/VCO.Media.Vine.js";
-	// @codekit-prepend "media/types/VCO.Media.Website.js";
-	// @codekit-prepend "media/types/VCO.Media.Wikipedia.js";
-	// @codekit-prepend "media/types/VCO.Media.YouTube.js";
-	// @codekit-prepend "media/types/VCO.Media.Slider.js";
+  // @codekit-prepend "media/types/VCO.Media.Blockquote.js";
+  // @codekit-prepend "media/types/VCO.Media.Flickr.js";
+  // @codekit-prepend "media/types/VCO.Media.Instagram.js";
+  // @codekit-prepend "media/types/VCO.Media.Profile.js";
+  // @codekit-prepend "media/types/VCO.Media.GoogleDoc.js";
+  // @codekit-prepend "media/types/VCO.Media.GooglePlus.js";
+  // @codekit-prepend "media/types/VCO.Media.IFrame.js";
+  // @codekit-prepend "media/types/VCO.Media.Image.js";
+  // @codekit-prepend "media/types/VCO.Media.SoundCloud.js";
+  // @codekit-prepend "media/types/VCO.Media.Storify.js";
+  // @codekit-prepend "media/types/VCO.Media.Text.js";
+  // @codekit-prepend "media/types/VCO.Media.Twitter.js";
+  // @codekit-prepend "media/types/VCO.Media.Vimeo.js";
+  // @codekit-prepend "media/types/VCO.Media.DailyMotion.js";
+  // @codekit-prepend "media/types/VCO.Media.Vine.js";
+  // @codekit-prepend "media/types/VCO.Media.Website.js";
+  // @codekit-prepend "media/types/VCO.Media.Wikipedia.js";
+  // @codekit-prepend "media/types/VCO.Media.YouTube.js";
+  // @codekit-prepend "media/types/VCO.Media.Slider.js";
 
 // STORYSLIDER
-	// @codekit-prepend "slider/VCO.Slide.js";
-	// @codekit-prepend "slider/VCO.SlideNav.js";
-	// @codekit-prepend "slider/VCO.StorySlider.js";
+  // @codekit-prepend "slider/VCO.Slide.js";
+  // @codekit-prepend "slider/VCO.SlideNav.js";
+  // @codekit-prepend "slider/VCO.StorySlider.js";
 
 // LEAFLET
-	
-	// LEAFLET SRC
-		// Leaflet Core
-			// @codekit-prepend "map/leaflet/leaflet-src/Leaflet.js";
-			// @codekit-prepend "map/leaflet/leaflet-src/core/Util.js";
-			// @codekit-prepend "map/leaflet/leaflet-src/core/Class.js";
-			// @codekit-prepend "map/leaflet/leaflet-src/core/Events.js";
-			// @codekit-prepend "map/leaflet/leaflet-src/core/Browser.js";
-			// @codekit-prepend "map/leaflet/leaflet-src/geometry/Point.js";
-			// @codekit-prepend "map/leaflet/leaflet-src/geometry/Bounds.js";
-			// @codekit-prepend "map/leaflet/leaflet-src/geometry/Transformation.js";
-			// @codekit-prepend "map/leaflet/leaflet-src/dom/DomUtil.js";
-			// @codekit-prepend "map/leaflet/leaflet-src/geo/LatLng.js";
-			// @codekit-prepend "map/leaflet/leaflet-src/geo/LatLngBounds.js";
-			// @codekit-prepend "map/leaflet/leaflet-src/geo/projection/Projection.js";
-			// @codekit-prepend "map/leaflet/leaflet-src/geo/projection/Projection.SphericalMercator.js";
-			// @codekit-prepend "map/leaflet/leaflet-src/geo/projection/Projection.LonLat.js";
-			// @codekit-prepend "map/leaflet/leaflet-src/geo/crs/CRS.js";
-			// @codekit-prepend "map/leaflet/leaflet-src/geo/crs/CRS.Simple.js";
-			// @codekit-prepend "map/leaflet/leaflet-src/geo/crs/CRS.EPSG3857.js";
-			// @codekit-prepend "map/leaflet/leaflet-src/geo/crs/CRS.EPSG4326.js";
-			// @codekit-prepend "map/leaflet/leaflet-src/map/Map.js";
-			// @codekit-prepend "map/leaflet/leaflet-src/dom/DomEvent.js";
-			// @codekit-prepend "map/leaflet/leaflet-src/dom/Draggable.js";
-			// @codekit-prepend "map/leaflet/leaflet-src/core/Handler.js";
-			// @codekit-prepend "map/leaflet/leaflet-src/control/Control.js";
 
-		// Additonal Projections EPSG:3395 projection (used by some map providers).
-			// "map/leaflet/leaflet-src/geo/projection/Projection.Mercator.js";
-			// "map/leaflet/leaflet-src/geo/crs/CRS.EPSG3395.js";
+  // LEAFLET SRC
+    // Leaflet Core
+      // @codekit-prepend "map/leaflet/leaflet-src/Leaflet.js";
+      // @codekit-prepend "map/leaflet/leaflet-src/core/Util.js";
+      // @codekit-prepend "map/leaflet/leaflet-src/core/Class.js";
+      // @codekit-prepend "map/leaflet/leaflet-src/core/Events.js";
+      // @codekit-prepend "map/leaflet/leaflet-src/core/Browser.js";
+      // @codekit-prepend "map/leaflet/leaflet-src/geometry/Point.js";
+      // @codekit-prepend "map/leaflet/leaflet-src/geometry/Bounds.js";
+      // @codekit-prepend "map/leaflet/leaflet-src/geometry/Transformation.js";
+      // @codekit-prepend "map/leaflet/leaflet-src/dom/DomUtil.js";
+      // @codekit-prepend "map/leaflet/leaflet-src/geo/LatLng.js";
+      // @codekit-prepend "map/leaflet/leaflet-src/geo/LatLngBounds.js";
+      // @codekit-prepend "map/leaflet/leaflet-src/geo/projection/Projection.js";
+      // @codekit-prepend "map/leaflet/leaflet-src/geo/projection/Projection.SphericalMercator.js";
+      // @codekit-prepend "map/leaflet/leaflet-src/geo/projection/Projection.LonLat.js";
+      // @codekit-prepend "map/leaflet/leaflet-src/geo/crs/CRS.js";
+      // @codekit-prepend "map/leaflet/leaflet-src/geo/crs/CRS.Simple.js";
+      // @codekit-prepend "map/leaflet/leaflet-src/geo/crs/CRS.EPSG3857.js";
+      // @codekit-prepend "map/leaflet/leaflet-src/geo/crs/CRS.EPSG4326.js";
+      // @codekit-prepend "map/leaflet/leaflet-src/map/Map.js";
+      // @codekit-prepend "map/leaflet/leaflet-src/dom/DomEvent.js";
+      // @codekit-prepend "map/leaflet/leaflet-src/dom/Draggable.js";
+      // @codekit-prepend "map/leaflet/leaflet-src/core/Handler.js";
+      // @codekit-prepend "map/leaflet/leaflet-src/control/Control.js";
 
-		// TileLayerWMS WMS tile layer.
-			// @codekit-prepend "map/leaflet/leaflet-src/layer/tile/TileLayer.js";
+    // Additonal Projections EPSG:3395 projection (used by some map providers).
+      // "map/leaflet/leaflet-src/geo/projection/Projection.Mercator.js";
+      // "map/leaflet/leaflet-src/geo/crs/CRS.EPSG3395.js";
 
-		// TileLayerCanvas Tile layer made from canvases (for custom drawing purposes)
-			// @codekit-prepend "map/leaflet/leaflet-src/layer/tile/TileLayer.Canvas.js";
+    // TileLayerWMS WMS tile layer.
+      // @codekit-prepend "map/leaflet/leaflet-src/layer/tile/TileLayer.js";
 
-		// ImageOverlay Used to display an image over a particular rectangular area of the map.
-			// @codekit-prepend "map/leaflet/leaflet-src/layer/ImageOverlay.js";
+    // TileLayerCanvas Tile layer made from canvases (for custom drawing purposes)
+      // @codekit-prepend "map/leaflet/leaflet-src/layer/tile/TileLayer.Canvas.js";
 
-		// Marker Markers to put on the map.
-			// @codekit-prepend "map/leaflet/leaflet-src/layer/marker/Icon.js";
-			// @codekit-prepend "map/leaflet/leaflet-src/layer/marker/Icon.Default.js";
-			// @codekit-prepend "map/leaflet/leaflet-src/layer/marker/Marker.js";
+    // ImageOverlay Used to display an image over a particular rectangular area of the map.
+      // @codekit-prepend "map/leaflet/leaflet-src/layer/ImageOverlay.js";
 
-		// DivIcon Lightweight div-based icon for markers.
-			// @codekit-prepend "map/leaflet/leaflet-src/layer/marker/DivIcon.js";
+    // Marker Markers to put on the map.
+      // @codekit-prepend "map/leaflet/leaflet-src/layer/marker/Icon.js";
+      // @codekit-prepend "map/leaflet/leaflet-src/layer/marker/Icon.Default.js";
+      // @codekit-prepend "map/leaflet/leaflet-src/layer/marker/Marker.js";
 
-		// Popup Used to display the map popup (used mostly for binding HTML data to markers and paths on click).
-			// "map/leaflet/leaflet-src/layer/Popup.js";
-			// "map/leaflet/leaflet-src/layer/marker/Marker.Popup.js";
+    // DivIcon Lightweight div-based icon for markers.
+      // @codekit-prepend "map/leaflet/leaflet-src/layer/marker/DivIcon.js";
 
-		// LayerGroup Allows grouping several layers to handle them as one.
-			// @codekit-prepend "map/leaflet/leaflet-src/layer/LayerGroup.js";
+    // Popup Used to display the map popup (used mostly for binding HTML data to markers and paths on click).
+      // "map/leaflet/leaflet-src/layer/Popup.js";
+      // "map/leaflet/leaflet-src/layer/marker/Marker.Popup.js";
 
-		// FeatureGroup Extends LayerGroup with mouse events and bindPopup method shared between layers.
-			// @codekit-prepend "map/leaflet/leaflet-src/layer/FeatureGroup.js";
+    // LayerGroup Allows grouping several layers to handle them as one.
+      // @codekit-prepend "map/leaflet/leaflet-src/layer/LayerGroup.js";
 
-		// Path Vector rendering core (SVG-powered), enables overlaying the map with SVG paths.
-			// @codekit-prepend "map/leaflet/leaflet-src/layer/vector/Path.js";
-			// @codekit-prepend "map/leaflet/leaflet-src/layer/vector/Path.SVG.js";
-			// "map/leaflet/leaflet-src/layer/vector/Path.Popup.js";
+    // FeatureGroup Extends LayerGroup with mouse events and bindPopup method shared between layers.
+      // @codekit-prepend "map/leaflet/leaflet-src/layer/FeatureGroup.js";
 
-		// PathVML VML fallback for vector rendering core (IE 6-8)
-			// "map/leaflet/leaflet-src/layer/vector/Path.VML.js";
+    // Path Vector rendering core (SVG-powered), enables overlaying the map with SVG paths.
+      // @codekit-prepend "map/leaflet/leaflet-src/layer/vector/Path.js";
+      // @codekit-prepend "map/leaflet/leaflet-src/layer/vector/Path.SVG.js";
+      // "map/leaflet/leaflet-src/layer/vector/Path.Popup.js";
 
-		// Path Canvas fallback for vector rendering core (makes it work on Android 2+)
-			// @codekit-prepend "map/leaflet/leaflet-src/layer/vector/canvas/Path.Canvas.js";
+    // PathVML VML fallback for vector rendering core (IE 6-8)
+      // "map/leaflet/leaflet-src/layer/vector/Path.VML.js";
 
-		// Polyline Polyline overlays.
-			// @codekit-prepend "map/leaflet/leaflet-src/geometry/LineUtil.js";
-			// @codekit-prepend "map/leaflet/leaflet-src/layer/vector/Polyline.js";
+    // Path Canvas fallback for vector rendering core (makes it work on Android 2+)
+      // @codekit-prepend "map/leaflet/leaflet-src/layer/vector/canvas/Path.Canvas.js";
 
-		// Polygon Polygon overlays
-			// @codekit-prepend "map/leaflet/leaflet-src/geometry/PolyUtil.js";
-			// @codekit-prepend "map/leaflet/leaflet-src/layer/vector/Polygon.js";
+    // Polyline Polyline overlays.
+      // @codekit-prepend "map/leaflet/leaflet-src/geometry/LineUtil.js";
+      // @codekit-prepend "map/leaflet/leaflet-src/layer/vector/Polyline.js";
 
-		// MultiPoly MultiPolygon and MultyPolyline layers.
-			// @codekit-prepend "map/leaflet/leaflet-src/layer/vector/MultiPoly.js";
+    // Polygon Polygon overlays
+      // @codekit-prepend "map/leaflet/leaflet-src/geometry/PolyUtil.js";
+      // @codekit-prepend "map/leaflet/leaflet-src/layer/vector/Polygon.js";
 
-		// Rectangle
-			// @codekit-prepend "map/leaflet/leaflet-src/layer/vector/Rectangle.js";
+    // MultiPoly MultiPolygon and MultyPolyline layers.
+      // @codekit-prepend "map/leaflet/leaflet-src/layer/vector/MultiPoly.js";
 
-		// Circle
-			// @codekit-prepend "map/leaflet/leaflet-src/layer/vector/Circle.js";
+    // Rectangle
+      // @codekit-prepend "map/leaflet/leaflet-src/layer/vector/Rectangle.js";
 
-		// CircleMarker
-			// @codekit-prepend "map/leaflet/leaflet-src/layer/vector/CircleMarker.js";
+    // Circle
+      // @codekit-prepend "map/leaflet/leaflet-src/layer/vector/Circle.js";
 
-		// VectorsCanvas Canvas fallback for vector layers (polygons, polylines, circles, circlemarkers)
-			// @codekit-prepend "map/leaflet/leaflet-src/layer/vector/canvas/Polyline.Canvas.js";
-			// "map/leaflet/leaflet-src/layer/vector/canvas/Polygon.Canvas.js";
-			// "map/leaflet/leaflet-src/layer/vector/canvas/Circle.Canvas.js";
-			// "map/leaflet/leaflet-src/layer/vector/canvas/CircleMarker.Canvas.js";
+    // CircleMarker
+      // @codekit-prepend "map/leaflet/leaflet-src/layer/vector/CircleMarker.js";
 
-		// GeoJSON GeoJSON layer, parses the data and adds corresponding layers above.
-			// "map/leaflet/leaflet-src/layer/GeoJSON.js";
+    // VectorsCanvas Canvas fallback for vector layers (polygons, polylines, circles, circlemarkers)
+      // @codekit-prepend "map/leaflet/leaflet-src/layer/vector/canvas/Polyline.Canvas.js";
+      // "map/leaflet/leaflet-src/layer/vector/canvas/Polygon.Canvas.js";
+      // "map/leaflet/leaflet-src/layer/vector/canvas/Circle.Canvas.js";
+      // "map/leaflet/leaflet-src/layer/vector/canvas/CircleMarker.Canvas.js";
 
-		// MapDrag Makes the map draggable (by mouse or touch).
-			// @codekit-prepend "map/leaflet/leaflet-src/map/handler/Map.Drag.js";
+    // GeoJSON GeoJSON layer, parses the data and adds corresponding layers above.
+      // "map/leaflet/leaflet-src/layer/GeoJSON.js";
 
-		// MouseZoom Scroll wheel zoom and double click zoom on the map.
-			// @codekit-prepend "map/leaflet/leaflet-src/map/handler/Map.DoubleClickZoom.js";
-			// @codekit-prepend "map/leaflet/leaflet-src/map/handler/Map.ScrollWheelZoom.js";
+    // MapDrag Makes the map draggable (by mouse or touch).
+      // @codekit-prepend "map/leaflet/leaflet-src/map/handler/Map.Drag.js";
 
-		// TouchZoom Enables smooth touch zoom / tap / longhold / doubletap on iOS, IE10, Android
-			// @codekit-prepend "map/leaflet/leaflet-src/dom/DomEvent.DoubleTap.js";
-			// @codekit-prepend "map/leaflet/leaflet-src/dom/DomEvent.Pointer.js";
-			// @codekit-prepend "map/leaflet/leaflet-src/map/handler/Map.TouchZoom.js";
-			// @codekit-prepend "map/leaflet/leaflet-src/map/handler/Map.Tap.js";
+    // MouseZoom Scroll wheel zoom and double click zoom on the map.
+      // @codekit-prepend "map/leaflet/leaflet-src/map/handler/Map.DoubleClickZoom.js";
+      // @codekit-prepend "map/leaflet/leaflet-src/map/handler/Map.ScrollWheelZoom.js";
 
-		// BoxZoom Enables zooming to bounding box by shift-dragging the map.
-			// "map/leaflet/leaflet-src/map/handler/Map.BoxZoom.js";
+    // TouchZoom Enables smooth touch zoom / tap / longhold / doubletap on iOS, IE10, Android
+      // @codekit-prepend "map/leaflet/leaflet-src/dom/DomEvent.DoubleTap.js";
+      // @codekit-prepend "map/leaflet/leaflet-src/dom/DomEvent.Pointer.js";
+      // @codekit-prepend "map/leaflet/leaflet-src/map/handler/Map.TouchZoom.js";
+      // @codekit-prepend "map/leaflet/leaflet-src/map/handler/Map.Tap.js";
 
-		// Keyboard Enables keyboard pan/zoom when the map is focused.
-			// "map/leaflet/leaflet-src/map/handler/Map.Keyboard.js";
+    // BoxZoom Enables zooming to bounding box by shift-dragging the map.
+      // "map/leaflet/leaflet-src/map/handler/Map.BoxZoom.js";
 
-		// ControlZoom Basic zoom control with two buttons (zoom in / zoom out).
-			// @codekit-prepend "map/leaflet/leaflet-src/control/Control.Zoom.js";
+    // Keyboard Enables keyboard pan/zoom when the map is focused.
+      // "map/leaflet/leaflet-src/map/handler/Map.Keyboard.js";
 
-		// ControlAttrib Attribution control.
-			// @codekit-prepend "map/leaflet/leaflet-src/control/Control.Attribution.js";
+    // ControlZoom Basic zoom control with two buttons (zoom in / zoom out).
+      // @codekit-prepend "map/leaflet/leaflet-src/control/Control.Zoom.js";
 
-		// ControlScale Scale control.
-			// "map/leaflet/leaflet-src/control/Control.Scale.js";
+    // ControlAttrib Attribution control.
+      // @codekit-prepend "map/leaflet/leaflet-src/control/Control.Attribution.js";
 
-		// ControlLayers Layer Switcher control.
-			// "map/leaflet/leaflet-src/control/Control.Layers.js";
+    // ControlScale Scale control.
+      // "map/leaflet/leaflet-src/control/Control.Scale.js";
 
-		// AnimationPan Core panning animation support.
-			// @codekit-prepend "map/leaflet/leaflet-src/dom/PosAnimation.js";
-			// @codekit-prepend "map/leaflet/leaflet-src/map/anim/Map.PanAnimation.js";
+    // ControlLayers Layer Switcher control.
+      // "map/leaflet/leaflet-src/control/Control.Layers.js";
 
-		// AnimationTimer Timer-based pan animation fallback for browsers that don\'t support CSS3 transitions.
-			// @codekit-prepend "map/leaflet/leaflet-src/dom/PosAnimation.Timer.js";
+    // AnimationPan Core panning animation support.
+      // @codekit-prepend "map/leaflet/leaflet-src/dom/PosAnimation.js";
+      // @codekit-prepend "map/leaflet/leaflet-src/map/anim/Map.PanAnimation.js";
 
-		// AnimationZoom Smooth zooming animation. Works only on browsers that support CSS3 Transitions.
-			// @codekit-prepend "map/leaflet/leaflet-src/map/anim/Map.ZoomAnimation.js";
-			// @codekit-prepend "map/leaflet/leaflet-src/layer/tile/TileLayer.Anim.js";
+    // AnimationTimer Timer-based pan animation fallback for browsers that don\'t support CSS3 transitions.
+      // @codekit-prepend "map/leaflet/leaflet-src/dom/PosAnimation.Timer.js";
 
-		// Geolocation Adds Map#locate method and related events to make geolocation easier.'
-			// "map/leaflet/leaflet-src/map/ext/Map.Geolocation.js";
-	
+    // AnimationZoom Smooth zooming animation. Works only on browsers that support CSS3 Transitions.
+      // @codekit-prepend "map/leaflet/leaflet-src/map/anim/Map.ZoomAnimation.js";
+      // @codekit-prepend "map/leaflet/leaflet-src/layer/tile/TileLayer.Anim.js";
+
+    // Geolocation Adds Map#locate method and related events to make geolocation easier.'
+      // "map/leaflet/leaflet-src/map/ext/Map.Geolocation.js";
+
 // LEAFLET EXTENTIONS
-	// @codekit-prepend "map/leaflet/extentions/VCO.Leaflet.TileLayer.Zoomify.js";
-	// @codekit-prepend "map/leaflet/extentions/VCO.Leaflet.MiniMap.js";
-	
+  // @codekit-prepend "map/leaflet/extentions/VCO.Leaflet.TileLayer.Zoomify.js";
+  // @codekit-prepend "map/leaflet/extentions/VCO.Leaflet.MiniMap.js";
+
 // TILES
-	// "map/tile/VCO.TileLayer.Mapbox.js"; NOT READY YET
-	// @codekit-prepend "map/tile/VCO.TileLayer.Stamen.js";
-	
+  // "map/tile/VCO.TileLayer.Mapbox.js"; NOT READY YET
+  // @codekit-prepend "map/tile/VCO.TileLayer.Stamen.js";
+
 // MAP
-	// @codekit-prepend "map/VCO.MapMarker.js";
-	// @codekit-prepend "map/VCO.Map.js";
+  // @codekit-prepend "map/VCO.MapMarker.js";
+  // @codekit-prepend "map/VCO.Map.js";
 
 // LEAFLET IMPLIMENTATION
-	// @codekit-prepend "map/leaflet/VCO.MapMarker.Leaflet.js";
-	// @codekit-prepend "map/leaflet/VCO.Map.Leaflet.js";
+  // @codekit-prepend "map/leaflet/VCO.MapMarker.Leaflet.js";
+  // @codekit-prepend "map/leaflet/VCO.Map.Leaflet.js";
 
 
 VCO.StoryMap = VCO.Class.extend({
-	
-	includes: VCO.Events,
-	
-	/*	Private Methods
-	================================================== */
-	initialize: function (elem, data, options,listeners) {
-		for (key in listeners) {
-			var callbacks = listeners[key];
-			if (typeof(callbacks) == 'function') {
-				this.on(key,callbacks);
-			} else {
-				for (var idx in callbacks) {
-					this.on(key,callbacks[idx]);
-				}
-			}
-		}
-		var self = this;
-		// Version
-		this.version = "0.1.16";
-		
-		// Ready
-		this.ready = false;
-		
-		// DOM ELEMENTS
-		this._el = {
-			container: {},
-			storyslider: {},
-			map: {},
-			menubar: {}
-		};
-		
-		// Determine Container Element
-		if (typeof elem === 'object') {
-			this._el.container = elem;
-		} else {
-			this._el.container = VCO.Dom.get(elem);
-		}
-		
-		// Slider
-		this._storyslider = {};
-		
-		// Map
-		this._map = {};
-		this.map = {}; // For direct access to Leaflet Map
-		
-		// Menu Bar
-		this._menubar = {};
-		
-		// Loaded State
-		this._loaded = {storyslider:false, map:false};
-		
-		// Data Object
-		// Test Data compiled from http://www.pbs.org/marktwain/learnmore/chronology.html
-		this.data = {};
-	
-		this.options = {
-			script_path:            VCO.StoryMap.SCRIPT_PATH,
-			height: 				this._el.container.offsetHeight,
-			width: 					this._el.container.offsetWidth,
-			layout: 				"landscape", 	// portrait or landscape
-			base_class: 			"",
-			default_bg_color: 		{r:256, g:256, b:256},
-			map_size_sticky: 		2.5, 				// Set as division 1/3 etc
-			map_center_offset:  	null, 			// takes object {top:0,left:0}
-			less_bounce: 			false, 			// Less map bounce when calculating zoom, false is good when there are clusters of tightly grouped markers
-			start_at_slide: 		0,
-			call_to_action: 		false,
-			call_to_action_text: 	"",
-			menubar_height: 		0,
-			skinny_size: 			650,
-			relative_date: 			false, 			// Use momentjs to show a relative date from the slide.text.date.created_time field
-			// animation
-			duration: 				1000,
-			ease: 					VCO.Ease.easeInOutQuint,
-			// interaction
-			dragging: 				true,
-			trackResize: 			true,
-			map_type: 				"stamen:toner-lite",
-			map_mini: 				true,
-			map_subdomains: 		"",
-			map_as_image: 			false,
-			map_background_color: 	"#d9d9d9",
-			zoomify: {
-				path: 				"",
-				width: 				"",
-				height: 			"",
-				tolerance: 			0.8,
-				attribution: 		""
-			},
-			map_height: 			300,
-			storyslider_height: 	600,
-			slide_padding_lr: 		45, 			// padding on slide of slide
-			slide_default_fade: 	"0%", 			// landscape fade
-			menubar_default_y: 		0,
-			path_gfx: 				"gfx",
-			map_popup: 				false,
-			zoom_distance: 			100,
-			calculate_zoom: 		true,   		// Allow map to determine best zoom level between markers (recommended)
-			use_custom_markers: 	false,  		// Allow use of custom map marker icons
-			line_follows_path: 		true,   		// Map history path follows default line, if false it will connect previous and current only
-			line_color: 			"#c34528", //"#DA0000",
-			line_color_inactive: 	"#CCC",
-			line_join: 				"miter",
-			line_weight: 			3,
-			line_opacity: 			0.80,
-			line_dash: 				"5,5",
-			show_lines: 			true,
-			show_history_line: 		true,
-			api_key_flickr: 		"f2cc870b4d233dd0a5bfe73fd0d64ef0",
-			language:               "en"		
-		};
-		
-		// Current Slide
-		this.current_slide = this.options.start_at_slide;
-		
-		// Animation Objects
-		this.animator_map = null;
-		this.animator_storyslider = null;
-		
-		// Merge Options -- legacy, in case people still need to pass in 
-		VCO.Util.mergeData(this.options, options);
+
+  includes: VCO.Events,
+
+  /*  Private Methods
+  ================================================== */
+  initialize: function (elem, data, options,listeners) {
+    for (key in listeners) {
+      var callbacks = listeners[key];
+      if (typeof(callbacks) == 'function') {
+        this.on(key,callbacks);
+      } else {
+        for (var idx in callbacks) {
+          this.on(key,callbacks[idx]);
+        }
+      }
+    }
+    var self = this;
+    // Version
+    this.version = "0.1.16";
+
+    // Ready
+    this.ready = false;
+
+    // DOM ELEMENTS
+    this._el = {
+      container: {},
+      storyslider: {},
+      map: {},
+      menubar: {}
+    };
+
+    // Determine Container Element
+    if (typeof elem === 'object') {
+      this._el.container = elem;
+    } else {
+      this._el.container = VCO.Dom.get(elem);
+    }
+
+    // Slider
+    this._storyslider = {};
+
+    // Map
+    this._map = {};
+    this.map = {}; // For direct access to Leaflet Map
+
+    // Menu Bar
+    this._menubar = {};
+
+    // Loaded State
+    this._loaded = {storyslider:false, map:false};
+
+    // Data Object
+    // Test Data compiled from http://www.pbs.org/marktwain/learnmore/chronology.html
+    this.data = {};
+
+    this.options = {
+      script_path:            VCO.StoryMap.SCRIPT_PATH,
+      height:         this._el.container.offsetHeight,
+      width:          this._el.container.offsetWidth,
+      layout:         "landscape",  // portrait or landscape
+      base_class:       "",
+      default_bg_color:     {r:256, g:256, b:256},
+      map_size_sticky:    2.5,        // Set as division 1/3 etc
+      map_center_offset:    null,       // takes object {top:0,left:0}
+      less_bounce:      false,      // Less map bounce when calculating zoom, false is good when there are clusters of tightly grouped markers
+      start_at_slide:     0,
+      call_to_action:     false,
+      call_to_action_text:  "",
+      menubar_height:     0,
+      skinny_size:      650,
+      relative_date:      false,      // Use momentjs to show a relative date from the slide.text.date.created_time field
+      // animation
+      duration:         1000,
+      ease:           VCO.Ease.easeInOutQuint,
+      // interaction
+      dragging:         true,
+      trackResize:      true,
+      map_type:         "stamen:toner-lite",
+      map_mini:         true,
+      map_subdomains:     "",
+      map_as_image:       false,
+      map_background_color:   "#d9d9d9",
+      zoomify: {
+        path:         "",
+        width:        "",
+        height:       "",
+        tolerance:      0.8,
+        attribution:    ""
+      },
+      map_height:       300,
+      storyslider_height:   600,
+      slide_padding_lr:     45,       // padding on slide of slide
+      slide_default_fade:   "0%",       // landscape fade
+      menubar_default_y:    0,
+      path_gfx:         "gfx",
+      map_popup:        false,
+      zoom_distance:      100,
+      calculate_zoom:     true,       // Allow map to determine best zoom level between markers (recommended)
+      use_custom_markers:   false,      // Allow use of custom map marker icons
+      line_follows_path:    true,       // Map history path follows default line, if false it will connect previous and current only
+      line_color:       "#c34528", //"#DA0000",
+      line_color_inactive:  "#CCC",
+      line_join:        "miter",
+      line_weight:      3,
+      line_opacity:       0.80,
+      line_dash:        "5,5",
+      show_lines:       true,
+      show_history_line:    true,
+      api_key_flickr:     "f2cc870b4d233dd0a5bfe73fd0d64ef0",
+      language:               "en"
+    };
+
+    // Current Slide
+    this.current_slide = this.options.start_at_slide;
+
+    // Animation Objects
+    this.animator_map = null;
+    this.animator_storyslider = null;
+
+    // Merge Options -- legacy, in case people still need to pass in
+    VCO.Util.mergeData(this.options, options);
 
         this._initData(data);
-        
-		return this;
-	},
-	
-	/* Initialize the data
-	================================================== */
+
+    return this;
+  },
+
+  /* Initialize the data
+  ================================================== */
     _initData: function(data) {
-		var self = this;
-		
-		if (typeof data === 'string') {			
-			VCO.getJSON(data, function(d) {
-				if (d && d.storymap) {
-					VCO.Util.mergeData(self.data, d.storymap);
-				}
-				self._initOptions();
-			});
-		} else if (typeof data === 'object') {
-			if (data.storymap) {
-				self.data = data.storymap;
-			} else {
-				trace("data must have a storymap property")
-			}
-			self._initOptions();
-		} else {
-		    trace("data has unknown type")
-		    self._initOptions();
+    var self = this;
+
+    if (typeof data === 'string') {
+      VCO.getJSON(data, function(d) {
+        if (d && d.storymap) {
+          VCO.Util.mergeData(self.data, d.storymap);
         }
-	},
-	
-	/* Initialize the options
-	================================================== */
+        self._initOptions();
+      });
+    } else if (typeof data === 'object') {
+      if (data.storymap) {
+        self.data = data.storymap;
+      } else {
+        trace("data must have a storymap property")
+      }
+      self._initOptions();
+    } else {
+        trace("data has unknown type")
+        self._initOptions();
+        }
+  },
+
+  /* Initialize the options
+  ================================================== */
     _initOptions: function() {
- 		var self = this;
+    var self = this;
 
         // Grab options from storymap data
         VCO.Util.updateData(this.options, this.data);
-        
-		if (this.options.layout == "landscape") {
-			this.options.map_center_offset = {left: -200, top: 0};
-		}
-		if (this.options.map_type == "zoomify" && this.options.map_as_image) {
-			this.options.map_size_sticky = 2;			
-		}
-		if (this.options.map_as_image) {
-			this.options.calculate_zoom = false;
-		}
-    
+
+    if (this.options.layout == "landscape") {
+      this.options.map_center_offset = {left: -200, top: 0};
+    }
+    if (this.options.map_type == "zoomify" && this.options.map_as_image) {
+      this.options.map_size_sticky = 2;
+    }
+    if (this.options.map_as_image) {
+      this.options.calculate_zoom = false;
+    }
+
         // Use relative date calculations?
-		if(this.options.relative_date) {
-			if (typeof(moment) !== 'undefined') {
-				self._loadLanguage();
-			} else {
-				VCO.Load.js(this.options.script_path + "/library/moment.js", function() {
-					self._loadLanguage();
-					trace("LOAD MOMENTJS")
-				});
-			}			
-		} else {
-			self._loadLanguage();
-		}    
- 
- 		// Emoji Support to Chrome?
-		if (VCO.Browser.chrome) {
-			VCO.Load.css(VCO.Util.urljoin(this.options.script_path,"../css/fonts/font.emoji.css"), function() {
-				trace("LOADED EMOJI CSS FOR CHROME")
-			});
-		}
-    },	
-    
-	/*	Load Language
-	================================================== */
-	_loadLanguage: function() {
-		var self = this;
-		if(this.options.language == 'en') {
-		    this.options.language = VCO.Language;
-		    self._onDataLoaded();
-		} else {
-			VCO.Load.js(this.options.script_path + "/locale/" + this.options.language + ".js", function() {
-				self._onDataLoaded();
-			});
-		}
-	},
-	
-	/*	Navigation
-	================================================== */
-	goTo: function(n) {
-		if (n != this.current_slide) {
-			this.current_slide = n;
-			this._storyslider.goTo(this.current_slide);
-			this._map.goTo(this.current_slide);
-		}
-	},
+    if(this.options.relative_date) {
+      if (typeof(moment) !== 'undefined') {
+        self._loadLanguage();
+      } else {
+        VCO.Load.js(this.options.script_path + "/library/moment.js", function() {
+          self._loadLanguage();
+          trace("LOAD MOMENTJS")
+        });
+      }
+    } else {
+      self._loadLanguage();
+    }
 
-	updateDisplay: function() {
-		if (this.ready) {
-			this._updateDisplay();
-		}
-	},
-	
-	/*	Private Methods
-	================================================== */
-	
-	// Initialize the data
+    // Emoji Support to Chrome?
+    if (VCO.Browser.chrome) {
+      VCO.Load.css(VCO.Util.urljoin(this.options.script_path,"../css/fonts/font.emoji.css"), function() {
+        trace("LOADED EMOJI CSS FOR CHROME")
+      });
+    }
+    },
+
+  /*  Load Language
+  ================================================== */
+  _loadLanguage: function() {
+    var self = this;
+    if(this.options.language == 'en') {
+        this.options.language = VCO.Language;
+        self._onDataLoaded();
+    } else {
+      VCO.Load.js(this.options.script_path + "/locale/" + this.options.language + ".js", function() {
+        self._onDataLoaded();
+      });
+    }
+  },
+
+  /*  Navigation
+  ================================================== */
+  goTo: function(n) {
+    if (n != this.current_slide) {
+      this.current_slide = n;
+      this._storyslider.goTo(this.current_slide);
+      this._map.goTo(this.current_slide);
+    }
+  },
+
+  updateDisplay: function() {
+    if (this.ready) {
+      this._updateDisplay();
+    }
+  },
+
+  /*  Private Methods
+  ================================================== */
+
+  // Initialize the data
 /*
-	_initData: function(data) {
-		var self = this;
-		
-		if (typeof data === 'string') {
-			
-			VCO.getJSON(data, function(d) {
-				if (d && d.storymap) {
-					VCO.Util.mergeData(self.data, d.storymap);
-				}
-				self._onDataLoaded();
-			});
-		} else if (typeof data === 'object') {
-			if (data.storymap) {
-				self.data = data.storymap;
-			} else {
-				trace("data must have a storymap property")
-			}
-			self._onDataLoaded();
-		} else {
-			self._onDataLoaded();
-		}
-	},
-*/	
-	// Initialize the layout
-	_initLayout: function () {
-		var self = this;
-		
-		this._el.container.className += ' vco-storymap';
-		this.options.base_class = this._el.container.className;
-		
-		// Create Layout
-		this._el.menubar		= VCO.Dom.create('div', 'vco-menubar', this._el.container);
-		this._el.map 			= VCO.Dom.create('div', 'vco-map', this._el.container);
-		this._el.storyslider 	= VCO.Dom.create('div', 'vco-storyslider', this._el.container);
-		
-		// Initial Default Layout
-		this.options.width 				= this._el.container.offsetWidth;
-		this.options.height 			= this._el.container.offsetHeight;
-		this._el.map.style.height 		= "1px";
-		this._el.storyslider.style.top 	= "1px";
-		
-		// Create Map using preferred Map API
-		this._map = new VCO.Map.Leaflet(this._el.map, this.data, this.options);
-		this.map = this._map._map; // For access to Leaflet Map.
-		this._map.on('loaded', this._onMapLoaded, this);
-		
-		// Map Background Color
-		this._el.map.style.backgroundColor = this.options.map_background_color;
-		
-		// Create Menu Bar
-		this._menubar = new VCO.MenuBar(this._el.menubar, this._el.container, this.options);
-		
-		// Create StorySlider
-		this._storyslider = new VCO.StorySlider(this._el.storyslider, this.data, this.options);
-		this._storyslider.on('loaded', this._onStorySliderLoaded, this);
-		this._storyslider.on('title', this._onTitle, this);
-		this._storyslider.init();
-		
-		// LAYOUT
-		if (this.options.layout == "portrait") {
-			// Set Default Component Sizes
-			this.options.map_height 		= (this.options.height / this.options.map_size_sticky);
-			this.options.storyslider_height = (this.options.height - this._el.menubar.offsetHeight - this.options.map_height - 1);
-			this._menubar.setSticky(0);
-		} else {
-			this.options.menubar_height = this._el.menubar.offsetHeight;
-			// Set Default Component Sizes
-			this.options.map_height 		= this.options.height;
-			this.options.storyslider_height = (this.options.height - this._el.menubar.offsetHeight - 1);
-			this._menubar.setSticky(this.options.menubar_height);
-		}
-		
-		
-		// Update Display
-		this._updateDisplay(this.options.map_height, true, 2000);
-		
-		// Animate Menu Bar to Default Location
-		this._menubar.show(2000);
-		
-	},
-	
-	_initEvents: function () {
-		
-		// Sidebar Events
-		this._menubar.on('collapse', this._onMenuBarCollapse, this);
-		this._menubar.on('back_to_start', this._onBackToStart, this);
-		this._menubar.on('overview', this._onOverview, this);
-		
-		// StorySlider Events
-		this._storyslider.on('change', this._onSlideChange, this);
-		this._storyslider.on('colorchange', this._onColorChange, this);
-		
-		// Map Events
-		this._map.on('change', this._onMapChange, this);
-	},
-	
-	// Update View
-	_updateDisplay: function(map_height, animate, d) {
-		var duration 		= this.options.duration,
-			display_class 	= this.options.base_class,
-			self			= this;
-		
-		if (d) {
-			duration = d;
-		}
-		
-		// Update width and height
-		this.options.width = this._el.container.offsetWidth;
-		this.options.height = this._el.container.offsetHeight;
-		
-		// Check if skinny
-		if (this.options.width <= this.options.skinny_size) {
-			this.options.layout = "portrait";
-			//display_class += " vco-skinny";
-		} else {
-			this.options.layout = "landscape";
-		}
-		
-		
-		// Map Height
-		if (map_height) {
-			this.options.map_height = map_height;
-		}
-		
-		
-		// Detect Mobile and Update Orientation on Touch devices
-		if (VCO.Browser.touch) {
-			this.options.layout = VCO.Browser.orientation();
-			display_class += " vco-mobile";
-		}
-		
-		// LAYOUT
-		if (this.options.layout == "portrait") {
-			display_class += " vco-skinny";
-			// Map Offset
-			this._map.setMapOffset(0, 0);
-			
-			this.options.map_height 		= (this.options.height / this.options.map_size_sticky);
-			this.options.storyslider_height = (this.options.height - this.options.map_height - 1);
-			this._menubar.setSticky(0);
-			
-			// Portrait
-			display_class += " vco-layout-portrait";
-			
-			if (animate) {
-			
-				// Animate Map
-				if (this.animator_map) {
-					this.animator_map.stop();
-				}
-			
-				this.animator_map = VCO.Animate(this._el.map, {
-					height: 	(this.options.map_height) + "px",
-					duration: 	duration,
-					easing: 	VCO.Ease.easeOutStrong,
-					complete: function () {
-						self._map.updateDisplay(self.options.width, self.options.map_height, animate, d, self.options.menubar_height);
-					}
-				});
-			
-				// Animate StorySlider
-				if (this.animator_storyslider) {
-					this.animator_storyslider.stop();
-				}
-				this.animator_storyslider = VCO.Animate(this._el.storyslider, {
-					height: 	this.options.storyslider_height + "px",
-					duration: 	duration,
-					easing: 	VCO.Ease.easeOutStrong
-				});
-			
-			} else {
-				// Map
-				this._el.map.style.height = Math.ceil(this.options.map_height) + "px";
-			
-				// StorySlider
-				this._el.storyslider.style.height = this.options.storyslider_height + "px";
-			}
-			
-			// Update Component Displays
-			this._menubar.updateDisplay(this.options.width, this.options.height, animate);
-			this._map.updateDisplay(this.options.width, this.options.height, false);
-			this._storyslider.updateDisplay(this.options.width, this.options.storyslider_height, animate, this.options.layout);
-			
-		} else {
-			
-			// Landscape
-			display_class += " vco-layout-landscape";
-			
-			this.options.menubar_height = this._el.menubar.offsetHeight;
-			
-			// Set Default Component Sizes
-			this.options.map_height 		= this.options.height;
-			this.options.storyslider_height = this.options.height;
-			this._menubar.setSticky(this.options.menubar_height);
-			
-			// Set Sticky state of MenuBar
-			this._menubar.setSticky(this.options.menubar_height);
-			
-			this._el.map.style.height = this.options.height + "px";
-			
-			// Update Component Displays
-			this._map.setMapOffset(-(this.options.width/4), 0);
-			
-			// StorySlider
-			this._el.storyslider.style.top = 0;
-			this._el.storyslider.style.height = this.options.storyslider_height + "px";
-			
-			this._menubar.updateDisplay(this.options.width, this.options.height, animate);
-			this._map.updateDisplay(this.options.width, this.options.height, animate, d);
-			this._storyslider.updateDisplay(this.options.width/2, this.options.storyslider_height, animate, this.options.layout);
-		}
-		
-		
-		
-		// Apply class
-		this._el.container.className = display_class;
-		
-		
-	},
-	
-	
-	/*	Events
-	================================================== */
-	
-	_onDataLoaded: function(e) {
-		this.fire("dataloaded");
-		this._initLayout();
-		this._initEvents();
-		this.ready = true;
-		
-	},
-	
-	_onTitle: function(e) {
-		this.fire("title", e);
-	},
-	
-	_onColorChange: function(e) {
-		if (e.color || e.image) {
-			this._menubar.setColor(true);
-		} else {
-			this._menubar.setColor(false);
-		}
-	},
-	
-	_onSlideChange: function(e) {
-		if (this.current_slide != e.current_slide) {
-			this.current_slide = e.current_slide;
-			this._map.goTo(this.current_slide);
-			this.fire("change", {current_slide: this.current_slide}, this);
-		}
-	},
-	
-	_onMapChange: function(e) {
-		if (this.current_slide != e.current_marker) {
-			this.current_slide = e.current_marker;
-			this._storyslider.goTo(this.current_slide);
-			this.fire("change", {current_slide: this.current_slide}, this);
-		}
-	},
-	
-	_onOverview: function(e) {
-		this._map.markerOverview();
-	},
-	
-	_onBackToStart: function(e) {
-		this.current_slide = 0;
-		this._map.goTo(this.current_slide);
-		this._storyslider.goTo(this.current_slide);
-		this.fire("change", {current_slide: this.current_slide}, this);
-	},
-	
-	_onMenuBarCollapse: function(e) {
-		this._updateDisplay(e.y, true);
-	},
-	
-	_onMouseClick: function(e) {
-		
-	},
-	
-	_fireMouseEvent: function (e) {
-		if (!this._loaded) {
-			return;
-		}
+  _initData: function(data) {
+    var self = this;
 
-		var type = e.type;
-		type = (type === 'mouseenter' ? 'mouseover' : (type === 'mouseleave' ? 'mouseout' : type));
+    if (typeof data === 'string') {
 
-		if (!this.hasEventListeners(type)) {
-			return;
-		}
+      VCO.getJSON(data, function(d) {
+        if (d && d.storymap) {
+          VCO.Util.mergeData(self.data, d.storymap);
+        }
+        self._onDataLoaded();
+      });
+    } else if (typeof data === 'object') {
+      if (data.storymap) {
+        self.data = data.storymap;
+      } else {
+        trace("data must have a storymap property")
+      }
+      self._onDataLoaded();
+    } else {
+      self._onDataLoaded();
+    }
+  },
+*/
+  // Initialize the layout
+  _initLayout: function () {
+    var self = this;
 
-		if (type === 'contextmenu') {
-			VCO.DomEvent.preventDefault(e);
-		}
-		
-		this.fire(type, {
-			latlng: "something", //this.mouseEventToLatLng(e),
-			layerPoint: "something else" //this.mouseEventToLayerPoint(e)
-		});
-	},
-	
-	_onMapLoaded: function() {
-		this._loaded.map = true;
-		this._onLoaded();
-	},
-	
-	_onStorySliderLoaded: function() {
-		this._loaded.storyslider = true;
-		this._onLoaded();
-	},
-		
-	_onLoaded: function() {
-		if (this._loaded.storyslider && this._loaded.map) {
-			this.fire("loaded", this.data);
-		}
-	}
-	
-	
+    this._el.container.className += ' vco-storymap';
+    this.options.base_class = this._el.container.className;
+
+    // Create Layout
+    this._el.menubar    = VCO.Dom.create('div', 'vco-menubar', this._el.container);
+    this._el.map      = VCO.Dom.create('div', 'vco-map', this._el.container);
+    this._el.storyslider  = VCO.Dom.create('div', 'vco-storyslider', this._el.container);
+
+    // Initial Default Layout
+    this.options.width        = this._el.container.offsetWidth;
+    this.options.height       = this._el.container.offsetHeight;
+    this._el.map.style.height     = "1px";
+    this._el.storyslider.style.top  = "1px";
+
+    // Create Map using preferred Map API
+    this._map = new VCO.Map.Leaflet(this._el.map, this.data, this.options);
+    this.map = this._map._map; // For access to Leaflet Map.
+    this._map.on('loaded', this._onMapLoaded, this);
+
+    // Map Background Color
+    this._el.map.style.backgroundColor = this.options.map_background_color;
+
+    // Create Menu Bar
+    this._menubar = new VCO.MenuBar(this._el.menubar, this._el.container, this.options);
+
+    // Create StorySlider
+    this._storyslider = new VCO.StorySlider(this._el.storyslider, this.data, this.options);
+    this._storyslider.on('loaded', this._onStorySliderLoaded, this);
+    this._storyslider.on('title', this._onTitle, this);
+    this._storyslider.init();
+
+    // LAYOUT
+    if (this.options.layout == "portrait") {
+      // Set Default Component Sizes
+      this.options.map_height     = (this.options.height / this.options.map_size_sticky);
+      this.options.storyslider_height = (this.options.height - this._el.menubar.offsetHeight - this.options.map_height - 1);
+      this._menubar.setSticky(0);
+    } else {
+      this.options.menubar_height = this._el.menubar.offsetHeight;
+      // Set Default Component Sizes
+      this.options.map_height     = this.options.height;
+      this.options.storyslider_height = (this.options.height - this._el.menubar.offsetHeight - 1);
+      this._menubar.setSticky(this.options.menubar_height);
+    }
+
+
+    // Update Display
+    this._updateDisplay(this.options.map_height, true, 2000);
+
+    // Animate Menu Bar to Default Location
+    this._menubar.show(2000);
+
+  },
+
+  _initEvents: function () {
+
+    // Sidebar Events
+    this._menubar.on('collapse', this._onMenuBarCollapse, this);
+    this._menubar.on('back_to_start', this._onBackToStart, this);
+    this._menubar.on('overview', this._onOverview, this);
+
+    // StorySlider Events
+    this._storyslider.on('change', this._onSlideChange, this);
+    this._storyslider.on('colorchange', this._onColorChange, this);
+
+    // Map Events
+    this._map.on('change', this._onMapChange, this);
+  },
+
+  // Update View
+  _updateDisplay: function(map_height, animate, d) {
+    var duration    = this.options.duration,
+      display_class   = this.options.base_class,
+      self      = this;
+
+    if (d) {
+      duration = d;
+    }
+
+    // Update width and height
+    this.options.width = this._el.container.offsetWidth;
+    this.options.height = this._el.container.offsetHeight;
+
+    // Check if skinny
+    if (this.options.width <= this.options.skinny_size) {
+      this.options.layout = "portrait";
+      //display_class += " vco-skinny";
+    } else {
+      this.options.layout = "landscape";
+    }
+
+
+    // Map Height
+    if (map_height) {
+      this.options.map_height = map_height;
+    }
+
+
+    // Detect Mobile and Update Orientation on Touch devices
+    if (VCO.Browser.touch) {
+      this.options.layout = VCO.Browser.orientation();
+      display_class += " vco-mobile";
+    }
+
+    // LAYOUT
+    if (this.options.layout == "portrait") {
+      display_class += " vco-skinny";
+      // Map Offset
+      this._map.setMapOffset(0, 0);
+
+      this.options.map_height     = (this.options.height / this.options.map_size_sticky);
+      this.options.storyslider_height = (this.options.height - this.options.map_height - 1);
+      this._menubar.setSticky(0);
+
+      // Portrait
+      display_class += " vco-layout-portrait";
+
+      if (animate) {
+
+        // Animate Map
+        if (this.animator_map) {
+          this.animator_map.stop();
+        }
+
+        this.animator_map = VCO.Animate(this._el.map, {
+          height:   (this.options.map_height) + "px",
+          duration:   duration,
+          easing:   VCO.Ease.easeOutStrong,
+          complete: function () {
+            self._map.updateDisplay(self.options.width, self.options.map_height, animate, d, self.options.menubar_height);
+          }
+        });
+
+        // Animate StorySlider
+        if (this.animator_storyslider) {
+          this.animator_storyslider.stop();
+        }
+        this.animator_storyslider = VCO.Animate(this._el.storyslider, {
+          height:   this.options.storyslider_height + "px",
+          duration:   duration,
+          easing:   VCO.Ease.easeOutStrong
+        });
+
+      } else {
+        // Map
+        this._el.map.style.height = Math.ceil(this.options.map_height) + "px";
+
+        // StorySlider
+        this._el.storyslider.style.height = this.options.storyslider_height + "px";
+      }
+
+      // Update Component Displays
+      this._menubar.updateDisplay(this.options.width, this.options.height, animate);
+      this._map.updateDisplay(this.options.width, this.options.height, false);
+      this._storyslider.updateDisplay(this.options.width, this.options.storyslider_height, animate, this.options.layout);
+
+    } else {
+
+      // Landscape
+      display_class += " vco-layout-landscape";
+
+      this.options.menubar_height = this._el.menubar.offsetHeight;
+
+      // Set Default Component Sizes
+      this.options.map_height     = this.options.height;
+      this.options.storyslider_height = this.options.height;
+      this._menubar.setSticky(this.options.menubar_height);
+
+      // Set Sticky state of MenuBar
+      this._menubar.setSticky(this.options.menubar_height);
+
+      this._el.map.style.height = this.options.height + "px";
+
+      // Update Component Displays
+      this._map.setMapOffset(-(this.options.width/4), 0);
+
+      // StorySlider
+      this._el.storyslider.style.top = 0;
+      this._el.storyslider.style.height = this.options.storyslider_height + "px";
+
+      this._menubar.updateDisplay(this.options.width, this.options.height, animate);
+      this._map.updateDisplay(this.options.width, this.options.height, animate, d);
+      this._storyslider.updateDisplay(this.options.width/2, this.options.storyslider_height, animate, this.options.layout);
+    }
+
+
+
+    // Apply class
+    this._el.container.className = display_class;
+
+
+  },
+
+
+  /*  Events
+  ================================================== */
+
+  _onDataLoaded: function(e) {
+    this.fire("dataloaded");
+    this._initLayout();
+    this._initEvents();
+    this.ready = true;
+
+  },
+
+  _onTitle: function(e) {
+    this.fire("title", e);
+  },
+
+  _onColorChange: function(e) {
+    if (e.color || e.image) {
+      this._menubar.setColor(true);
+    } else {
+      this._menubar.setColor(false);
+    }
+  },
+
+  _onSlideChange: function(e) {
+    if (this.current_slide != e.current_slide) {
+      this.current_slide = e.current_slide;
+      this._map.goTo(this.current_slide);
+      this.fire("change", {current_slide: this.current_slide}, this);
+    }
+  },
+
+  _onMapChange: function(e) {
+    if (this.current_slide != e.current_marker) {
+      this.current_slide = e.current_marker;
+      this._storyslider.goTo(this.current_slide);
+      this.fire("change", {current_slide: this.current_slide}, this);
+    }
+  },
+
+  _onOverview: function(e) {
+    this._map.markerOverview();
+  },
+
+  _onBackToStart: function(e) {
+    this.current_slide = 0;
+    this._map.goTo(this.current_slide);
+    this._storyslider.goTo(this.current_slide);
+    this.fire("change", {current_slide: this.current_slide}, this);
+  },
+
+  _onMenuBarCollapse: function(e) {
+    this._updateDisplay(e.y, true);
+  },
+
+  _onMouseClick: function(e) {
+
+  },
+
+  _fireMouseEvent: function (e) {
+    if (!this._loaded) {
+      return;
+    }
+
+    var type = e.type;
+    type = (type === 'mouseenter' ? 'mouseover' : (type === 'mouseleave' ? 'mouseout' : type));
+
+    if (!this.hasEventListeners(type)) {
+      return;
+    }
+
+    if (type === 'contextmenu') {
+      VCO.DomEvent.preventDefault(e);
+    }
+
+    this.fire(type, {
+      latlng: "something", //this.mouseEventToLatLng(e),
+      layerPoint: "something else" //this.mouseEventToLayerPoint(e)
+    });
+  },
+
+  _onMapLoaded: function() {
+    this._loaded.map = true;
+    this._onLoaded();
+  },
+
+  _onStorySliderLoaded: function() {
+    this._loaded.storyslider = true;
+    this._onLoaded();
+  },
+
+  _onLoaded: function() {
+    if (this._loaded.storyslider && this._loaded.map) {
+      this.fire("loaded", this.data);
+    }
+  }
+
+
 });
 
 (function(_) {
-	var scripts = document.getElementsByTagName("script"),
-    		src = scripts[scripts.length-1].src;
-	_.SCRIPT_PATH = src.substr(0,src.lastIndexOf("/"));
+  var scripts = document.getElementsByTagName("script"),
+        src = scripts[scripts.length-1].src;
+  _.SCRIPT_PATH = src.substr(0,src.lastIndexOf("/"));
 
 })(VCO.StoryMap)


### PR DESCRIPTION
When loading over ssl, these references will throw errors in the console. The two hosts are apathetic to protocol, so this shouldn't cause a problem.