### PR TITLE
Fix orphaned storymap records from delete/save race conditions

### DIFF
--- a/storymap/api.py
+++ b/storymap/api.py
@@ -40,7 +40,8 @@ import hashlib
 import requests
 import slugify
 from oauth2client.client import OAuth2WebServerFlow
-from .connection import get_user, save_user, create_user, find_users, pg_conn
+from .connection import (get_user, save_user, create_user, find_users, pg_conn,
+    delete_user_storymap, set_user_storymap_value, set_user_migrated)
 from . import googleauth
 from . import storage
 
@@ -477,7 +478,7 @@ def storymap_update_meta(user, id):
         key, value = _request_get_required('key', 'value')
 
         user['storymaps'][id][key] = value
-        save_user(user, db=db())
+        set_user_storymap_value(user['uid'], [id, key], value, db=db())
 
         key_prefix = storage.key_prefix(user['uid'], id)
 
@@ -621,7 +622,7 @@ def storymap_copy(user, id):
             'draft_on': user['storymaps'][id]['draft_on'],
             'published_on': user['storymaps'][id]['published_on']
         }
-        save_user(user, db=db())
+        set_user_storymap_value(user['uid'], [dst_id], user['storymaps'][dst_id], db=db())
         # Write new embed pages
         _write_embed_draft(dst_key_prefix, user['storymaps'][dst_id])
         if user['storymaps'][dst_id].get('published_on'):
@@ -642,9 +643,12 @@ def storymap_delete(user, id):
     """Delete storymap"""
     storymap_id = id
     try:
-        storymap_cleanup(user["uid"], storymap_id)
+        # Commit the metadata removal FIRST, atomically (single JSONB key),
+        # then enqueue the S3 cleanup. If the DB delete fails, cleanup is never
+        # queued, so we never orphan the account record from its S3 objects.
         del user['storymaps'][storymap_id]
-        save_user(user, db=db())
+        delete_user_storymap(user['uid'], storymap_id, db=db())
+        storymap_cleanup(user["uid"], storymap_id)
         return jsonify({})
     except storage.StorageException as e:
         traceback.print_exc()
@@ -670,7 +674,7 @@ def storymap_create(user):
             'draft_on': _utc_now(),
             'published_on': ''
         }
-        save_user(user, db=db())
+        set_user_storymap_value(user['uid'], [id], user['storymaps'][id], db=db())
         _write_embed_draft(key_prefix, user['storymaps'][id])
         return jsonify({'id': id})
     except storage.StorageException as e:
@@ -687,7 +691,7 @@ def storymap_migrate_done(user):
     """Flag user as migrated"""
     try:
         user['migrated'] = 1
-        save_user(user, db=db())
+        set_user_migrated(user['uid'], 1, db=db())
         return jsonify({})
     except Exception as e:
         traceback.print_exc()
@@ -758,7 +762,7 @@ def storymap_migrate(user):
             'draft_on': draft_on,
             'published_on': published_on
         }
-        save_user(user, db=db())
+        set_user_storymap_value(user['uid'], [dst_id], user['storymaps'][dst_id], db=db())
         _write_embed_draft(dst_key_prefix, user['storymaps'][dst_id])
         if published_on:
             _write_embed_published(dst_key_prefix, user['storymaps'][dst_id])
@@ -831,7 +835,8 @@ def storymap_save(user, id):
                 time.sleep(retry_delay_seconds)
 
         user['storymaps'][id]['draft_on'] = _utc_now()
-        save_user(user, db=db())
+        set_user_storymap_value(user['uid'], [id, 'draft_on'],
+            user['storymaps'][id]['draft_on'], db=db())
         return jsonify({'meta': user['storymaps'][id]})
     except storage.StorageException as e:
         traceback.print_exc()
@@ -855,7 +860,8 @@ def storymap_publish(user, id):
         storage.save_json(key_prefix+'published.json', content)
 
         user['storymaps'][id]['published_on'] = _utc_now()
-        save_user(user, db=db())
+        set_user_storymap_value(user['uid'], [id, 'published_on'],
+            user['storymaps'][id]['published_on'], db=db())
         _write_embed_published(key_prefix, user['storymaps'][id])
 
         return jsonify({'meta': user['storymaps'][id]})

--- a/storymap/connection.py
+++ b/storymap/connection.py
@@ -112,6 +112,47 @@ def save_user(user, *, db):
     save_pg_user(user, db=db)
 
 
