### PR TITLE
Pgdb

### DIFF
--- a/README_DOCKER.md
+++ b/README_DOCKER.md
@@ -74,3 +74,9 @@ build details.
 ```
 $ docker-compose up
 ```
+
+### Connecting to postgres
+
+```
+ $ docker-compose run pg psql -h pg -U storymap
+```

--- a/api.py
+++ b/api.py
@@ -34,7 +34,7 @@ import slugify
 import bson
 from oauth2client.client import OAuth2WebServerFlow
 from storymap import google
-from storymap.connection import _user, get_pg_user
+from storymap.connection import get_user, save_user, create_user, find_users
 
 app = Flask(__name__)
 app.config.from_envvar('FLASK_SETTINGS_FILE')
@@ -263,9 +263,7 @@ def google_auth_verify():
 
         # Upsert user record
         uid = _get_uid('google:'+info['id'])
-
-        user = _user.find_one({'uid': uid})
-        pg_user = get_pg_user(uid)
+        user = get_user(uid)
         if user:
             user['google'] = info
         else:
@@ -276,7 +274,7 @@ def google_auth_verify():
                 'google': info
             }
         user['uname'] = info['name']
-        _user.save(user)
+        save_user(user)
 
         # Update session
         session['uid'] = uid
@@ -293,30 +291,22 @@ def google_auth_verify():
 # Misc
 #
 
-def _user_get():
+def get_session_user():
     """Enforce authenticated user"""
     uid = session.get('uid')
-    user = _user.find_one({'uid': uid})
-    pg_user = get_pg_user(uid)
-    # google data field in user record no longer used
+    user = get_user(uid)
     if not user:
         try:
             session.pop('uid')
         except KeyError: pass
         return None
-    if 'google' in user:
-        del user['google']
     return user
+
 
 def check_test_user():
     if settings.TEST_MODE:
-        if not _user.find_one({ 'uid': 'test' }):
-            _user.insert({
-                'uid': 'test',
-                'migrated': 1,
-                'storymaps': {},
-                'google': { 'name': 'Test User' }
-            })
+        if not get_user('test'):
+            create_user('test', 'Test User')
         session['uid'] = 'test'
 
 def require_user(f):
