### PR TITLE
289 null location

### DIFF
--- a/templates/edit.html
+++ b/templates/edit.html
@@ -249,10 +249,12 @@ function slide_select(event) {
             for(var i = 1; i < _slides.length; i++) {
                 if(_slides[i].hasOwnProperty('location')) {
                     var loc_data = _slides[i].location;
-
-                    if(loc_data.lat && loc_data.lon) {
+                    if(loc_data
+                            && loc_data.hasOwnProperty('lat')
+                            && loc_data.hasOwnProperty('lon')
+                            && loc_data.lat && loc_data.lon) {
                         _map.addMarker(_slides[i], false);
-                     }
+                    }
                 }
             }
 

--- a/templates/edit.html
+++ b/templates/edit.html
@@ -164,7 +164,10 @@ function map_set_type() {
 
 function location_set(slide_index, data) {
     var dirty = 0;
-
+    if ( ('location' in _slides[slide_index]) === false
+         || _slides[slide_index].location === null) {
+        _slides[slide_index]['location'] = {};
+    }
     for(var key in data) {
         if(_slides[slide_index].location[key] != data[key]) {
             _slides[slide_index].location[key] = data[key];
@@ -250,8 +253,8 @@ function slide_select(event) {
                 if(_slides[i].hasOwnProperty('location')) {
                     var loc_data = _slides[i].location;
                     if(loc_data
-                            && loc_data.hasOwnProperty('lat')
-                            && loc_data.hasOwnProperty('lon')
+                            && 'lat' in loc_data
+                            && 'lon' in loc_data
                             && loc_data.lat && loc_data.lon) {
                         _map.addMarker(_slides[i], false);
                     }
@@ -276,10 +279,20 @@ function slide_select(event) {
                 $('#map_search_input').val('').show();
             }
 
-            _map.setView(data.location.lat, data.location.lon, data.location.zoom);
+            if(data.location
+                    && 'lat' in data.location
+                    && 'lon' in data.location
+                    && data.location.lat && data.location.lon) {
+                _map.setView(data.location.lat, data.location.lon, data.location.zoom);
+            }
             _map.zoomEnable(true);
 
-            location_mark(data);
+            if(data.location
+                    && 'lat' in data.location
+                    && 'lon' in data.location
+                    && data.location.lat && data.location.lon) {
+                location_mark(data);
+            }
         }
 
         $('#url').val(data.media.url);


### PR DESCRIPTION
**What**
Add checks to better handle null/missing location slide data in the editor

**Why**
Missing or corrupted location data was causing the editor to hang on init of the StoryMap. New checks allow the map to load and provides opportunity for the user to fix the missing location data

**Notes**
From what I can see, the embed code already handles missing locations decently. By extension, the preview should also be fine provided the editor can actually load the StoryMap. The current behavior is simply not to show a marker for the location

**Reviewers**
@JoeGermuska 