+def delete_user_storymap(uid, storymap_id, *, db):
+    """Atomically remove a single storymap key from a user's storymaps JSONB.
+
+    Uses the JSONB `-` operator so only this key is touched, rather than
+    rewriting the whole `storymaps` column from an in-memory snapshot (which
+    a concurrent save could clobber).
+    """
+    with db.cursor() as cursor:
+        cursor.execute(
+            "UPDATE users SET storymaps = storymaps - %(id)s "
+            "WHERE uid = %(uid)s;",
+            {'id': storymap_id, 'uid': uid})
+    db.commit()
+
+
+def set_user_storymap_value(uid, path, value, *, db):
+    """Atomically set storymaps#>path = value for one user, via jsonb_set.
+
+    `path` is a list of JSON keys, e.g. ['my-map'] to write a whole storymap
+    entry or ['my-map', 'draft_on'] to write a single field. Only that path is
+    written; the rest of the storymaps column is untouched, so a concurrent
+    write to a different storymap (or a different field) cannot clobber it.
+    """
+    with db.cursor() as cursor:
+        cursor.execute(
+            "UPDATE users SET storymaps = jsonb_set("
+            "coalesce(storymaps, '{}'::jsonb), %(path)s::text[], "
+            "%(value)s::jsonb, true) WHERE uid = %(uid)s;",
+            {'path': list(path), 'value': json.dumps(value), 'uid': uid})
+    db.commit()
+
+
+def set_user_migrated(uid, migrated, *, db):
+    """Atomically set the `migrated` flag without rewriting other columns."""
+    with db.cursor() as cursor:
+        cursor.execute(
+            "UPDATE users SET migrated = %(migrated)s WHERE uid = %(uid)s;",
+            {'migrated': migrated, 'uid': uid})
+    db.commit()
+
+
 def find_users(*, db, uname=None, uname__like=None, uid=None, migrated=None,
         limit=DEFAULT_USER_QUERY_LIMIT, offset=0):
     """NOTE: currently does not properly handle an all-users search. Must

--- a/tests/integration_tests.py
+++ b/tests/integration_tests.py
@@ -33,6 +33,13 @@ except ImportError as e:
 
 settings = sys.modules[os.environ['FLASK_SETTINGS_MODULE']]
 settings.TEST_MODE = False
+# Tests run on the host, but settings default the DB host to the Docker-internal
+# name "pg". Rewrite it to localhost (the port is published to the host).
+try:
+    if settings.DATABASES['pg']['HOST'] == 'pg':
+        settings.DATABASES['pg']['HOST'] = 'localhost'
+except (AttributeError, KeyError, TypeError):
+    pass
 # Use the actual bucket from settings (uploads.knilab.com) instead of a test bucket
 # The bucket should be created by running scripts/makebuckets.sh
 if not os.environ.get('AWS_TEST_BUCKET'):
@@ -43,6 +50,69 @@ else:
 
 # Import storage module AFTER setting environment
 from storymap.storage import all_keys, save_from_data
+from storymap.connection import (pg_conn, create_user, get_user,
+    set_user_storymap_value, set_user_migrated, delete_user_storymap)
+
+
+@pytest.fixture
+def pg_user():
+    """Create a throwaway user in Postgres and clean it up afterwards."""
+    uid = 'itest-concurrent-writes'
+    db = pg_conn(settings)
+    with db.cursor() as cursor:
+        cursor.execute('DELETE FROM users WHERE uid=%s', (uid,))
+    db.commit()
+    create_user(uid, 'Integration Test', db=db, storymaps={
+        'map-a': {'id': 'map-a', 'title': 'A', 'draft_on': 't0', 'published_on': ''},
+        'map-b': {'id': 'map-b', 'title': 'B', 'draft_on': 't0', 'published_on': ''},
+    })
+    yield uid, db
+    with db.cursor() as cursor:
+        cursor.execute('DELETE FROM users WHERE uid=%s', (uid,))
+    db.commit()
+    db.close()
+
+
+@pytest.mark.integration
+def test_set_user_storymap_value_whole_key(pg_user):
+    """Writing a whole storymap entry must not disturb sibling entries."""
+    uid, db = pg_user
+    set_user_storymap_value(uid, ['map-c'],
+        {'id': 'map-c', 'title': 'C', 'draft_on': 't1', 'published_on': ''}, db=db)
+    maps = get_user(uid, db=db)['storymaps']
+    assert set(maps) == {'map-a', 'map-b', 'map-c'}
+    assert maps['map-c']['title'] == 'C'
+    assert maps['map-a']['title'] == 'A'  # untouched
+
+
+@pytest.mark.integration
+def test_set_user_storymap_value_single_field(pg_user):
+    """Writing one field must leave the entry's other fields and siblings intact."""
+    uid, db = pg_user
+    set_user_storymap_value(uid, ['map-a', 'published_on'], 't2', db=db)
+    maps = get_user(uid, db=db)['storymaps']
+    assert maps['map-a']['published_on'] == 't2'
+    assert maps['map-a']['title'] == 'A'      # other field intact
+    assert maps['map-b']['published_on'] == ''  # sibling intact
+
+
+@pytest.mark.integration
+def test_delete_user_storymap_removes_only_target(pg_user):
+    """Delete must remove exactly one key, leaving the rest of the account."""
+    uid, db = pg_user
+    delete_user_storymap(uid, 'map-a', db=db)
+    maps = get_user(uid, db=db)['storymaps']
+    assert set(maps) == {'map-b'}
+
+
+@pytest.mark.integration
+def test_set_user_migrated_leaves_storymaps_intact(pg_user):
+    """Flipping the migrated flag must not rewrite the storymaps column."""
+    uid, db = pg_user
+    set_user_migrated(uid, 1, db=db)
+    user = get_user(uid, db=db)
+    assert user['migrated'] == 1
+    assert set(user['storymaps']) == {'map-a', 'map-b'}
 
 
 @pytest.mark.integration

