### PR TITLE
Robot test framework fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 codekit-config.json
 
 build
+robot_tests/logs
 s3analysis/mirror
 s3analysis/*csv
 

--- a/fabfile.py
+++ b/fabfile.py
@@ -28,6 +28,10 @@ add_paths(project_path, repos_path)
 from fablib import *
 
 @task
+def test(*args,**kwargs):
+    os.execvp('robot', ('robot', '-d', 'robot_tests/logs') + args + ('robot_tests',))
+
+@task
 def prd(*args,**kwargs):
     abort( "you should be deploying with git, not the prd task")
 

--- a/fabfile.py
+++ b/fabfile.py
@@ -1,5 +1,6 @@
 from os.path import abspath, basename, dirname, join
 import sys
+import shutil
 from fabric.api import env
 
 #
@@ -29,6 +30,8 @@ from fablib import *
 
 @task
 def test(*args,**kwargs):
+    if os.path.isdir('robot_tests/logs'):
+        shutil.rmtree('robot_tests/logs')
     os.execvp('robot', ('robot', '-d', 'robot_tests/logs') + args + ('robot_tests',))
 
 @task

--- a/robot_tests/qunit.robot
+++ b/robot_tests/qunit.robot
@@ -6,7 +6,7 @@ Resource        resource.robot
 
 *** Test Cases ***
 Run QUnit
-    Detect And Open Browser  ${SERVER}/qunit.html
+    Go To  ${SERVER}/qunit.html
     Wait Until Page Contains  Tests completed
     ${failed count} =  Execute Javascript  return parseInt($('#qunit-testresult .failed').text())
     ${tests failed} =  Set Variable  ${failed count} != ${0}

--- a/robot_tests/qunit.robot
+++ b/robot_tests/qunit.robot
@@ -6,7 +6,7 @@ Resource        resource.robot
 
 *** Test Cases ***
 Run QUnit
-    Open Browser  ${SERVER}/qunit.html
+    Detect And Open Browser  ${SERVER}/qunit.html
     Wait Until Page Contains  Tests completed
     ${failed count} =  Execute Javascript  return parseInt($('#qunit-testresult .failed').text())
     ${tests failed} =  Set Variable  ${failed count} != ${0}

--- a/robot_tests/resource.robot
+++ b/robot_tests/resource.robot
@@ -8,12 +8,13 @@ Library        String
 ${PORT}        5001
 ${SERVER}      http://localhost:${PORT}
 ${BROWSER}     Firefox
+${SERVER LOG}  ${OUTPUT DIR}/server.log
 ${DELAY}       0
 ${ROOT URL}    ${SERVER}/select/
 
 *** Keywords ***
 Start Test Server
-    Start Process  bash -c "source env.sh && TEST_MODE\=on fab serve:port\=${PORT}"  shell=yes stdout=server.log  stderr=server.log  alias=test_server
+    Start Process  bash -c "source env.sh && TEST_MODE\=on fab serve:port\=${PORT}"  shell=yes  stdout=${SERVER LOG}  stderr=${SERVER LOG}  alias=test_server
     Sleep  3s
 
 Stop Test Server

--- a/robot_tests/resource.robot
+++ b/robot_tests/resource.robot
@@ -1,18 +1,24 @@
 *** Settings ***
 Documentation  Reusable keywords and variables for the StoryMap server.
 Library        Selenium2Library  timeout=5  implicit_wait=30
+Library        OperatingSystem
 Library        Process
 Library        String
 
 *** Variables ***
 ${PORT}        5001
 ${SERVER}      http://localhost:${PORT}
-${BROWSER}     Firefox
 ${SERVER LOG}  ${OUTPUT DIR}/server.log
 ${DELAY}       0
 ${ROOT URL}    ${SERVER}/select/
 
 *** Keywords ***
+Detect And Open Browser
+    [Arguments]  ${url}
+
+    ${browser} =  Get Environment Variable  BROWSER  default=chrome
+    Open Browser  ${url}  browser=${BROWSER}
+
 Start Test Server
     Start Process  bash -c "source env.sh && TEST_MODE\=on fab serve:port\=${PORT}"  shell=yes  stdout=${SERVER LOG}  stderr=${SERVER LOG}  alias=test_server
     Sleep  3s
@@ -22,7 +28,7 @@ Stop Test Server
     Close Browser
 
 Open Browser To Authoring Tool
-    Open Browser  ${SERVER}/select/
+    Detect And Open Browser  ${SERVER}/select/
     Maximize Browser Window
     Set Selenium Speed  ${DELAY}
     Authoring Tool Should Be Open

--- a/robot_tests/resource.robot
+++ b/robot_tests/resource.robot
@@ -59,20 +59,27 @@ StoryMap Should Exist
     [Arguments]  ${name}
     Element Should Contain  css=#entry_modal .modal-body  ${name}
 
+StoryMap Should Exist ID
+    [Arguments]  ${id}
+    Page Should Contain Element  css=tr[storymap-data="${id}"]
+
 StoryMap Should Not Exist
     [Arguments]  ${name}
     Element Should Not Contain  css=#entry_modal .modal-body  ${name}
 
+StoryMap Should Not Exist ID
+    [Arguments]  ${id}
+    Page Should Not Contain Element  css=tr[storymap-data="${id}"]
+
 Delete StoryMap
-    [Arguments]  ${name}
-    StoryMap Should Exist  ${name}
-    ${id} =  Convert To Lowercase  ${name}
+    [Arguments]  ${id}
+    StoryMap Should Exist ID  ${id}
     Click Link  css=tr[storymap-data="${id}"] td div div a
     #use jquery to click the delete button incase it's off the bottom of the screen
     Execute Javascript  $(".dropdown.open a.list-item-delete").click()
     Click Button  css=.modal-confirm button.btn-primary
     Sleep  2sec
-    StoryMap Should Not Exist  ${name}
+    StoryMap Should Not Exist ID  ${id}
 
 Rename StoryMap
     [Arguments]  ${oldName}  ${newName}

--- a/robot_tests/resource.robot
+++ b/robot_tests/resource.robot
@@ -13,15 +13,17 @@ ${DELAY}       0
 ${ROOT URL}    ${SERVER}/select/
 
 *** Keywords ***
-Detect And Open Browser
-    [Arguments]  ${url}
-
+Open Browser To Homepage
     ${browser} =  Get Environment Variable  BROWSER  default=chrome
-    Open Browser  ${url}  browser=${BROWSER}
+    Open Browser  ${SERVER}  browser=${browser}
+
+Go To Authoring Tool
+    Go To  ${SERVER}/select/
 
 Start Test Server
     Start Process  bash -c "source env.sh && TEST_MODE\=on fab serve:port\=${PORT}"  shell=yes  stdout=${SERVER LOG}  stderr=${SERVER LOG}  alias=test_server
     Sleep  3s
+    Open Browser To Homepage
 
 Stop Test Server
     Terminate Process  test_server

--- a/robot_tests/storymaps.robot
+++ b/robot_tests/storymaps.robot
@@ -1,23 +1,23 @@
 *** Settings ***
 Documentation   Suite of tests for creating, updating and deleting new storymaps.
 Suite Setup     Start Test Server
-Suite Teardown  Run Keywords  Stop Test Server  Close All Browsers
+Suite Teardown  Stop Test Server
 Resource        resource.robot
 
 *** Test Cases ***
 Create StoryMap
-    Open Browser To Authoring Tool
+    Go To Authoring Tool
     Create StoryMap  Test
 
 Delete StoryMap
-    Open Browser To Authoring Tool
+    Go To Authoring Tool
     Wait Until Loaded
     Delete StoryMap  test
     StoryMap Should Not Exist  Test
     StoryMap Should Not Exist ID  test
 
 Create And Delete Multiple StoryMaps
-    Open Browser To Authoring Tool
+    Go To Authoring Tool
     Create StoryMap  Test1
     Create Another StoryMap  Test2
     Create Another StoryMap  SomeOtherVeryDifferentName
@@ -34,7 +34,7 @@ Create And Delete Multiple StoryMaps
     StoryMap Should Not Exist  SomeOtherVeryDifferentName
 
 Rename A StoryMap
-    Open Browser To Authoring Tool
+    Go To Authoring Tool
     Create StoryMap  Test1
     StoryMap Should Exist  Test1
     Rename StoryMap  Test1  Test2
@@ -44,7 +44,7 @@ Rename A StoryMap
     Delete StoryMap  test1
 
 Copy A StoryMap
-    Open Browser To Authoring Tool
+    Go To Authoring Tool
     Create StoryMap  Test1
     StoryMap Should Exist  Test1
     Copy StoryMap  Test1  Test2

--- a/robot_tests/storymaps.robot
+++ b/robot_tests/storymaps.robot
@@ -12,7 +12,9 @@ Create StoryMap
 Delete StoryMap
     Open Browser To Authoring Tool
     Wait Until Loaded
-    Delete StoryMap  Test
+    Delete StoryMap  test
+    StoryMap Should Not Exist  Test
+    StoryMap Should Not Exist ID  test
 
 Create And Delete Multiple StoryMaps
     Open Browser To Authoring Tool
@@ -21,12 +23,12 @@ Create And Delete Multiple StoryMaps
     Create Another StoryMap  SomeOtherVeryDifferentName
     Go To  ${SERVER}/select
     Sleep  2sec
-    Delete StoryMap  Test2
+    Delete StoryMap  test2
     StoryMap Should Exist  Test1
     StoryMap Should Exist  SomeOtherVeryDifferentName
-    Delete StoryMap  SomeOtherVeryDifferentName
+    Delete StoryMap  someotherverydifferentname
     StoryMap Should Exist  Test1
-    Delete StoryMap  Test1
+    Delete StoryMap  test1
     StoryMap Should Not Exist  Test1
     StoryMap Should Not Exist  Test2
     StoryMap Should Not Exist  SomeOtherVeryDifferentName
@@ -38,6 +40,8 @@ Rename A StoryMap
     Rename StoryMap  Test1  Test2
     StoryMap Should Not Exist  Test1
     StoryMap Should Exist  Test2
+    #The ID doesn't change when we rename
+    Delete StoryMap  test1
 
 Copy A StoryMap
     Open Browser To Authoring Tool
@@ -46,3 +50,5 @@ Copy A StoryMap
     Copy StoryMap  Test1  Test2
     StoryMap Should Exist  Test1
     StoryMap Should Exist  Test2
+    Delete StoryMap  test1
+    Delete StoryMap  test2


### PR DESCRIPTION
All the quality-of-life stuff that wasn't in the first pull request.

* You can now run tests with `fab test`. You can also specify Robot arguments as part of the task, e.g. `fab test:-t,"Create StoryMap"` will run a single test. (Not at all elegant, but it works)
* When tests are run with that command, the output directory is set to `robot_tests/logs`, which is gitignored.
* You can specify the browser as an environment variable; it currently defaults to Chrome (not sure if that's a good idea?) but you can override it like: `BROWSER=firefox fab test`