### PR TITLE
Media pause

### DIFF
--- a/source/js/media/types/VCO.Media.DailyMotion.js
+++ b/source/js/media/types/VCO.Media.DailyMotion.js
@@ -2,41 +2,46 @@
 ================================================== */
 
 VCO.Media.DailyMotion = VCO.Media.extend({
-	
+
 	includes: [VCO.Events],
-	
+
 	/*	Load the media
 	================================================== */
 	_loadMedia: function() {
 		var api_url,
 			self = this;
-		
+
 		// Loading Message
 		this.message.updateMessage(VCO.Language.messages.loading + " " + this.options.media_name);
-		
+
 		// Create Dom element
 		this._el.content_item	= VCO.Dom.create("div", "vco-media-item vco-media-iframe vco-media-dailymotion", this._el.content);
-		
+
 		// Get Media ID
 		if (this.data.url.match("video")) {
 			this.media_id = this.data.url.split("video\/")[1].split(/[?&]/)[0];
 		} else {
 			this.media_id = this.data.url.split("embed\/")[1].split(/[?&]/)[0];
 		}
-		
+
 		// API URL
-		api_url = "https://www.dailymotion.com/embed/video/" + this.media_id;
-		
+		api_url = "https://www.dailymotion.com/embed/video/" + this.media_id+"?api=postMessage";
+
 		// API Call
-		this._el.content_item.innerHTML = "<iframe autostart='false' frameborder='0' width='100%' height='100%' src='" + api_url + "'></iframe>"		
-		
+		this._el.content_item.innerHTML = "<iframe autostart='false' frameborder='0' width='100%' height='100%' src='" + api_url + "'></iframe>"
+
 		// After Loaded
 		this.onLoaded();
 	},
-	
+
 	// Update Media Display
 	_updateMediaDisplay: function() {
 		this._el.content_item.style.height = VCO.Util.ratio.r16_9({w:this._el.content_item.offsetWidth}) + "px";
+	},
+
+	_stopMedia: function() {
+		this._el.content_item.querySelector("iframe").contentWindow.postMessage('{"command":"pause","parameters":[]}', "*");
 	}
-	
+
+
 });

--- a/source/js/media/types/VCO.Media.SoundCloud.js
+++ b/source/js/media/types/VCO.Media.SoundCloud.js
@@ -1,40 +1,58 @@
 /*	VCO.Media.SoundCloud
 ================================================== */
 
+var soundCoudCreated = false;
+
+
 VCO.Media.SoundCloud = VCO.Media.extend({
-	
+
 	includes: [VCO.Events],
-	
+
 	/*	Load the media
 	================================================== */
 	_loadMedia: function() {
 		var api_url,
 			self = this;
-		
+
 		// Loading Message
 		this.message.updateMessage(VCO.Language.messages.loading + " " + this.options.media_name);
-		
+
 		// Create Dom element
 		this._el.content_item	= VCO.Dom.create("div", "vco-media-item vco-media-iframe vco-media-soundcloud vco-media-shadow", this._el.content);
-		
+
 		// Get Media ID
 		this.media_id = this.data.url;
-		
+
 		// API URL
 		api_url = "https://soundcloud.com/oembed?url=" + this.media_id + "&format=js&callback=?"
-		
+
 		// API Call
 		VCO.getJSON(api_url, function(d) {
-			self.createMedia(d);
+			TL.Load.js("https://w.soundcloud.com/player/api.js", function() {//load soundcloud api for pausing.
+ 				self.createMedia(d);
+ 			});
 		});
-		
+
 	},
-	
+
 	createMedia: function(d) {
 		this._el.content_item.innerHTML = d.html;
-		
+
+		this.soundCloudCreated = true;
+
+ 		self.widget = SC.Widget(this._el.content_item.querySelector("iframe"));//create widget for api use
+
 		// After Loaded
 		this.onLoaded();
+
+	},
+
+	 	_stopMedia: function() {
+	 		if (this.soundCloudCreated)
+	 		{
+	 			self.widget.pause();
+	 		}
+
 	}
-	
+
 });