--- a/tests/unit_tests.py
+++ b/tests/unit_tests.py
@@ -39,12 +39,109 @@ def api_client(monkeypatch):
         lambda uid, db=None: test_user if uid == test_user['uid'] else None,
     )
     monkeypatch.setattr(api, 'save_user', lambda user, db=None: None)
+    monkeypatch.setattr(
+        api, 'set_user_storymap_value', lambda uid, path, value, db=None: None)
     monkeypatch.setattr(api, '_utc_now', lambda: '2024-01-02T00:00:00Z')
 
     with api.app.test_client() as client:
         with client.session_transaction() as session:
             session['uid'] = test_user['uid']
         yield client, test_user
+
+
+def _delete_client(monkeypatch, storymaps):
+    """Flask test client whose session user has the given storymaps dict."""
+    test_user = {
+        'uid': 'user-123',
+        'uname': 'Test User',
+        'storymaps': storymaps,
+    }
+    monkeypatch.setattr(api, 'db', lambda: None)
+    monkeypatch.setattr(
+        api,
+        'get_user',
+        lambda uid, db=None: test_user if uid == test_user['uid'] else None,
+    )
+    client = api.app.test_client()
+    with client.session_transaction() as session:
+        session['uid'] = test_user['uid']
+    return client, test_user
+
+
+@pytest.mark.unit
+def test_storymap_delete_commits_metadata_before_cleanup(monkeypatch):
+    """Delete must remove the DB record BEFORE enqueuing S3 cleanup, and must
+    only touch the targeted storymap key."""
+    client, user = _delete_client(monkeypatch, {
+        'map-123': {'id': 'map-123', 'title': 'Doomed', 'published_on': ''},
+        'map-456': {'id': 'map-456', 'title': 'Keep me', 'published_on': ''},
+    })
+
+    calls = []
+    monkeypatch.setattr(
+        api, 'delete_user_storymap',
+        lambda uid, sid, db=None: calls.append(('delete_meta', uid, sid)))
+    monkeypatch.setattr(
+        api, 'storymap_cleanup',
+        lambda uid, sid: calls.append(('cleanup', uid, sid)))
+
+    response = client.get('/storymap/delete/?id=map-123')
+
+    assert response.status_code == 200
+    # Both ran, targeting the right key, and metadata delete came first.
+    assert calls == [
+        ('delete_meta', 'user-123', 'map-123'),
+        ('cleanup', 'user-123', 'map-123'),
+    ]
+    # The other storymap is untouched.
+    assert 'map-456' in user['storymaps']
+
+
+@pytest.mark.unit
+def test_storymap_delete_does_not_cleanup_when_metadata_delete_fails(monkeypatch):
+    """If the DB removal raises, S3 cleanup must NOT be enqueued — otherwise we
+    orphan the account record from its (now-deleted) S3 objects."""
+    client, _ = _delete_client(monkeypatch, {
+        'map-123': {'id': 'map-123', 'title': 'Doomed', 'published_on': ''},
+    })
+
+    cleanup_calls = []
+
+    def boom(uid, sid, db=None):
+        raise Exception('db unavailable')
+
+    monkeypatch.setattr(api, 'delete_user_storymap', boom)
+    monkeypatch.setattr(
+        api, 'storymap_cleanup',
+        lambda uid, sid: cleanup_calls.append((uid, sid)))
+
+    response = client.get('/storymap/delete/?id=map-123')
+
+    assert response.status_code == 200
+    assert response.get_json().get('error')
+    assert cleanup_calls == [], 'cleanup must not run when the DB delete fails'
+
+
+@pytest.mark.unit
+def test_storymap_save_writes_only_its_field_atomically(api_client, monkeypatch):
+    """A save must persist just the draft_on field via the per-key atomic helper,
+    never a whole-blob save_user (which could clobber a concurrent write)."""
+    client, _ = api_client
+
+    writes = []
+    monkeypatch.setattr(
+        api, 'set_user_storymap_value',
+        lambda uid, path, value, db=None: writes.append((uid, path, value)))
+    monkeypatch.setattr(
+        api, 'save_user',
+        lambda *a, **k: pytest.fail('save_user must not be used to persist a save'))
+    monkeypatch.setattr(api.storage, 'save_json', lambda key_name, content: None)
+
+    response = client.post(
+        '/storymap/save/', data={'id': 'map-123', 'd': json.dumps({'slides': []})})
+
+    assert response.status_code == 200
+    assert writes == [('user-123', ['map-123', 'draft_on'], '2024-01-02T00:00:00Z')]
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Problem

