### PR TITLE
Support for Website media functionality

### DIFF
--- a/source/js/media/VCO.MediaType.js
+++ b/source/js/media/VCO.MediaType.js
@@ -116,7 +116,7 @@ VCO.MediaType = function(m) {
 			{
 				type: 		"website",
 				name: 		"Website",
-				match_str: 	"http://",
+				match_str: 	"(http://|.html$)",
 				cls: 		VCO.Media.Website
 			},
 			{

--- a/source/js/media/types/VCO.Media.Website.js
+++ b/source/js/media/types/VCO.Media.Website.js
@@ -8,12 +8,27 @@ VCO.Media.Website = VCO.Media.extend({
 	/*	Load the media
 	================================================== */
 	_loadMedia: function() {
+
+		this._el.content_item	= VCO.Dom.create("div", "vco-media-item vco-media-web", this._el.content);
+                var self = this;
+		VCO.ajax({
+			type: 'GET',
+			url: this.data.url,
+			dataType: 'html',
+			success: function(d){
+				self.createMedia(d);
+			},
+			error:function(xhr, type){
+				var error_text = "Unable to load website";
+				self.loadErrorDisplay(error_text);
+			}
+		});
 		
 		
 	},
 	
 	createMedia: function(d) {		
-
+		this._el.content_item.innerHTML	= d;
 		
 		// After Loaded
 		this.onLoaded();


### PR DESCRIPTION
I noticed that there is a ``VCO.Media.Website`` method but it is empty. I'm not sure if there is an inheritance that I don't get but it appears that that functionality got stubbed out but not added.

This PR adds the ability to get a remote or local html page. I added the local option so I could add html to slides without adding large html strings directly to the JSON. See an example here: https://github.com/acouch/cityrealandimagined/blob/gh-pages/city_real.json#L32

I couldn't figure out how to update the compiled version so this is missing that step. I'm happy to do that step if you can help point me in the right direction. After reading https://github.com/NUKnightLab/StoryMapJS/issues/255 I think I might be by design.

Regardless this is an amazing project and I'm happy to try and help with this feature as directed.