### PR TITLE
Allow adding custom map markers in the authoring tool

### DIFF
--- a/robot_tests/resource.robot
+++ b/robot_tests/resource.robot
@@ -29,10 +29,6 @@ Stop Test Server
     Terminate Process  test_server
     Close Browser
 
-Go To Authoring Tool
-    Go To  ${SERVER}/select/
-
-
 Open Browser To Authoring Tool
     Detect And Open Browser  ${SERVER}/select/
     Maximize Browser Window

--- a/robot_tests/resource.robot
+++ b/robot_tests/resource.robot
@@ -1,6 +1,6 @@
 *** Settings ***
 Documentation  Reusable keywords and variables for the StoryMap server.
-Library        Selenium2Library  timeout=5  implicit_wait=30
+Library        Selenium2Library  timeout=5  implicit_wait=5
 Library        OperatingSystem
 Library        Process
 Library        String
@@ -28,6 +28,10 @@ Start Test Server
 Stop Test Server
     Terminate Process  test_server
     Close Browser
+
+Go To Authoring Tool
+    Go To  ${SERVER}/select/
+
 
 Open Browser To Authoring Tool
     Detect And Open Browser  ${SERVER}/select/
@@ -114,3 +118,30 @@ Copy StoryMap
 
 Wait Until Loaded
     Wait Until Element Is Not Visible  css=.icon-spinner
+
+Edit StoryMap
+    [Arguments]  ${name}
+    ${id} =  Convert To Lowercase  ${name}
+    Click Link  css=tr[storymap-data="${id}"] td a.title
+    Edit StoryMap Fields  ${name}  Test title slide
+
+Edit StoryMap Fields
+    [Arguments]  ${headline}  ${body}
+    Wait Until Loaded
+    Input Text  css=#headline  ${headline}
+    Select Frame  css=#edit iframe
+    Input Text  css=.wysihtml5-editor  ${body}
+    Unselect Frame
+Apply Custom Map Marker
+    [Arguments]  ${marker}
+    Click Element  css=#marker_options
+    Sleep  2sec
+    Input Text  css=#marker_url  ${marker}
+    Click Element  css=#marker_options_close
+    Sleep  2sec
+    Element Should Be Visible  css=img.leaflet-marker-icon
+    ${img_src}=  Get Element Attribute  css=img.leaflet-marker-icon@src
+    Should Be Equal As Strings  ${marker}  ${img_src}
+
+Create New StoryMap Slide
+    Click Element  css=div#storymap_add_slide.slides-add

--- a/robot_tests/storymaps.robot
+++ b/robot_tests/storymaps.robot
@@ -54,7 +54,7 @@ Copy A StoryMap
     Delete StoryMap  test2
 
 Use Custom Map Marker
-    Open Browser To Authoring Tool
+    Go To Authoring Tool
     Create StoryMap  Test
     StoryMap Should Exist  Test
     Edit StoryMap  Test

--- a/robot_tests/storymaps.robot
+++ b/robot_tests/storymaps.robot
@@ -52,3 +52,14 @@ Copy A StoryMap
     StoryMap Should Exist  Test2
     Delete StoryMap  test1
     Delete StoryMap  test2
+
+Use Custom Map Marker
+    Open Browser To Authoring Tool
+    Create StoryMap  Test
+    StoryMap Should Exist  Test
+    Edit StoryMap  Test
+    Create New StoryMap Slide
+    Apply Custom Map Marker  https://maps.gstatic.com/intl/en_us/mapfiles/ms/micons/blue-pushpin.png
+    Go To  ${SERVER}/select
+    Confirm Action
+    Delete StoryMap  test