A user reported *"There was a problem connecting to the document storage service"* when opening a storymap (`llyn`) that their account **still listed**. The underlying error was a `NoSuchKey` on `GetObject` — the `draft.json` object was gone from S3, but the Postgres account record still referenced it. The storymap's `draft_on`/`published_on` timestamps proved the S3 objects had *existed* and were later lost, not that they were never created.

Two independent defects let the account metadata (Postgres) and the S3 objects diverge.

## Root causes & fixes

### 1. Delete ordering (`storymap_delete`)
The async S3 cleanup job was enqueued **before** the metadata removal was committed:

```python
storymap_cleanup(user["uid"], storymap_id)   # queued — S3 delete now guaranteed
del user['storymaps'][storymap_id]
save_user(user, db=db())                       # if THIS fails, files gone, record stays
```

The Huey cleanup task never consults Postgres — once enqueued, it deletes the `<uid>/<id>/` prefix regardless of DB state. If `save_user` failed after the enqueue, the files were deleted while the record survived.

**Fix:** commit the metadata removal first (atomically), enqueue cleanup only after it succeeds. If the DB delete fails, cleanup never runs.

### 2. Whole-blob overwrite race (`save_pg_user`)
Every mutating endpoint rewrote the **entire** `storymaps` JSONB column from an in-memory snapshot read at request start (`UPDATE users SET storymaps = <full blob>`). Two concurrent requests last-writer-win, so a save of one storymap could **resurrect a just-deleted sibling** (or silently lose a concurrent edit). Postgres isolation doesn't help — the read and write span the request and the write is a blind full-column overwrite.

**Fix:** all storymap writes now go through per-key atomic helpers:

| Helper | SQL | Used by |
|---|---|---|
| `set_user_storymap_value(uid, path, value)` | `jsonb_set` | create/copy/migrate (`[id]`), save (`[id,'draft_on']`), publish (`[id,'published_on']`), update_meta (`[id,key]`) |
| `delete_user_storymap(uid, id)` | `storymaps - key` | delete |
| `set_user_migrated(uid, value)` | single column | migrate_done |

save/publish/update_meta write a **single field path**, so concurrent edits to different storymaps — or different fields of the same one — no longer clobber each other. `save_user` remains only for the login/auth user-record upsert.

## Tests
- **Unit:** delete commits metadata before cleanup and targets only the right key; cleanup is suppressed when the DB delete fails; save persists only its field via the atomic helper and never calls `save_user`.
- **Integration (Postgres):** each helper touches only its target path, leaving siblings and other fields intact; `set_user_migrated` doesn't rewrite `storymaps`.

All passing (6 unit + 6 integration).

## Not included (follow-up)
The login/auth path still does a whole-user write, so a save concurrent with a re-authentication remains a much narrower window. Left as a follow-up rather than bundled here.

## Ops follow-up (separate from this code)
Recovery/diagnosis for the reported `llyn` storymap is still open: check S3 bucket **versioning** to see if the deleted objects can be restored, and grep production logs for the `storymap_cleanup` "Deleting assets… llyn" lines to confirm a delete actually ran.

🤖 Generated with [Claude Code](https://claude.com/claude-code)