--- a/source/js/media/types/VCO.Media.SoundCloud.js
+++ b/source/js/media/types/VCO.Media.SoundCloud.js
@@ -28,7 +28,7 @@ VCO.Media.SoundCloud = VCO.Media.extend({
 
 		// API Call
 		VCO.getJSON(api_url, function(d) {
-			TL.Load.js("https://w.soundcloud.com/player/api.js", function() {//load soundcloud api for pausing.
+			VCO.Load.js("https://w.soundcloud.com/player/api.js", function() {//load soundcloud api for pausing.
  				self.createMedia(d);
  			});
 		});

--- a/source/js/media/types/VCO.Media.Vimeo.js
+++ b/source/js/media/types/VCO.Media.Vimeo.js
@@ -2,52 +2,52 @@
 ================================================== */
 
 VCO.Media.Vimeo = VCO.Media.extend({
-	
+
 	includes: [VCO.Events],
-	
+
 	/*	Load the media
 	================================================== */
 	_loadMedia: function() {
 		var api_url,
 			self = this;
-		
+
 		// Loading Message
 		this.message.updateMessage(VCO.Language.messages.loading + " " + this.options.media_name);
-		
+
 		// Create Dom element
 		this._el.content_item	= VCO.Dom.create("div", "vco-media-item vco-media-iframe vco-media-vimeo vco-media-shadow", this._el.content);
-		
+
 		// Get Media ID
 		this.media_id = this.data.url.split(/video\/|\/\/vimeo\.com\//)[1].split(/[?&]/)[0];
-		
+
 		// API URL
 		api_url = "https://player.vimeo.com/video/" + this.media_id + "?api=1&title=0&amp;byline=0&amp;portrait=0&amp;color=ffffff";
-		
+
 		this.player = VCO.Dom.create("iframe", "", this._el.content_item);
 		this.player.width 		= "100%";
 		this.player.height 		= "100%";
 		this.player.frameBorder = "0";
 		this.player.src 		= api_url;
-		
+
 		// After Loaded
 		this.onLoaded();
 	},
-	
+
 	// Update Media Display
 	_updateMediaDisplay: function() {
 		this._el.content_item.style.height = VCO.Util.ratio.r16_9({w:this._el.content_item.offsetWidth}) + "px";
-		
+
 	},
-	
+
 	_stopMedia: function() {
-		
+
 		try {
 			this.player.contentWindow.postMessage(JSON.stringify({method: "pause"}), "https://player.vimeo.com");
 		}
 		catch(err) {
 			trace(err);
 		}
-		
+
 	}
-	
+
 });

--- a/source/js/media/types/VCO.Media.Vine.js
+++ b/source/js/media/types/VCO.Media.Vine.js
@@ -3,38 +3,42 @@
 ================================================== */
 
 VCO.Media.Vine = VCO.Media.extend({
-	
+
 	includes: [VCO.Events],
-	
+
 	/*	Load the media
 	================================================== */
 	_loadMedia: function() {
 		var api_url,
 			self = this;
-		
+
 		// Loading Message
 		this.message.updateMessage(VCO.Language.messages.loading + " " + this.options.media_name);
-		
+
 		// Create Dom element
 		this._el.content_item	= VCO.Dom.create("div", "vco-media-item vco-media-iframe vco-media-vine vco-media-shadow", this._el.content);
-		
+
 		// Get Media ID
 		this.media_id = this.data.url.split("vine.co/v/")[1];
-		
+
 		// API URL
 		api_url = "https://vine.co/v/" + this.media_id + "/embed/simple";
-		
+
 		// API Call
-		this._el.content_item.innerHTML = "<iframe frameborder='0' width='100%' height='100%' src='" + api_url + "'></iframe><script async src='https://platform.vine.co/static/scripts/embed.js' charset='utf-8'></script>"		
-		
+		this._el.content_item.innerHTML = "<iframe frameborder='0' width='100%' height='100%' src='" + api_url + "'></iframe><script async src='https://platform.vine.co/static/scripts/embed.js' charset='utf-8'></script>"
+
 		// After Loaded
 		this.onLoaded();
 	},
-	
+
 	// Update Media Display
 	_updateMediaDisplay: function() {
 		var size = VCO.Util.ratio.square({w:this._el.content_item.offsetWidth , h:this.options.height});
 		this._el.content_item.style.height = size.h + "px";
+	},
+
+	 	_stopMedia: function() {
+	 		this._el.content_item.querySelector("iframe").contentWindow.postMessage('pause', '*');
 	}
-	
+
 });


### PR DESCRIPTION
A fix for issue #261 cloned over from our timeline fix (https://github.com/NUKnightLab/TimelineJS3/pull/400), includes the other fixes for vines and soundcloud too.

Vimeo seems to have been shoved in here too for some reason, it's not been changed but my editor has removed all the trailing whitespace. If this is a problem please let me know.