--- a/source/js/VCO.StoryMap.js
+++ b/source/js/VCO.StoryMap.js
@@ -339,7 +339,6 @@ VCO.StoryMap = VCO.Class.extend({
 			map_popup: 				false,
 			zoom_distance: 			100,
 			calculate_zoom: 		true,   		// Allow map to determine best zoom level between markers (recommended)
-			use_custom_markers: 	false,  		// Allow use of custom map marker icons
 			line_follows_path: 		true,   		// Map history path follows default line, if false it will connect previous and current only
 			line_color: 			"#c34528", //"#DA0000",
 			line_color_inactive: 	"#CCC",

--- a/source/js/map/VCO.Map.js
+++ b/source/js/map/VCO.Map.js
@@ -107,7 +107,6 @@ VCO.Map = VCO.Class.extend({
 			line_join: 			"miter",
 			show_lines: 		true,
 			show_history_line: 	true,
-			use_custom_markers: false,
 			map_center_offset:  null // takes object {top:0,left:0}
 		};
 		

--- a/source/js/map/VCO.MapMarker.js
+++ b/source/js/map/VCO.MapMarker.js
@@ -46,8 +46,7 @@ VCO.MapMarker = VCO.Class.extend({
 			ease: 				VCO.Ease.easeInSpline,
 			width: 				600,
 			height: 			600,
-			map_popup: 			false,
-			use_custom_markers: false
+			map_popup: 			false
 		};
 		
 		

--- a/source/js/map/leaflet/VCO.MapMarker.Leaflet.js
+++ b/source/js/map/leaflet/VCO.MapMarker.Leaflet.js
@@ -14,17 +14,18 @@ VCO.MapMarker.Leaflet = VCO.MapMarker.extend({
 		if (d.location && d.location.lat && d.location.lon) {
 			this.data.real_marker = true;
 			var use_custom_marker = o.use_custom_markers || d.location.use_custom_marker;
-			if (use_custom_marker && d.location.icon && d.location.icon != "") {
-				this._custom_icon = true;
-				this._custom_icon_url = d.location.icon;
-				this._icon = new L.icon({iconUrl: this._custom_icon_url, iconSize: [48], iconAnchor:[24, 48]});
-			
-			} else if (use_custom_marker && d.location.image && d.location.image != "") {
-				this._custom_image_icon = true;
-				this._custom_icon_url = d.location.image;
-				this._icon = new L.icon({iconUrl: this._custom_icon_url, iconSize: [48], iconAnchor:[24, 48], shadowSize: [68, 95], shadowAnchor: [22, 94], className:"vco-mapmarker-image-icon"});
+			if (use_custom_marker && d.location.icon) {
+				this._custom_icon = {
+					url: d.location.icon,
+					size: d.location.iconSize || [48,48],
+					anchor: this._customIconAnchor(d.location.iconSize)
+				};
+				this._icon = this._createIcon();
+			} else if (use_custom_marker && d.location.image) {
+				this._custom_image_icon = d.location.image;
+				this._icon = this._createImage();
 			} else {
-				this._icon = new L.divIcon({className: 'vco-mapmarker ' + this.media_icon_class, iconAnchor:[10, 10]});
+				this._icon = this._createDefaultIcon(false);
 			}
 			
 			this._marker = new L.marker([d.location.lat, d.location.lon], {
@@ -62,34 +63,46 @@ VCO.MapMarker.Leaflet = VCO.MapMarker.extend({
 		} else {
 			this.media_icon_class = "vco-mapmarker-icon vco-icon-plaintext";
 		}
-		
 		if (this.data.real_marker) {
 			if (a) {
 				this._marker.setZIndexOffset(100);
-				if (this._custom_icon) {
-					this._icon = new L.icon({iconUrl: this._custom_icon_url, iconSize: [48], iconAnchor:[24, 48]});
-				} else if (this._custom_image_icon) {
-					this._icon = new L.icon({iconUrl: this._custom_icon_url, iconSize: [48], iconAnchor:[24, 48], shadowSize: [68, 95], shadowAnchor: [22, 94], className:"vco-mapmarker-image-icon-active"});
-				} else {
-					this._icon = new L.divIcon({className: 'vco-mapmarker-active ' + this.media_icon_class, iconAnchor:[10, 10]});
-				}
-				
 				//this.timer = setTimeout(function() {self._openPopup();}, this.options.duration + 200);
-				this._setIcon();
 			} else {
-				//this._marker.closePopup();
 				clearTimeout(this.timer);
 				this._marker.setZIndexOffset(0);
-				if (this._custom_icon) {
-					this._icon = new L.icon({iconUrl: this._custom_icon_url, iconSize: [48], iconAnchor:[24, 48]});
-				} else if (this._custom_image_icon) {
-					this._icon = new L.icon({iconUrl: this._custom_icon_url, iconSize: [48], iconAnchor:[24, 48], shadowSize: [68, 95], shadowAnchor: [22, 94], className:"vco-mapmarker-image-icon"});
-				} else {
-					this._icon = new L.divIcon({className: 'vco-mapmarker ' + this.media_icon_class, iconAnchor:[10, 10]});
-				}
-				
-				this._setIcon();
 			}
+			//this._marker.closePopup();
+			if (this._custom_icon) {
+				this._icon = this._createIcon();
+			} else if (this._custom_image_icon) {
+				this._icon = this._createImage(a);
+			} else {
+				this._icon = this._createDefaultIcon (a);
+			}
+
+			this._setIcon();
+		}
+	},
+
+	_createIcon: function() {
+		return new L.icon({iconUrl: this._custom_icon.url, iconSize: this._custom_icon.size, iconAnchor: this._custom_icon.anchor});
+	},
+
+	_createImage: function(active) { // TODO: calculate shadow dimensions
+		var className = active ? "vco-mapmarker-image-icon-active" : "vco-mapmarker-image-icon";
+		return new L.icon({iconUrl: url, iconSize: [48], iconAnchor:[24, 48], shadowSize: [68, 95], shadowAnchor: [22, 94], className: className});
+	},
+
+	_createDefaultIcon: function(active) {
+		var className = active ? "vco-mapmarker-active" : "vco-mapmarker";
+		return L.divIcon({className: className + " " + this.media_icon_class, iconAnchor:[10, 10]});
+	},
+
+	_customIconAnchor: function(size) {
+		if (size) {
+			return [ size[0] * 0.5, size[1] ];
+		} else {
+			return [ 24, 48 ];
 		}
 	},
 	

--- a/source/js/map/leaflet/VCO.MapMarker.Leaflet.js
+++ b/source/js/map/leaflet/VCO.MapMarker.Leaflet.js
@@ -13,12 +13,13 @@ VCO.MapMarker.Leaflet = VCO.MapMarker.extend({
 		
 		if (d.location && d.location.lat && d.location.lon) {
 			this.data.real_marker = true;
-			if (d.location.icon && d.location.icon != "") {
+			var use_custom_marker = o.use_custom_markers || d.location.use_custom_marker;
+			if (use_custom_marker && d.location.icon && d.location.icon != "") {
 				this._custom_icon = true;
 				this._custom_icon_url = d.location.icon;
 				this._icon = new L.icon({iconUrl: this._custom_icon_url, iconSize: [48], iconAnchor:[24, 48]});
 			
-			} else if (d.location.image && d.location.image != "") {
+			} else if (use_custom_marker && d.location.image && d.location.image != "") {
 				this._custom_image_icon = true;
 				this._custom_icon_url = d.location.image;
 				this._icon = new L.icon({iconUrl: this._custom_icon_url, iconSize: [48], iconAnchor:[24, 48], shadowSize: [68, 95], shadowAnchor: [22, 94], className:"vco-mapmarker-image-icon"});

--- a/source/js/map/leaflet/VCO.MapMarker.Leaflet.js
+++ b/source/js/map/leaflet/VCO.MapMarker.Leaflet.js
@@ -13,12 +13,12 @@ VCO.MapMarker.Leaflet = VCO.MapMarker.extend({
 		
 		if (d.location && d.location.lat && d.location.lon) {
 			this.data.real_marker = true;
-			if (o.use_custom_markers && d.location.icon && d.location.icon != "") {
+			if (d.location.icon && d.location.icon != "") {
 				this._custom_icon = true;
 				this._custom_icon_url = d.location.icon;
 				this._icon = new L.icon({iconUrl: this._custom_icon_url, iconSize: [48], iconAnchor:[24, 48]});
 			
-			} else if (o.use_custom_markers && d.location.image && d.location.image != "") {
+			} else if (d.location.image && d.location.image != "") {
 				this._custom_image_icon = true;
 				this._custom_icon_url = d.location.image;
 				this._icon = new L.icon({iconUrl: this._custom_icon_url, iconSize: [48], iconAnchor:[24, 48], shadowSize: [68, 95], shadowAnchor: [22, 94], className:"vco-mapmarker-image-icon"});
@@ -65,7 +65,9 @@ VCO.MapMarker.Leaflet = VCO.MapMarker.extend({
 		if (this.data.real_marker) {
 			if (a) {
 				this._marker.setZIndexOffset(100);
-				if (this._custom_image_icon) {
+				if (this._custom_icon) {
+					this._icon = new L.icon({iconUrl: this._custom_icon_url, iconSize: [48], iconAnchor:[24, 48]});
+				} else if (this._custom_image_icon) {
 					this._icon = new L.icon({iconUrl: this._custom_icon_url, iconSize: [48], iconAnchor:[24, 48], shadowSize: [68, 95], shadowAnchor: [22, 94], className:"vco-mapmarker-image-icon-active"});
 				} else {
 					this._icon = new L.divIcon({className: 'vco-mapmarker-active ' + this.media_icon_class, iconAnchor:[10, 10]});
@@ -77,7 +79,9 @@ VCO.MapMarker.Leaflet = VCO.MapMarker.extend({
 				//this._marker.closePopup();
 				clearTimeout(this.timer);
 				this._marker.setZIndexOffset(0);
-				if (this._custom_image_icon) {
+				if (this._custom_icon) {
+					this._icon = new L.icon({iconUrl: this._custom_icon_url, iconSize: [48], iconAnchor:[24, 48]});
+				} else if (this._custom_image_icon) {
 					this._icon = new L.icon({iconUrl: this._custom_icon_url, iconSize: [48], iconAnchor:[24, 48], shadowSize: [68, 95], shadowAnchor: [22, 94], className:"vco-mapmarker-image-icon"});
 				} else {
 					this._icon = new L.divIcon({className: 'vco-mapmarker ' + this.media_icon_class, iconAnchor:[10, 10]});

--- a/static/css/editor.css
+++ b/static/css/editor.css
@@ -221,6 +221,10 @@ input[type="radio"] {margin: 0;}
     height: 32px;
 }
 
+#marker_url {
+	margin-right:10px;
+}
+
 .minicolors-theme-bootstrap .minicolors-swatch {width: 24px;height: 24px;}
 #share_modal label {
 	font-weight:bold;

--- a/static/css/editor.css
+++ b/static/css/editor.css
@@ -763,7 +763,6 @@ a.list-item-options:hover {
 */
 #map-div {position: absolute;top: 0;left: 0;bottom: 312px;right: 0;border-bottom: 1px solid #CCC;}
 #map {width: 100%;height: 100%;}
-#map * {font-family: Roboto,Arial,sans-serif;}
 #map img{max-width:none}
 
 #map_overlay {position: absolute;left: 0;top: 0;width: 100%;height: 100%;}

--- a/static/css/editor.css
+++ b/static/css/editor.css
@@ -903,7 +903,7 @@ label, .data-media-upload {
 	margin-bottom: 24px;
 }
 
-.data-right button {margin-bottom: 10px;}
+.data-right button {margin-bottom: 10px; margin-left: 5px;}
 
 /* font-face, font-size, line-height, etc should be set in font-specific css */
 #headline {color: #000;margin-bottom: 11px;height: auto;}

--- a/static/js/EditorMap.js
+++ b/static/js/EditorMap.js
@@ -140,13 +140,20 @@ LeafletEditorMap.prototype.removePolyLine = function() {
     }
 }
 
-LeafletEditorMap.prototype.addMarker = function(lat, lng, draggable, customIcon) {
-    var latlng = L.latLng(lat, lng);
+LeafletEditorMap.prototype.addMarker = function(data, draggable) {
+    var latlng = L.latLng(data.location.lat, data.location.lon);
 
-    if (customIcon) {
-      var icon = L.icon({iconUrl: customIcon, iconSize: [48], iconAnchor:[24, 48]});
+    if (data.location.icon) {
+      var icon = L.icon({iconUrl: data.location.icon, iconSize: [48], iconAnchor:[24, 48]});
     } else {
-      var icon = L.divIcon({className: 'vco-mapmarker', iconAnchor:[10, 10]});
+      var media = VCO.MediaType({url: data.media.url});
+      if (media.type) {
+        var iconClass = "vco-mapmarker-icon vco-icon-" + media.type;
+      } else {
+        var iconClass = "vco-mapmarker-icon vco-icon-plaintext";
+      }
+
+      var icon = L.divIcon({className: 'vco-mapmarker ' + iconClass, iconAnchor:[10, 10]});
     }
 
     var marker = L.marker(latlng, {

--- a/static/js/EditorMap.js
+++ b/static/js/EditorMap.js
@@ -140,9 +140,19 @@ LeafletEditorMap.prototype.removePolyLine = function() {
     }
 }
 
-LeafletEditorMap.prototype.addMarker = function(lat, lng, draggable) {
+LeafletEditorMap.prototype.addMarker = function(lat, lng, draggable, customIcon) {
     var latlng = L.latLng(lat, lng);
-    var marker = L.marker(latlng, {draggable: (draggable || false)})
+
+    if (customIcon) {
+      var icon = L.icon({iconUrl: customIcon, iconSize: [48], iconAnchor:[24, 48]});
+    } else {
+      var icon = L.divIcon({className: 'vco-mapmarker', iconAnchor:[10, 10]});
+    }
+
+    var marker = L.marker(latlng, {
+      icon: icon,
+      draggable: (draggable || false)
+    });
     marker.addTo(this.map);
 
     if(draggable) {

--- a/static/js/EditorMap.js
+++ b/static/js/EditorMap.js
@@ -144,7 +144,8 @@ LeafletEditorMap.prototype.addMarker = function(data, draggable) {
     var latlng = L.latLng(data.location.lat, data.location.lon);
 
     if (data.location.icon) {
-      var icon = L.icon({iconUrl: data.location.icon, iconSize: [48], iconAnchor:[24, 48]});
+      var anchor = data.location.iconSize ? [data.location.iconSize[0] * 0.5, data.location.iconSize[1]] : [24,48] ;
+      var icon = L.icon({iconUrl: data.location.icon, iconSize: data.location.iconSize || [48,48], iconAnchor: anchor});
     } else {
       var media = VCO.MediaType({url: data.media.url});
       if (media.type) {

--- a/templates/_editor.html
+++ b/templates/_editor.html
@@ -91,6 +91,7 @@
                 <div class="data-section">
                     <input id="headline" type="text" placeholder="Headline" class="editor-headline">
                     <textarea id="text" rows="5"></textarea>
+                    <button id="marker_options" class="btn" href="#marker_opt_modal" data-toggle="modal" style="margin-right: 3px;"> Marker Options</button>
                     <button id="slide_options" class="btn" href="#slide_opt_modal" data-toggle="modal"><i class="icon-cog icon-medium"></i> Slide Options</button>
                </div>
             </div>

--- a/templates/_editor.html
+++ b/templates/_editor.html
@@ -91,7 +91,7 @@
                 <div class="data-section">
                     <input id="headline" type="text" placeholder="Headline" class="editor-headline">
                     <textarea id="text" rows="5"></textarea>
-                    <button id="marker_options" class="btn" href="#marker_opt_modal" data-toggle="modal" style="margin-right: 3px;"> Marker Options</button>
+                    <button id="marker_options" class="btn" href="#marker_opt_modal" data-toggle="modal" style="margin-right: 3px;"><i class="icon-map-marker icon-medium"></i> Marker Options</button>
                     <button id="background_options" class="btn" href="#background_opt_modal" data-toggle="modal"><i class="icon-cog icon-medium"></i> Background Options</button>
                </div>
             </div>

--- a/templates/_editor.html
+++ b/templates/_editor.html
@@ -91,7 +91,7 @@
                 <div class="data-section">
                     <input id="headline" type="text" placeholder="Headline" class="editor-headline">
                     <textarea id="text" rows="5"></textarea>
-                    <button id="marker_options" class="btn" href="#marker_opt_modal" data-toggle="modal" style="margin-right: 3px;"><i class="icon-map-marker icon-medium"></i> Marker Options</button>
+                    <button id="marker_options" class="btn" href="#marker_opt_modal" data-toggle="modal"><i class="icon-map-marker icon-medium"></i> Marker Options</button>
                     <button id="background_options" class="btn" href="#background_opt_modal" data-toggle="modal"><i class="icon-cog icon-medium"></i> Background Options</button>
                </div>
             </div>

--- a/templates/_editor.html
+++ b/templates/_editor.html
@@ -45,7 +45,7 @@
     <div class="tab-content">
         <div class="tab-pane active" id="edit">
             <div id="map-div">
-                <div id="map"></div>
+                <div id="map" class="vco-map"></div>
                 <svg id="map_overlay" xmlns="http://www.w3.org/2000/svg" version="1.1">
                     <polyline points="" />
                 </svg>

--- a/templates/_editor.html
+++ b/templates/_editor.html
@@ -92,7 +92,7 @@
                     <input id="headline" type="text" placeholder="Headline" class="editor-headline">
                     <textarea id="text" rows="5"></textarea>
                     <button id="marker_options" class="btn" href="#marker_opt_modal" data-toggle="modal" style="margin-right: 3px;"> Marker Options</button>
-                    <button id="slide_options" class="btn" href="#slide_opt_modal" data-toggle="modal"><i class="icon-cog icon-medium"></i> Slide Options</button>
+                    <button id="background_options" class="btn" href="#background_opt_modal" data-toggle="modal"><i class="icon-cog icon-medium"></i> Background Options</button>
                </div>
             </div>
 

--- a/templates/_modals.html
+++ b/templates/_modals.html
@@ -353,6 +353,55 @@
             </div>
         </div>
     </div>
+</div>
+
+<!-- Markers //-->
+<div id="marker_opt_modal" class="modal hide fade" data-backdrop="static">
+    <div class="modal-header">
+        <h4>Map Markers</h4>
+    </div>
+    <div class="modal-body">
+        <!-- error -->
+        <div class="modal-error hide">
+            <span class="modal-msg error"></span>
+        </div>
+        <div class="input-prepend" style="width: 96%;">
+            <div class="btn-group">
+                <button class="btn dropdown-toggle" data-toggle="dropdown">
+                    <span class="caret"></span>
+                </button>
+                <ul id="marker_image_select" class="image-select dropdown-menu">
+                    <li><a href="javascript:">image 1</a></li>
+                    <li><a href="javascript:">image 2</a></li>
+                    <li><a href="javascript:">image 3</a></li>
+                </ul>
+            </div>
+            <input type="text" id="marker_url" placeholder="<< select an image, or enter an URL">
+        </div>
+        <p>or upload an new marker to your StoryMap folder.</p>
+        <div class="upload-panel">
+            <form class="form-inline">
+                <a class="upload-file-link btn" href="javascript:">
+                Choose File...
+                <input type="file" class="upload-file" accept="image/*" size="40">
+                </a>
+                &nbsp;<label class="upload-file-name"></label>
+                &nbsp;<a href="javascript:" class="btn btn-success upload pull-right">Upload</a>
+            </form>
+        </div>
+        <div class="upload-conflict hide">
+            <p class="error">A file with the same name already exists.</p>
+            <label class="radio upload-conflict-replace">
+            <input type="radio" name="upload_modal_conflict" value="replace">Replace existing file
+            </label>
+            <div>
+                <label class="radio inline upload-conflict-rename">
+                <input type="radio" name="upload_modal_conflict" value="rename">Save file as:
+                <input class="upload-rename-as" type="text" size="40">
+                </label>
+            </div>
+       </div>
+    </div>
     <div class="modal-footer">
         <a href="javascript:;" class="btn btn-primary" data-dismiss="modal">Close</a>
     </div>

--- a/templates/_modals.html
+++ b/templates/_modals.html
@@ -299,10 +299,10 @@
     </div>
 </div>
 
-
-<div id="slide_opt_modal" class="modal hide fade" role="dialog" aria-hidden="true">
+<!-- Editing //-->
+<div id="background_opt_modal" class="modal hide fade" data-backdrop="static">
     <div class="modal-header">
-        <h5>Slide Options</h5>
+        <h4>Slide Background</h4>
     </div>
     <div class="modal-body">
         <!-- error -->

--- a/templates/_modals.html
+++ b/templates/_modals.html
@@ -320,7 +320,7 @@
                 <button class="btn dropdown-toggle" data-toggle="dropdown">
                     <span class="caret"></span>
                 </button>
-                <ul id="background_image_select" class="dropdown-menu">
+                <ul id="background_image_select" class="image-select dropdown-menu">
                     <li><a href="javascript:">image 1</a></li>
                     <li><a href="javascript:">image 2</a></li>
                     <li><a href="javascript:">image 3</a></li>

--- a/templates/_modals.html
+++ b/templates/_modals.html
@@ -365,6 +365,7 @@
         <div class="modal-error hide">
             <span class="modal-msg error"></span>
         </div>
+        <label>Select a custom marker to use on this slide, or reset to use the default.</label>
         <div class="input-prepend" style="width: 96%;">
             <div class="btn-group">
                 <button class="btn dropdown-toggle" data-toggle="dropdown">
@@ -375,8 +376,8 @@
                     <li><a href="javascript:">image 2</a></li>
                     <li><a href="javascript:">image 3</a></li>
                 </ul>
+                <input type="text" class="input-large" id="marker_url" style="margin-right:10px;" placeholder="<< select an image, or enter an URL">
             </div>
-            <input type="text" id="marker_url" placeholder="<< select an image, or enter an URL">
         </div>
         <p>or upload an new marker to your StoryMap folder.</p>
         <div class="upload-panel">

--- a/templates/_modals.html
+++ b/templates/_modals.html
@@ -404,7 +404,7 @@
        </div>
     </div>
     <div class="modal-footer">
-        <a href="javascript:;" class="btn btn-primary" data-dismiss="modal">Close</a>
+        <a id="marker_options_close" href="javascript:;" class="btn btn-primary" data-dismiss="modal">Close</a>
     </div>
     <!-- progress -->
     <div class="modal-progress hide">

--- a/templates/_modals.html
+++ b/templates/_modals.html
@@ -376,7 +376,7 @@
                     <li><a href="javascript:">image 2</a></li>
                     <li><a href="javascript:">image 3</a></li>
                 </ul>
-                <input type="text" class="input-large" id="marker_url" style="margin-right:10px;" placeholder="<< select an image, or enter an URL">
+                <input id="marker_url" type="text" class="input-large" placeholder="<< select an image, or enter an URL">
             </div>
         </div>
         <p>or upload an new marker to your StoryMap folder.</p>

--- a/templates/edit.html
+++ b/templates/edit.html
@@ -179,8 +179,8 @@ function location_set(slide_index, data) {
 function location_mark(data) {
     _map.clearOverlays();
     if(data) {
-        _map.addMarker(data.lat, data.lon, true, data.icon);
-        _map.panTo(data.lat, data.lon);
+        _map.addMarker(data, true);
+        _map.panTo(data.location.lat, data.location.lon);
     }
 }
 
@@ -251,7 +251,7 @@ function slide_select(event) {
                     var loc_data = _slides[i].location;
 
                     if(loc_data.lat && loc_data.lon) {
-                        _map.addMarker(loc_data.lat, loc_data.lon, false, loc_data.icon);
+                        _map.addMarker(_slides[i], false);
                      }
                 }
             }
@@ -277,7 +277,7 @@ function slide_select(event) {
             _map.setView(data.location.lat, data.location.lon, data.location.zoom);
             _map.zoomEnable(true);
 
-            location_mark(data.location);
+            location_mark(data);
         }
 
         $('#url').val(data.media.url);
@@ -502,8 +502,8 @@ function media_preview_update(url) {
 
 var search = function(lat, lng) {
     var data = {lat: lat, lon: lng};
-    location_mark(data);
     location_set(_current_slide_index, data);
+    location_mark(_slides[_current_slide_index]);
     if (_map.getZoom() == 1) {
       _map.setView(lat, lng, 12);
     }
@@ -516,9 +516,8 @@ var _map_options = {
     handlers: {
         double_click: function(lat, lng) {
             var data = {lat: lat, lon: lng};
-            location_mark(data);
             location_set(_current_slide_index, data);
-
+            location_mark(_slides[_current_slide_index]);
         },
         zoom: function(zoom) {
             location_set(_current_slide_index, {zoom: zoom});
@@ -1037,6 +1036,7 @@ $(function() {
         storymap_dirty(1);
 
         slide_set_class(_current_slide_index);
+        location_mark(_slides[_current_slide_index]);
 
         if (id == 'url') {
             media_preview_update(val);
@@ -1254,7 +1254,7 @@ $(function() {
         var old = _slides[_current_slide_index].location.icon;
         _slides[_current_slide_index].location.icon = $(this).val().trim();
         storymap_dirty(1);
-        location_mark(_slides[_current_slide_index].location);
+        location_mark(_slides[_current_slide_index]);
     });
 
     modal_init($('#marker_opt_modal'))

--- a/templates/edit.html
+++ b/templates/edit.html
@@ -1251,10 +1251,25 @@ $(function() {
 // ------------------------------------------------------------
 
     $('#marker_url').change(function(event) {
-        _slides[_current_slide_index].location.use_custom_marker = Boolean($(this).val());
-        _slides[_current_slide_index].location.icon = $(this).val().trim();
-        storymap_dirty(1);
-        location_mark(_slides[_current_slide_index]);
+        var currentSlide = _slides[_current_slide_index];
+        var icon = $(this).val().trim();
+        var img = new Image();
+
+        img.onload = function() {
+            currentSlide.location.use_custom_marker = Boolean(icon);
+            currentSlide.location.icon = icon;
+            currentSlide.location.iconSize = [this.width, this.height];
+            var size = currentSlide.location.iconSize;
+            if (this.width > this.height) {
+                currentSlide.location.iconSize = [48, this.height * 48/this.width ];
+            } else {
+                currentSlide.location.iconSize = [this.width * 48/this.height, 48];
+            }
+            storymap_dirty(1);
+            location_mark(_slides[_current_slide_index]);
+        }
+
+        img.src = icon;
     });
 
     modal_init($('#marker_opt_modal'))

--- a/templates/edit.html
+++ b/templates/edit.html
@@ -1264,9 +1264,10 @@ $(function() {
             $(this).find('.upload-panel').trigger('reset');
         })
         .on('refresh_image_select', function(event) {
-            var html = '';
+            var html = '<li><a href="javascript:">(Default icon)</a></li>';
             for(var i = 0; i < _storymap_files.length; i++) {
-                html += '<li><a href="javascript:">'+_storymap_files[i]+'</a></li>'; // TODO: find a nicer way of trimming these (local doesn't look nice)
+                // TODO: find a nicer way of trimming these (local doesn't look nice)
+                html += '<li><a href="javascript:" data-filename="'+_storymap_files[i]+'">'+_storymap_files[i]+'</a></li>';
             }
             $('.image-select').html(html || '<li class="default">no uploaded images found</li>');
         })
@@ -1275,10 +1276,13 @@ $(function() {
             $(this).trigger('refresh_image_select');
 
             $('#marker_image_select a').click(function(event) {
-                $('#marker_url')
-                    .val(storymap_image_url(_user.uid, _storymap_meta.id, $(this).html()))
+                if ($(this).data('filename')) {
+                  $('#marker_url')
+                    .val(storymap_image_url(_user.uid, _storymap_meta.id, $(this).data('filename')))
                     .change();
-                    console.log("change marker url");
+                } else {
+                  $('#marker_url').val('').change();
+                }
             });
 
             $('#marker_url').val(marker);

--- a/templates/edit.html
+++ b/templates/edit.html
@@ -1251,7 +1251,7 @@ $(function() {
 // ------------------------------------------------------------
 
     $('#marker_url').change(function(event) {
-        var old = _slides[_current_slide_index].location.icon;
+        _slides[_current_slide_index].location.use_custom_marker = Boolean($(this).val());
         _slides[_current_slide_index].location.icon = $(this).val().trim();
         storymap_dirty(1);
         location_mark(_slides[_current_slide_index]);

--- a/templates/edit.html
+++ b/templates/edit.html
@@ -256,6 +256,8 @@ function slide_select(event) {
                 }
             }
 
+            $('#marker_options').attr('disabled',true);
+
             _map.setDefaultView();
 
             if(!get_map_as_image()) {
@@ -264,6 +266,7 @@ function slide_select(event) {
         } else {
             // Show slide view
             $('#map_info, #map_overlay').hide();
+            $('#marker_options').attr('disabled',false);
 
             if(_storymap_data.storymap.zoomify) {
                 $('#map_search_input').hide();
@@ -1199,20 +1202,19 @@ $(function() {
 
     modal_init($('#slide_opt_modal'))
         .on('upload', function(event, url) {
-            $(this).trigger('refresh_background_select');
+            $(this).trigger('refresh_image_select');
             $('#background_url').val(url).change();
             $(this).find('.upload-panel').trigger('reset');
         })
-        .on('refresh_background_select', function(event) {
+        .on('refresh_image_select', function(event) {
             var html = '';
             for(var i = 0; i < _storymap_files.length; i++) {
                 html += '<li><a href="javascript:">'+_storymap_files[i]+'</a></li>';
             }
-            $('#background_image_select').html(html || '<li class="default">no uploaded images found</li>');
+            $('.image-select').html(html || '<li class="default">no uploaded images found</li>');
         })
         .on('modal_show', function(event, error_msg) {
             var background = _slides[_current_slide_index].background || {};
-
             var color = background.color || '';
             var opacity = (background.opacity || 100) / 100;
             var url = background.url || '';
@@ -1220,13 +1222,14 @@ $(function() {
             $('#background_color').minicolors('value', color);
             $('#background_color').minicolors('opacity', opacity);
 
+
             if(color) {
                 $('#background_color_clear').show();
             } else {
                 $('#background_color_clear').hide();
             }
 
-            $(this).trigger('refresh_background_select');
+            $(this).trigger('refresh_image_select');
 
             $('#background_image_select a').click(function(event) {
                 $('#background_url')
@@ -1235,6 +1238,49 @@ $(function() {
             });
 
             $('#background_url').val(url);
+
+            $(this).find('.upload-panel').trigger('reset');
+            $(this).trigger('reset', error_msg);
+        })
+        .on('show', function() {
+            $(this).trigger('modal_show');
+        });
+
+// ------------------------------------------------------------
+// Markers
+// ------------------------------------------------------------
+
+    $('#marker_url').change(function(event) {
+        var old = _slides[_current_slide_index].location.icon;
+        _slides[_current_slide_index].location.icon = $(this).val().trim();
+        storymap_dirty(1);
+    });
+
+    modal_init($('#marker_opt_modal'))
+        .on('upload', function(event, url) {
+            $(this).trigger('refresh_image_select');
+            $('#marker_url').val(url).change();
+            $(this).find('.upload-panel').trigger('reset');
+        })
+        .on('refresh_image_select', function(event) {
+            var html = '';
+            for(var i = 0; i < _storymap_files.length; i++) {
+                html += '<li><a href="javascript:">'+_storymap_files[i]+'</a></li>'; // TODO: find a nicer way of trimming these (local doesn't look nice)
+            }
+            $('.image-select').html(html || '<li class="default">no uploaded images found</li>');
+        })
+        .on('modal_show', function(event, error_msg) {
+            var marker = _slides[_current_slide_index].location.icon;
+            $(this).trigger('refresh_image_select');
+
+            $('#marker_image_select a').click(function(event) {
+                $('#marker_url')
+                    .val(storymap_image_url(_user.uid, _storymap_meta.id, $(this).html()))
+                    .change();
+                    console.log("change marker url");
+            });
+
+            $('#marker_url').val(marker);
 
             $(this).find('.upload-panel').trigger('reset');
             $(this).trigger('reset', error_msg);

--- a/templates/edit.html
+++ b/templates/edit.html
@@ -1212,6 +1212,12 @@ $(function() {
                 html += '<li><a href="javascript:">'+_storymap_files[i]+'</a></li>';
             }
             $('.image-select').html(html || '<li class="default">no uploaded images found</li>');
+
+            $('#background_image_select a').click(function(event) {
+                $('#background_url')
+                    .val(storymap_image_url(_user.uid, _storymap_meta.id, $(this).html()))
+                    .change();
+            });
         })
         .on('modal_show', function(event, error_msg) {
             var background = _slides[_current_slide_index].background || {};
@@ -1230,12 +1236,6 @@ $(function() {
             }
 
             $(this).trigger('refresh_image_select');
-
-            $('#background_image_select a').click(function(event) {
-                $('#background_url')
-                    .val(storymap_image_url(_user.uid, _storymap_meta.id, $(this).html()))
-                    .change();
-            });
 
             $('#background_url').val(url);
 
@@ -1270,10 +1270,6 @@ $(function() {
                 html += '<li><a href="javascript:" data-filename="'+_storymap_files[i]+'">'+_storymap_files[i]+'</a></li>';
             }
             $('.image-select').html(html || '<li class="default">no uploaded images found</li>');
-        })
-        .on('modal_show', function(event, error_msg) {
-            var marker = _slides[_current_slide_index].location.icon;
-            $(this).trigger('refresh_image_select');
 
             $('#marker_image_select a').click(function(event) {
                 if ($(this).data('filename')) {
@@ -1284,6 +1280,10 @@ $(function() {
                   $('#marker_url').val('').change();
                 }
             });
+        })
+        .on('modal_show', function(event, error_msg) {
+            var marker = _slides[_current_slide_index].location.icon;
+            $(this).trigger('refresh_image_select');
 
             $('#marker_url').val(marker);
 

--- a/templates/edit.html
+++ b/templates/edit.html
@@ -1253,23 +1253,32 @@ $(function() {
     $('#marker_url').change(function(event) {
         var currentSlide = _slides[_current_slide_index];
         var icon = $(this).val().trim();
-        var img = new Image();
 
-        img.onload = function() {
-            currentSlide.location.use_custom_marker = Boolean(icon);
-            currentSlide.location.icon = icon;
-            currentSlide.location.iconSize = [this.width, this.height];
-            var size = currentSlide.location.iconSize;
-            if (this.width > this.height) {
-                currentSlide.location.iconSize = [48, this.height * 48/this.width ];
-            } else {
-                currentSlide.location.iconSize = [this.width * 48/this.height, 48];
+        if (icon) {
+            var img = new Image();
+
+            img.onload = function() {
+                currentSlide.location.use_custom_marker = true;
+                currentSlide.location.icon = icon;
+                currentSlide.location.iconSize = [this.width, this.height];
+                var size = currentSlide.location.iconSize;
+                if (this.width > this.height) {
+                    currentSlide.location.iconSize = [48, this.height * 48/this.width ];
+                } else {
+                    currentSlide.location.iconSize = [this.width * 48/this.height, 48];
+                }
+                storymap_dirty(1);
+                location_mark(_slides[_current_slide_index]);
             }
+
+            img.src = icon;
+        } else {
+            currentSlide.location.use_custom_marker = false;
+            delete currentSlide.location.icon;
+            delete currentSlide.location.iconSize;
             storymap_dirty(1);
             location_mark(_slides[_current_slide_index]);
         }
-
-        img.src = icon;
     });
 
     modal_init($('#marker_opt_modal'))

--- a/templates/edit.html
+++ b/templates/edit.html
@@ -1254,6 +1254,7 @@ $(function() {
         var old = _slides[_current_slide_index].location.icon;
         _slides[_current_slide_index].location.icon = $(this).val().trim();
         storymap_dirty(1);
+        location_mark(_slides[_current_slide_index].location);
     });
 
     modal_init($('#marker_opt_modal'))

--- a/templates/edit.html
+++ b/templates/edit.html
@@ -101,8 +101,7 @@ var _default_data = {
             text: {headline: "", text: ""},
             media: {url: "", credit: "", caption: ""},
             location: {
-                line: true,
-                icon: 'https://maps.gstatic.com/intl/en_us/mapfiles/ms/micons/blue-pushpin.png'
+                line: true
             }
         }
     }
@@ -180,7 +179,7 @@ function location_set(slide_index, data) {
 function location_mark(data) {
     _map.clearOverlays();
     if(data) {
-        _map.addMarker(data.lat, data.lon, true);
+        _map.addMarker(data.lat, data.lon, true, data.icon);
         _map.panTo(data.lat, data.lon);
     }
 }
@@ -252,7 +251,7 @@ function slide_select(event) {
                     var loc_data = _slides[i].location;
 
                     if(loc_data.lat && loc_data.lon) {
-                        _map.addMarker(loc_data.lat, loc_data.lon, false);
+                        _map.addMarker(loc_data.lat, loc_data.lon, false, loc_data.icon);
                      }
                 }
             }

--- a/templates/edit.html
+++ b/templates/edit.html
@@ -1200,7 +1200,7 @@ $(function() {
         storymap_dirty(1);
     });
 
-    modal_init($('#slide_opt_modal'))
+    modal_init($('#background_opt_modal'))
         .on('upload', function(event, url) {
             $(this).trigger('refresh_image_select');
             $('#background_url').val(url).change();


### PR DESCRIPTION
Fixes #295 

This adds a modal dialog for changing the map marker of a slide. It allows uploading and selecting images in the same way as the background image dialog (and using the same directory). Once added, custom markers are shown on the edit view and in the final StoryMap.

This has a bunch of side effects

* Removes the global `use_custom_markers` option (although it's still supported for backwards compatibility) and adds a per-slide `use_custom_marker` option
* Displays the actual default icon on the edit view instead of a placeholder one (because the old placeholder one ends up looking like a custom icon)
* Renames the "Slide Options" modal to "Background Options" for clarity