### PR TITLE
Call to action text displayed in editor option menu, and more

### DIFF
--- a/source/js/language/locale/en.js
+++ b/source/js/language/locale/en.js
@@ -1,1 +1,0 @@
-VCO.Language={name:"English",lang:"en",messages:{loading:"Loading",wikipedia:"From Wikipedia, the free encyclopedia",start:"Start Exploring"},buttons:{map_overview:"Map Overview",overview:"Overview",backtostart:"Back To Beginning",collapse_toggle:"Hide Map",uncollapse_toggle:"Show Map"}}

--- a/source/js/language/locale/en.js
+++ b/source/js/language/locale/en.js
@@ -1,0 +1,1 @@
+VCO.Language={name:"English",lang:"en",messages:{loading:"Loading",wikipedia:"From Wikipedia, the free encyclopedia",start:"Start Exploring"},buttons:{map_overview:"Map Overview",overview:"Overview",backtostart:"Back To Beginning",collapse_toggle:"Hide Map",uncollapse_toggle:"Show Map"}}

--- a/static/css/editor.css
+++ b/static/css/editor.css
@@ -91,7 +91,7 @@ input[type="radio"] {margin: 0;}
 .radio.inline {line-height: 16px;}
 
 #call_to_action_text {margin-left: 6px;}
-#call_default {
+#call_to_action_default {
 	padding-left: 108px;
     margin-bottom: 0px;
 }

--- a/static/css/editor.css
+++ b/static/css/editor.css
@@ -91,6 +91,10 @@ input[type="radio"] {margin: 0;}
 .radio.inline {line-height: 16px;}
 
 #call_to_action_text {margin-left: 6px;}
+#call_default {
+	padding-left: 108px;
+    margin-bottom: 0px;
+}
 
 .modal-backdrop {background-color: #F8F8F8;}
 .modal .error {color: #cc0000;font-style: italic;}

--- a/templates/_modals.html
+++ b/templates/_modals.html
@@ -147,6 +147,7 @@
                                 data-html="true"
                                 data-content="Choosing this will show a button on your first slide to lead your readers into the story. You can change the words on the button.<br><img style='margin-top: 5px' src='{{ STATIC_URL }}img/calltoaction.png'>"                    
                             >&nbsp;<i class="icon-question-sign icon-large"></i></a>
+                            <p id="call_default">Default: "Start Exploring"</p>
                         </div>
                     </div>            
                     <!-- zoomify -->

--- a/templates/_modals.html
+++ b/templates/_modals.html
@@ -147,7 +147,7 @@
                                 data-html="true"
                                 data-content="Choosing this will show a button on your first slide to lead your readers into the story. You can change the words on the button.<br><img style='margin-top: 5px' src='{{ STATIC_URL }}img/calltoaction.png'>"                    
                             >&nbsp;<i class="icon-question-sign icon-large"></i></a>
-                            <p id="call_default">Default: "Start Exploring"</p>
+                            <p id="call_to_action_default">Default: "<span id="call_default_text"></span>"</p>
                         </div>
                     </div>            
                     <!-- zoomify -->

--- a/templates/edit.html
+++ b/templates/edit.html
@@ -699,9 +699,32 @@ function storymap_init() {
             
             // Map init           
             map_init();
+            set_language_on_load();
         }
     );
 }
