### PR TITLE
Deprecates google subdocument of the user record -- removes it from t…

### DIFF
--- a/api.py
+++ b/api.py
@@ -244,6 +244,9 @@ def _user_get():
     """Enforce authenticated user"""
     uid = session.get('uid')
     user = _user.find_one({'uid': uid})
+    # google data field in user record no longer used
+    if 'google' in user:
+        del user['google']
     if not user and 'uid' in session:
         session.pop('uid')
     return user


### PR DESCRIPTION
**What**

Deprecate the google sub-document of the user's mongo record by removing it from the editor UI

**Why**

This is an artifact of a bygone era or Google Drive based StoryMap persistence. This data is no longer being used. An instance was seen in which this information was somehow manipulated or corrupted so as to break the UI