### PR TITLE
Allow exporting a ZIP file of a StoryMap and importing it into another account

### DIFF
--- a/static/css/editor.css
+++ b/static/css/editor.css
@@ -281,6 +281,9 @@ input[type="radio"] {margin: 0;}
 #share_modal #oembed-note {
 	border-bottom: 1px dotted #ccc;
 }
+#share_modal .share-embed-params {
+	margin-bottom: 10px;
+}
 #share_modal .share-embed-params input[type="text"] {
 	border: 1px solid #DDD;
 }

--- a/static/js/editor.js
+++ b/static/js/editor.js
@@ -70,14 +70,11 @@ function format_dt(dt_string) {
 
 function noop() {}
 
-function _ajax(url, type, data, on_error, on_success, on_complete) {
+function _ajax(options, on_error, on_success, on_complete) {
     var _error = '';
     var _error_detail = '';
-    
-    $.ajax({
-        url: url,
-        type: type,
-        data: data,
+
+    var options = $.extend({
         cache: false,
         dataType: 'json',
         timeout: 45000, // ms
@@ -99,15 +96,19 @@ function _ajax(url, type, data, on_error, on_success, on_complete) {
         complete: function() {
             on_complete(_error, _error_detail);
         }
-    });
+    }, options);
+
+    $.ajax(options);
 }
 
 function ajax_get(url, data, on_error, on_success, on_complete) {
-    _ajax(url, 'GET', data, on_error, on_success || noop, on_complete || noop);
+    var options = { url: url, type: 'GET', data: data };
+    _ajax(options, on_error, on_success || noop, on_complete || noop);
 }
 
 function ajax_post(url, data, on_error, on_success, on_complete) {
-    _ajax(url, 'POST', data, on_error, on_success || noop, on_complete || noop);
+    var options = { url: url, type: 'POST', data: data };
+    _ajax(options, on_error, on_success || noop, on_complete || noop);
 }
 
 

--- a/templates/_modals.html
+++ b/templates/_modals.html
@@ -571,6 +571,14 @@
 					 </div>
 				 </div>
 			 </div>
+      <label>Export</label>
+      <div class="share-export">
+          <p class="note">
+              Downloading this package allows you to import your StoryMap into another user's account,
+              or host it on your own server.
+          </p>
+          <button id="share_export" type="button" class="btn btn-default">Download packaged StoryMap</button>
+      </div>
 		</div>
 
 	</div>

--- a/templates/edit.html
+++ b/templates/edit.html
@@ -1334,6 +1334,9 @@ $(function() {
                 }
             });
         })
+        .on('click', '#share_export', function(event) {
+          window.location = "{{ url_for('storymap_export') }}?id=" + _storymap_meta.id;
+        })
         //
         // Sharing
         //

--- a/templates/select.html
+++ b/templates/select.html
@@ -97,7 +97,19 @@
             </p>
             <p class="ui-note">Making a gigapixel storymap? Click 'create' and set the details using 'Map Type' in the <i class='icon-cog'></i> options. <br> <a target="_blank" href="http://knightlab.northwestern.edu/2016/05/24/a-few-small-improvements-to-storymapjs/">Read this for more info.</a></p>
         </div>
-<!-- import panel -->
+<!-- import package panel -->
+        <div class="entry-panel entry-import-package hide">
+            <p>
+                <label>Import a package created using the <strong>Share &rarr; Export</strong> option.</label>
+                <div class="upload-panel">
+                    <a class="upload-file-link btn" href="javascript:">
+                        Choose File...
+                        <input id="entry_import_package" type="file" accept="application/zip, application/octet-stream" size="40">
+                    </a>
+                </div>
+            </p>
+        </div>
+<!-- import URL panel -->
         <div class="entry-panel entry-import hide">
             <p>
                 <label>Let's import your StoryMap.  What do you want to call it?</label>
@@ -129,10 +141,12 @@
             Start Migration</a>
         <a id="entry_migrate_resume" class="entry-panel entry-migrate-resume hide btn btn-success" href="javascript:;">
             Resume Migration</a>
-        <a id="entry_create_cancel" class="entry-panel entry-create entry-import entry-rename entry-copy hide btn" onclick="$('#entry_modal').trigger('show_list');">
+        <a id="entry_create_cancel" class="entry-panel entry-import-package entry-create entry-import entry-rename entry-copy hide btn" onclick="$('#entry_modal').trigger('show_list');">
             Cancel</a>
         <a id="entry_create" class="entry-panel entry-create hide btn btn-success" href="javascript:;">
             Create</a>
+        <a id="import_package" class="entry-panel entry-list hide btn btn-default" href="javascript:;" onclick="$('#entry_modal').trigger('show_import_package');">
+            Import</a>
         <a id="new_storymap" class="entry-panel entry-list hide btn btn-success" href="javascript:;" onclick="$('#entry_modal').trigger('show_create_map');">
             <i class="icon-file "></i> New</a>
         <a id="entry_rename" class="entry-panel entry-rename hide btn btn-success" href="javascript:;">
@@ -384,7 +398,7 @@ $(function() {
     });
 
 // ------------------------------------------------------------
-// import
+// import URL
 // ------------------------------------------------------------
 
     $('#entry_import').click(function() {
@@ -417,6 +431,36 @@ $(function() {
                         document.location.href = "{{ url_for('edit') }}?id="+data.id;
                     }
                 );
+            }
+        );
+    });
+
+// ------------------------------------------------------------
+// import package
+// ------------------------------------------------------------
+
+    $('#entry_import_package').change(function() {
+        var $modal = $('#entry_modal');
+        var $panel = $('.entry-import');
+
+        var data = new FormData();
+        data.append('archive', $('#entry_import_package').get(0).files[0]);
+
+        $modal.trigger('progress_show', 'Importing StoryMap');
+
+        _ajax(
+            {
+                url: "{{ url_for('storymap_import') }}",
+                type: 'POST',
+                data: data,
+                processData: false,
+                contentType: false
+            },
+            function(error) {
+                $modal.trigger('reset', format_error('Error importing storymap', error));
+            },
+            function(data) {
+                document.location.href = "{{ url_for('edit') }}?id="+data.id;
             }
         );
     });
@@ -561,6 +605,12 @@ $(function() {
             $(this).find('.entry-panel').hide();
             $(this).find('.entry-login').show();
             $(this).trigger('progress_hide');
+        })
+        .on('show_import_package', function(event) {
+            $('.entry-import-package input[type="file"]').val('');
+
+            $(this).find('.entry-panel').hide();
+            $(this).find('.entry-import-package').show();
         })
         .on('show_create_map', function(event) {
             $('.entry-create-map input[type="text"]').val('');


### PR DESCRIPTION
Since this feature would be useful for us to demo here, we made an example implementation of how importing/exporting StoryMaps could work (#304).

One problem with this feature is that URLs (e.g. to images) aren't updated and still point to the old user's StoryMap. I'm sure this could be fixed, so if you decide this feature makes sense then I can have a look at doing it.

This is certainly not the only way to build an import/export UI, but hopefully it's useful for continuing the conversation.