+
+function set_language_on_load () {
+    var url = "{{ CDN_URL }}js/locale/" + _storymap_data.storymap.language + ".js";
+    console.log(url);
+    load_language_script(url, language_loaded)
+}
+
+function load_language_script(url, callback) {
+    var head = document.getElementsByTagName('head')[0];
+    var script = document.createElement('script');
+    script.type = 'text/javascript';
+    script.charset = 'UTF-8'
+    script.src = url;
+    script.onreadystatechange = callback;
+    script.onload = callback;
+    head.appendChild(script);
+}
+
+function language_loaded () {
+    var call_defaul_exists = document.getElementById('call_default');
+    call_defaul_exists.innerHTML = 'Default: \"' + VCO.Language.messages.start + '\"';
+};
 
 $(function() {     
 
@@ -760,6 +783,9 @@ $(function() {
     $('#language').change(function(event) {
         _storymap_data.storymap['language'] = $(this).val();
         storymap_dirty(1);
+        var url = "{{ CDN_URL }}js/locale/" + $(this).val() + ".js";
+        console.log(url);
+        load_language_script(url, language_loaded)
     });
         
     $("input[name='map_as_image']").click(function() {

--- a/templates/edit.html
+++ b/templates/edit.html
@@ -130,6 +130,8 @@ var _storymap_object;       // VCO.StoryMap, for preview
 var _current_slide_index = -1;
 var _dirty = 0;
 
+var _language_library = {};  //cache for translations to allow switching back to English in editor, and reduce # of scripts loaded
+_language_library['en'] = VCO.Language;
 
 //
 // urls
@@ -699,31 +701,41 @@ function storymap_init() {
             
             // Map init           
             map_init();
-            set_language_on_load();
+
+            //Language init
+            check_language();
         }
     );
 }
 
-function set_language_on_load () {
-    var url = "{{ CDN_URL }}js/locale/" + _storymap_data.storymap.language + ".js";
-    console.log(url);
-    load_language_script(url, language_loaded)
-}
+function check_language () {
+    var _lang_ISO = _storymap_data.storymap['language'];
+    if (_language_library[_lang_ISO]) {
+        VCO.Language = _language_library[_lang_ISO];
+        var elem = document.getElementById('call_default_text');
+        elem.innerHTML = VCO.Language.messages['start'];
+    } else {
+        load_language_script(_lang_ISO)
+    }
+};
 
-function load_language_script(url, callback) {
+function load_language_script(_lang_ISO) {
+    var url = "{{ CDN_URL }}js/locale/" + _lang_ISO + ".js";
     var head = document.getElementsByTagName('head')[0];
     var script = document.createElement('script');
     script.type = 'text/javascript';
     script.charset = 'UTF-8'
     script.src = url;
-    script.onreadystatechange = callback;
-    script.onload = callback;
+    script.onload = function() {
+        language_loaded(_lang_ISO); 
+    }
     head.appendChild(script);
-}
+};
 
-function language_loaded () {
-    var call_defaul_exists = document.getElementById('call_default');
-    call_defaul_exists.innerHTML = 'Default: \"' + VCO.Language.messages.start + '\"';
+function language_loaded (_lang_ISO) {
+    _language_library[_lang_ISO] = VCO.Language;
+    var elem = document.getElementById('call_default_text');
+    elem.innerHTML = VCO.Language.messages['start'];
 };
 
 $(function() {     
@@ -783,9 +795,7 @@ $(function() {
     $('#language').change(function(event) {
         _storymap_data.storymap['language'] = $(this).val();
         storymap_dirty(1);
-        var url = "{{ CDN_URL }}js/locale/" + $(this).val() + ".js";
-        console.log(url);
-        load_language_script(url, language_loaded)
+        check_language();
     });
         
     $("input[name='map_as_image']").click(function() {


### PR DESCRIPTION
The default call to action text is displayed below the input. It is updated when the language option is changed. It could use some design love or a new position, but it is functional.
![screenshot 122](https://cloud.githubusercontent.com/assets/7632315/6835515/4483fb7e-d309-11e4-9692-fa5523348bcb.png)

Implemented by loading the language script into the head right after map_init() is called, and then loading new language scripts as they are selected in the options modal. This can easily be changed to the footer if requested.

Since the language script is being loaded, we have the unintended but helpful effect of the preview loading in the selected language (it previously only displayed the English translation, regardless of language selected).

These changes necessitated the creation of an en.js file to be included with the rest of the language files. It is a minified copy of the language function in storymap.js. I left the original function in storymap.js untouched.