### PR TITLE
Don't show custom marker in edit mode unless a custom marker has been added

### DIFF
--- a/static/js/EditorMap.js
+++ b/static/js/EditorMap.js
@@ -143,7 +143,7 @@ LeafletEditorMap.prototype.removePolyLine = function() {
 LeafletEditorMap.prototype.addMarker = function(data, draggable) {
     var latlng = L.latLng(data.location.lat, data.location.lon);
 
-    if (data.location.icon) {
+    if (data.location.use_custom_marker) {
       var anchor = data.location.iconSize ? [data.location.iconSize[0] * 0.5, data.location.iconSize[1]] : [24,48] ;
       var icon = L.icon({iconUrl: data.location.icon, iconSize: data.location.iconSize || [48,48], iconAnchor: anchor});
     } else {

--- a/templates/edit.html
+++ b/templates/edit.html
@@ -1306,10 +1306,12 @@ $(function() {
             });
         })
         .on('modal_show', function(event, error_msg) {
-            var marker = _slides[_current_slide_index].location.icon;
+            var currentSlide = _slides[_current_slide_index];
             $(this).trigger('refresh_image_select');
 
-            $('#marker_url').val(marker);
+            if (currentSlide.location.use_custom_marker) {
+                $('#marker_url').val(currentSlide.location.icon);
+            }
 
             $(this).find('.upload-panel').trigger('reset');
             $(this).trigger('reset', error_msg);


### PR DESCRIPTION
Fixes #313

The edit mode map now checks whether use_custom_marker is set, for consistency with how the map marker is shown in the final StoryMap.