@@ -326,7 +316,7 @@ def require_user(f):
     """
     @wraps(f)
     def decorated_function(*args, **kwargs):
-        user = _user_get()
+        user = get_session_user()
         if user is None:
             return redirect(url_for('select'))
         request.user = user
@@ -342,7 +332,7 @@ def require_user_id(template=None):
     def decorator(f):
         @wraps(f)
         def decorated_function(*args, **kwargs):
-            user = _user_get()
+            user = get_session_user()
 
             id = _request_get_required('id')
             if id not in user['storymaps']:
@@ -435,7 +425,7 @@ def storymap_update_meta(user, id):
         key, value = _request_get_required('key', 'value')
 
         user['storymaps'][id][key] = value
-        _user.save(user)
+        save_user(user)
 
         key_prefix = storage.key_prefix(user['uid'], id)
 
@@ -487,7 +477,7 @@ def storymap_copy(user, id):
             'draft_on': user['storymaps'][id]['draft_on'],
             'published_on': user['storymaps'][id]['published_on']
         }
-        _user.save(user)
+        save_user(user)
         # Write new embed pages
         _write_embed_draft(dst_key_prefix, user['storymaps'][dst_id])
         if user['storymaps'][dst_id].get('published_on'):
@@ -510,7 +500,7 @@ def storymap_delete(user, id):
             storage.delete(key);
 
         del user['storymaps'][id]
-        _user.save(user)
+        save_user(user)
 
         return jsonify({})
     except Exception as e:
@@ -537,7 +527,7 @@ def storymap_create(user):
             'draft_on': _utc_now(),
             'published_on': ''
         }
-        _user.save(user)
+        save_user(user)
 
         _write_embed_draft(key_prefix, user['storymaps'][id])
 
@@ -552,8 +542,7 @@ def storymap_migrate_done(user):
     """Flag user as migrated"""
     try:
         user['migrated'] = 1
-        _user.save(user)
-
+        save_user(user)
         return jsonify({})
     except Exception as e:
         traceback.print_exc()
@@ -624,8 +613,7 @@ def storymap_migrate(user):
             'draft_on': draft_on,
             'published_on': published_on
         }
-        _user.save(user)
-
+        save_user(user)
         _write_embed_draft(dst_key_prefix, user['storymaps'][dst_id])
         if published_on:
             _write_embed_published(dst_key_prefix, user['storymaps'][dst_id])
@@ -670,8 +658,7 @@ def storymap_save(user, id):
         storage.save_json(key_name, content)
 
         user['storymaps'][id]['draft_on'] = _utc_now()
-        _user.save(user)
-
+        save_user(user)
         return jsonify({'meta': user['storymaps'][id]})
     except storage.StorageException as e:
         traceback.print_exc()
@@ -693,8 +680,7 @@ def storymap_publish(user, id):
         storage.save_json(key_prefix+'published.json', content)
 
         user['storymaps'][id]['published_on'] = _utc_now()
-        _user.save(user)
-
+        save_user(user)
         _write_embed_published(key_prefix, user['storymaps'][id])
 
         return jsonify({'meta': user['storymaps'][id]})
@@ -799,7 +785,7 @@ def userinfo():
     migrate_data = None
 
     if uid:
-        user = _user.find_one({'uid': uid})
+        user = get_user(uid)
         if user:
             if not user['migrated']:
                 migrate_data = google.drive_get_migration_diagnostics(user)
@@ -821,25 +807,24 @@ def legacy_redirect():
     """Legacy redirect"""
     return redirect(url_for('select')+'?'+request.query_string)
 
+
 @app.route("/select/", methods=['GET', 'POST'])
 def select():
     check_test_user()
-
     try:
         uid = session.get('uid')
         if not uid:
             return render_template('select.html')
-
-        user = _user.find_one({'uid': uid})
+        user = get_user(uid)
         if not user:
             _session_pop('uid')
             return render_template('select.html')
         del user['_id']
-
         return render_template('select.html', user=user)
     except Exception as e:
         traceback.print_exc()
         return render_template('select.html', error=str(e))
+
 
 @app.route("/edit/", methods=['GET', 'POST'])
 @require_user
@@ -895,7 +880,7 @@ def admin_users(user):
         files[uid].append(k)
     pages = 0
     if query:
-        for u in _user.find(query, skip=skip, limit=rpp):
+        for u in find_users(query, skip, limit):
             u.update({ 'files': files[u['uid']] })
             users.append(u)
         pages = int(math.ceil(_user.find(query).count() / rpp))
@@ -919,7 +904,7 @@ def admin_unmatched_files(user):
     for k in storage.all_keys():
         uid = k.split('/')[1]
         files[uid].append(k)
-    for u in _user.find():
+    for u in find_users():
         try:
             del files[u['uid']]
         except KeyError:

--- a/api.py
+++ b/api.py
@@ -985,6 +985,16 @@ if __name__ == '__main__':
         migrate_pg()
         exit()
 
+    if sys.argv[1] == 'audit':
+        """Temporary utility to audit user database entries and to ensure
+        pg/mongo parity.
+
+        $ docker-compose run app python api.py audit
+        """
+        from storymap.connection import audit_pg
+        audit_pg()
+        exit()
+
     # Add current directory to sys.path
     site_dir = os.path.dirname(os.path.abspath(__file__))
     if site_dir not in sys.path:
@@ -992,6 +1002,8 @@ if __name__ == '__main__':
 
     ssl_context = None
     port = 5000
+    app.run(host='0.0.0.0', port=port, debug=True, ssl_context='adhoc')
+    exit()
 
     try:
         opts, args = getopt.getopt(sys.argv[1:], "sp:", ["port="])

--- a/core/settings.py
+++ b/core/settings.py
@@ -23,6 +23,7 @@ DATABASES = {
     },
     'pg': {
         'HOST': env.get('PG_HOST', 'pg'),
+        'PORT': env.get('PG_PORT', '5432'),
         'NAME': env.get('PG_NAME', 'storymap'),
         'USER': env.get('PG_USER', 'storymap'),
         'PASSWORD': env.get('PG_PASSWORD', 'storymap')

--- a/core/settings.py
+++ b/core/settings.py
@@ -20,6 +20,12 @@ DATABASES = {
         'NAME': env['DB_NAME__DEFAULT'],
         'HOST': env['DB_HOST__DEFAULT'],
         'PORT': env['DB_PORT__DEFAULT']
+    },
+    'pg': {
+        'HOST': env.get('PG_HOST', 'pg'),
+        'NAME': env.get('PG_NAME', 'storymap'),
+        'USER': env.get('PG_USER', 'storymap'),
+        'PASSWORD': env.get('PG_PASSWORD', 'storymap')
     }
 }
 

--- a/deploy/config.common.yml
+++ b/deploy/config.common.yml
@@ -24,6 +24,11 @@ init_env_common:
   GOOGLE_CLIENT_SECRET: "{{ vault_google_client_secret }}"
   ADMINS: "{{ vault_admins | join(',') }}"
   ALLOWED_IDS: "{{ vault_allowed_ids }}"
+  PG_HOST: "{{ vault_pg_host }}"
+  PG_PORT: "{{ vault_pg_port }}"
+  PG_NAME: "{{ vault_pg_name }}"
+  PG_USER: "{{ vault_pg_user }}"
+  PG_PASSWORD: "{{ vault_pg_password }}"
 
 # Flask specific configs
 static_dir: "{{ deploy_dir }}/static"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,6 +22,7 @@ services:
     links:
       - mongo:mongo
       - localstack:localstack
+      - pg:pg
     volumes:
       - .:/usr/src/apps/StoryMapJS
       - .localstack:/usr/src/apps/StoryMapJS/.localstack
@@ -29,6 +30,7 @@ services:
     command: python api.py -s -p 5000
     depends_on:
       - mongo
+      - pg
 
   static:
     restart: always
@@ -51,6 +53,18 @@ services:
       - "28017:28017"
     environment:
       MONGO_INITDB_DATABASE: storymapjs
+
+  pg:
+    image: postgres:11.6
+    restart: always
+    environment:
+      POSTGRES_USER: storymap
+      POSTGRES_DB: storymap
+      POSTGRES_PASSWORD: storymap
+    ports:
+      - "5432:5432"
+    volumes:
+      - ./.pgdata:/var/lib/postgresql/data/
 
   localstack:
     image: localstack/localstack-light

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -72,7 +72,6 @@ services:
     restart: always
     environment:
       USE_LIGHT_IMAGE: 1
-      # USE_SSL: 1
       LOCALSTACK_SERVICES: s3
       DATA_DIR: /tmp/localstack/data
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,7 @@ version: '3'
 # create the application database, run `initdb.sh` after building.
 
 services:
+
   app:
     restart: always
     build: .
@@ -71,7 +72,7 @@ services:
     restart: always
     environment:
       USE_LIGHT_IMAGE: 1
-      USE_SSL: 1
+      # USE_SSL: 1
       LOCALSTACK_SERVICES: s3
       DATA_DIR: /tmp/localstack/data
     ports:

--- a/requirements.txt
+++ b/requirements.txt
@@ -31,6 +31,7 @@ oauth2client
 paramiko==2.4.2
 pbr==1.10.0
 ply==3.4
+psycopg2-binary
 pyasn1
 pyasn1-modules
 pycparser==2.14

--- a/requirements.txt
+++ b/requirements.txt
@@ -40,7 +40,7 @@ pymongo==2.8
 PyNaCl==1.3.0
 pyOpenSSL
 python-slugify==1.1.2
-readline==6.2.4.1
+#readline==6.2.4.1
 requests[security]
 robotframework
 robotframework-selenium2library

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 asn1crypto==0.24.0
 bcrypt==3.1.6
-#boto==2.42.0
 boto3
 certifi
 cffi==1.8.3
@@ -40,7 +39,6 @@ pymongo==2.8
 PyNaCl==1.3.0
 pyOpenSSL
 python-slugify==1.1.2
-#readline==6.2.4.1
 requests[security]
 robotframework
 robotframework-selenium2library

--- a/storymap/connection.py
+++ b/storymap/connection.py
@@ -14,9 +14,11 @@ settings = sys.modules[os.environ['FLASK_SETTINGS_MODULE']]
 print('db host', settings.DATABASES['default']['HOST'])
 print('db port', int(settings.DATABASES['default']['PORT']))
 
-# Checked max length of uname in mongo was 71 characters
-_pg_conn = psycopg2.connect('host=pg dbname=storymap user=storymap password=storymap')
-
+_pg_conn = psycopg2.connect(
+    f"host={settings.DATABASES['pg']['HOST']} " \
+    f"dbname={settings.DATABASES['pg']['NAME']} " \
+    f"user={settings.DATABASES['pg']['USER']} " \
+    f"password={settings.DATABASES['pg']['PASSWORD']}")
 
 
 
@@ -55,6 +57,7 @@ def create_pg_user(uid, uname, migrated=1, storymaps=None, cursor=None):
 
 
 def migrate_pg(drop_table=True):
+    # Checked max length of uname in mongo was 71 characters
     if drop_table:
         with _pg_conn.cursor() as cursor:
             cursor.execute('DROP TABLE IF EXISTS users;')

--- a/storymap/connection.py
+++ b/storymap/connection.py
@@ -15,11 +15,11 @@ print('db host', settings.DATABASES['default']['HOST'])
 print('db port', int(settings.DATABASES['default']['PORT']))
 
 _pg_conn = psycopg2.connect(
-    f"host={settings.DATABASES['pg']['HOST']} " \
-    f"dbname={settings.DATABASES['pg']['NAME']} " \
-    f"user={settings.DATABASES['pg']['USER']} " \
-    f"password={settings.DATABASES['pg']['PASSWORD']}")
-
+    host=settings.DATABASES['pg']['HOST'],
+    port=settings.DATABASES['pg']['PORT'],
+    dbname=settings.DATABASES['pg']['NAME'],
+    user=settings.DATABASES['pg']['USER'],
+    password=settings.DATABASES['pg']['PASSWORD'])
 
 
 if settings.TEST_MODE:

--- a/storymap/connection.py
+++ b/storymap/connection.py
@@ -6,6 +6,8 @@ import psycopg2.extras
 import pymongo
 import mongomock
 
+psycopg2.extensions.register_adapter(dict, psycopg2.extras.Json)
+
 # Get settings module
 settings = sys.modules[os.environ['FLASK_SETTINGS_MODULE']]
 
@@ -29,30 +31,44 @@ else:
 _db = _conn[settings.DATABASES['default']['NAME']]
 
 # Mongo collections
-_user = _db['users']
+_users = _db['users']
 
 # Ensure indicies
-_user.ensure_index('uid')
-_user.ensure_index('uname')
+_users.ensure_index('uid')
+_users.ensure_index('uname')
 
 
 ### Postgres ###
 
-def migrate_pg():
+def create_pg_user(uid, uname, migrated=1, storymaps=None, cursor=None):
+    if storymaps is None:
+        storymaps = {}
+    query = "INSERT INTO users (uid, uname, migrated, storymaps) " \
+        "VALUES (%s, %s, %s, %s);"
+    if cursor:
+        cursor.execute(query, (uid, uname, migrated, storymaps))
+        return
+    else:
+        with _pg_conn.cursor() as cursor:
+            cursor.execute(query, (uid, uname, migrated, storymaps))
+        _pg_conn.commit()
+
+
+def migrate_pg(drop_table=True):
+    if drop_table:
+        with _pg_conn.cursor() as cursor:
+            cursor.execute('DROP TABLE IF EXISTS users;')
+            cursor.execute(
+                "CREATE TABLE IF NOT EXISTS users " \
+                "(id serial PRIMARY KEY, uid varchar(32), uname varchar(100), " \
+                "migrated smallint, storymaps jsonb, " \
+                "CONSTRAINT unique_uid UNIQUE (uid))")
+        _pg_conn.commit()
     with _pg_conn.cursor() as cursor:
-        # cursor.execute('DROP TABLE IF EXISTS users;')
-        cursor.execute(
-            "CREATE TABLE IF NOT EXISTS users " \
-            "(id serial PRIMARY KEY, uid varchar(32), uname varchar(100), " \
-            "migrated boolean, google jsonb, storymaps jsonb, " \
-            "CONSTRAINT unique_uid UNIQUE (uid))")
-        for u in _user.find({}):
+        for u in _users.find({}):
             try:
-                cursor.execute(
-                    "INSERT INTO users (uid, uname, migrated, google, storymaps) " \
-                    "VALUES (%s, %s, %s, %s, %s);",
-                    (u['uid'], u['uname'], bool(u['migrated']),
-                    json.dumps(u['google']), json.dumps(u['storymaps'])))
+                create_pg_user(u['uid'], u['uname'], u['migrated'],
+                    json.dumps(u['storymaps']))
                 print(u['uid'])
             except psycopg2.errors.UniqueViolation:
                 print('Skipping existing:', u['uid'])
@@ -64,29 +80,25 @@ def audit_pg():
     with _pg_conn.cursor() as cursor:
         cursor.execute('SELECT COUNT (*) from users')
         count = cursor.fetchone()[0]
-        assert count == _user.count(), 'Postgres / Mongo user count mismatch'
-
+        assert count == _users.count(), 'Postgres / Mongo user count mismatch'
         cursor.execute(
-            "SELECT uid, uname, migrated, google, storymaps FROM users " \
+            "SELECT uid, uname, migrated, storymaps FROM users " \
             "ORDER BY RANDOM() " \
             "LIMIT 1000")
         rand_users = cursor.fetchall()
         for u in rand_users:
-            uid, uname, migrated, google, storymaps = u
-            print(uid)
-            mongo_user = _user.find_one({'uid': uid})
-            print(mongo_user)
+            uid, uname, migrated, storymaps = u
+            mongo_user = _users.find_one({'uid': uid})
             assert uid == mongo_user['uid']
             assert uname == mongo_user['uname']
             assert migrated == mongo_user['migrated']
-            assert google == mongo_user['google']
             assert storymaps == mongo_user['storymaps']
 
 
 def get_pg_user(uid):
     with _pg_conn.cursor(cursor_factory=psycopg2.extras.DictCursor) as cursor:
         cursor.execute(
-            "SELECT uid, uname, migrated, google, storymaps FROM users " \
+            "SELECT uid, uname, migrated, storymaps FROM users " \
             "WHERE uid=%s", (uid,))
         u = cursor.fetchone()
     return u
@@ -94,11 +106,40 @@ def get_pg_user(uid):
 
 def save_pg_user(user):
     with _pg_conn.cursor() as cursor:
-        pass
-        _u = get_pg_user(user['uid'])
+        _u = dict(get_pg_user(user['uid']))
         _u.update(user)
         cursor.execute(
-            "UPDATE user SET (uid, uname, migrated, google, storymaps) " \
-            "VALUES (%(uid)s, %(uname)s, %(migrated)s, %(google)s, %(storymap) WHERE uid=%(uid)s;",
-            **user)
+            "UPDATE users SET uid=%(uid)s, uname=%(uname)s, " \
+            "migrated=%(migrated)s, storymaps=%(storymaps)s " \
+            "WHERE uid=%(uid)s;", user)
         _pg_conn.commit()
+
+
+def create_user(uid, uname, migrated=1, storymaps=None):
+    if storymaps is None:
+        storymaps = {}
+    _users.insert({
+        'uid': uid,
+        'uname': uname,
+        'migrated': migrated,
+        'storymaps': storymaps
+    })
+    create_pg_user(uid, uname, migrated=1, storymaps=storymaps)
+
+
+def get_user(uid):
+    # for pg: get_pg_user(uid)
+    user = _users.find_one({'uid': uid})
+    if 'google' in user:
+        del user['google']
+    return user
+
+
+def save_user(user):
+    _users.save(user)
+    save_pg_user(user)
+
+
+def find_users(query=None, skip=None, limit=None):
+    for u in _users.find(query, skip, limit):
+        yield u

--- a/storymap/connection.py
+++ b/storymap/connection.py
@@ -1,5 +1,8 @@
+import json
 import sys
 import os
+import psycopg2
+import psycopg2.extras
 import pymongo
 import mongomock
 
@@ -8,6 +11,12 @@ settings = sys.modules[os.environ['FLASK_SETTINGS_MODULE']]
 
 print('db host', settings.DATABASES['default']['HOST'])
 print('db port', int(settings.DATABASES['default']['PORT']))
+
+# Checked max length of uname in mongo was 71 characters
+_pg_conn = psycopg2.connect('host=pg dbname=storymap user=storymap password=storymap')
+
+
+
 
 if settings.TEST_MODE:
     _conn = mongomock.MongoClient()
@@ -26,3 +35,47 @@ _user = _db['users']
 _user.ensure_index('uid')
 _user.ensure_index('uname')
 
+
+### Postgres ###
+
+def migrate_pg():
+    with _pg_conn.cursor() as cursor:
+        # cursor.execute('DROP TABLE IF EXISTS users;')
+        cursor.execute(
+            "CREATE TABLE IF NOT EXISTS users " \
+            "(id serial PRIMARY KEY, uid varchar(32), uname varchar(100), " \
+            "migrated boolean, google jsonb, storymaps jsonb, " \
+            "CONSTRAINT unique_uid UNIQUE (uid))")
+        for u in _user.find({}):
+            try:
+                cursor.execute(
+                    "INSERT INTO users (uid, uname, migrated, google, storymaps) " \
+                    "VALUES (%s, %s, %s, %s, %s);",
+                    (u['uid'], u['uname'], bool(u['migrated']),
+                    json.dumps(u['google']), json.dumps(u['storymaps'])))
+                print(u['uid'])
+            except psycopg2.errors.UniqueViolation:
+                print('Skipping existing:', u['uid'])
+    _pg_conn.commit()
+    _pg_conn.close()
+
+
+def get_pg_user(uid):
+    with _pg_conn.cursor(cursor_factory=psycopg2.extras.DictCursor) as cursor:
+        cursor.execute(
+            "SELECT uid, uname, migrated, google, storymaps FROM users " \
+            "WHERE uid=%s", (uid,))
+        u = cursor.fetchone()
+    return u
+
+
+def save_pg_user(user):
+    with _pg_conn.cursor() as cursor:
+        pass
+        _u = get_pg_user(user['uid'])
+        _u.update(user)
+        cursor.execute(
+            "UPDATE user SET (uid, uname, migrated, google, storymaps) " \
+            "VALUES (%(uid)s, %(uname)s, %(migrated)s, %(google)s, %(storymap) WHERE uid=%(uid)s;",
+            **user)
+        _pg_conn.commit()


### PR DESCRIPTION
Adds postgres CRUD for anticipated migration from mongo to postgres

- user records are saved to both mongo and pg
- user records are still only retrieved from mongo for the time being
- a migrate tool is provided for the initial setup, and needs to be run manually upon deployment
- an audit tool is provided which should be used to check parity between mongo and pg before a cutover is initiated

Cutover mechanism itself is tbd. It is anticipated that the only change required will be to fetch users from postgres rather than mongo .. thus pg based implementations of connection.get_user and connection.find_user